### PR TITLE
fix(midnight-contracts): sanitize networkId before building dust-state file path

### DIFF
--- a/packages/chains/midnight-contracts/src/dust-state.ts
+++ b/packages/chains/midnight-contracts/src/dust-state.ts
@@ -19,10 +19,17 @@ const log = console;
  * Uses first 16 hex chars of the seed as a stable identifier — the seed
  * deterministically maps to a dust address, so this is a unique key per wallet
  * that is available before building the facade.
+ *
+ * `networkId` is stripped to a safe character set before it reaches
+ * `path.join`. No caller currently passes untrusted input here (`networkId`
+ * comes from the wallet SDK's own enum or a local CLI env var), but nothing
+ * upstream enforces that, and a `networkId` containing `../` would otherwise
+ * let the resulting path escape `baseDir`.
  */
 export function getDustStatePath(baseDir: string, networkId: string, seed: string): string {
   const seedKey = seed.slice(0, 16);
-  return path.join(baseDir, `${networkId}-${seedKey}.json`);
+  const safeNetworkId = networkId.replace(/[^a-zA-Z0-9_-]/g, "_");
+  return path.join(baseDir, `${safeNetworkId}-${seedKey}.json`);
 }
 
 function isUndeployedNetwork(networkId: string): boolean {


### PR DESCRIPTION
## Summary

`getDustStatePath()` in `packages/chains/midnight-contracts/src/dust-state.ts` interpolates `networkId` directly into a filename passed to `path.join(baseDir, ...)`:

```ts
export function getDustStatePath(baseDir: string, networkId: string, seed: string): string {
  const seedKey = seed.slice(0, 16);
  return path.join(baseDir, `${networkId}-${seedKey}.json`);
}
```

`networkId` isn't sanitized before this, so a value containing `../` segments lets the resulting path escape `baseDir`.

I traced every current caller (`waitForDustFundsWithRetry` in `get-wallet-info.ts`, itself only reachable from node-side CLI flows — `faucet.ts`, `create-wallets.ts`, `register-filler-dust.ts`, `mint-m20-to-fillers.ts` — never from the browser-facing `MidnightLocal.connectFromSeed` path, which the file's own header comment confirms is deliberate). In all of those, `networkId` comes from the wallet SDK's own enum or a local env var, not untrusted/remote input, so there's no exploit path today.

That said, nothing upstream enforces that `networkId` is safe, and the function is exported (`./wallet-info` subpath), so any future caller that does pass externally-influenced `networkId` would inherit this gap silently. This PR strips `networkId` to a safe character set (`[a-zA-Z0-9_-]`) as defense in depth, matching how `seedKey` is already treated as an opaque identifier rather than raw untrusted text.

## Change

```ts
const safeNetworkId = networkId.replace(/[^a-zA-Z0-9_-]/g, "_");
return path.join(baseDir, `${safeNetworkId}-${seedKey}.json`);
```

Normal values (`"testnet"`, `"undeployed"`, `"devnet"`, `"preview"`) are unaffected — the regex only touches characters outside the existing naming convention.

## Test plan

- [x] Verified sanitization logic in isolation: normal `networkId` values produce identical output to before; a `networkId` of `"../../../../etc/evil"` now resolves to a path that stays inside `baseDir` instead of escaping it.
- [ ] `bun test` for `packages/chains/midnight-contracts` (I don't have Bun available in my environment to run this — happy to update if CI surfaces anything).