### PR TITLE
fix(bitcoin-core): download binaries from bitcoincore.org, not bitcoin.org

### DIFF
--- a/packages/binaries/bitcoin-core/index.js
+++ b/packages/binaries/bitcoin-core/index.js
@@ -10,7 +10,10 @@ import { CHECKSUMS } from './checksums.js';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const version = '28.1';
-const base = `https://bitcoin.org/bin/bitcoin-core-${version}`;
+// bitcoin.org stopped serving /bin/ (every release asset 404s there now); the
+// binaries live on bitcoincore.org, which is the canonical host upstream links.
+// The artifacts are byte-identical, so CHECKSUMS below is unchanged.
+const base = `https://bitcoincore.org/bin/bitcoin-core-${version}`;
 const dest = path.join(__dirname, 'vendor');
 
 const bin = new BinWrapper()
@@ -42,7 +45,7 @@ fallbackfee=0.00001
 /**
  * Apple Silicon refuses to exec an arm64 Mach-O that carries no code signature
  * at all — the process is SIGKILLed before `main`, with no diagnostic beyond
- * exit 137. bitcoin.org ships `bitcoin-*-arm64-apple-darwin.tar.gz` unsigned
+ * exit 137. Upstream ships `bitcoin-*-arm64-apple-darwin.tar.gz` unsigned
  * (`codesign -dv` → "code object is not signed at all"), so an ad-hoc signature
  * has to be applied locally before first use. Every other binary in
  * packages/binaries/ already ships signed; this is bitcoin-core only.

--- a/scripts/generate-binary-checksums.ts
+++ b/scripts/generate-binary-checksums.ts
@@ -53,7 +53,7 @@ type PackageSpec = {
   assets: Asset[];
 };
 
-const BITCOIN = "https://bitcoin.org/bin/bitcoin-core-28.1";
+const BITCOIN = "https://bitcoincore.org/bin/bitcoin-core-28.1";
 const LOKI = "https://github.com/grafana/loki/releases/download/v3.5.8";
 const ALLOY = "https://github.com/grafana/alloy/releases/download/v1.11.3";
 


### PR DESCRIPTION
## Problem

`bitcoin.org` stopped serving `/bin/`, so every Bitcoin Core release asset 404s there now. `@effectstream/bitcoin-core` downloads `bitcoind` on first run, which breaks any template or e2e suite that starts a Bitcoin regtest node:

```
[bitcoin-core] Starting Bitcoin Core regtest...
[bitcoin-core] Failed to start Bitcoin Core: HTTPError: Response code 404 (Not Found)
[bitcoin-core] error: script "chain:start" exited with code 1
✗ bitcoin-core exited with code 1
```

This is a **hosting change, not a version change**. The whole `/bin/` tree is gone from bitcoin.org — the directory itself, and older releases (26.0, 27.0), all 404. 28.1 was not pulled or superseded.

| URL | Before | After |
|---|---|---|
| `bitcoin.org/bin/…28.1…` (all 4 platforms) | 404 | — |
| `bitcoincore.org/bin/…28.1…` (all 4 platforms) | — | 200 |

## Fix

Point the download base at `bitcoincore.org`, the canonical host upstream links to.

**`checksums.js` is deliberately unchanged.** The artifacts are byte-identical: the `bitcoind` extracted from the bitcoincore.org linux-x64 archive hashes to `c2e73c31a0b371bd0721bc8bb6d199736fa1f3d2bb45edb7c8056eab3cec168a`, which already matches the pinned `linux-x64` digest. Fail-closed verification still applies and still passes.

Also updates `scripts/generate-binary-checksums.ts`, which regenerates the pinned table from the same dead host (its `SHA256SUMS` URL 404s too, so the script could not have been re-run).

## Verification

Run in Docker via the CI image (`.github/Dockerfile`), isolated on the default bridge network:

- Wrapper directly: downloads, `verified bitcoind v28.1 (linux-x64)`, `Bitcoin Core version v28.1.0 (release build)` starts on regtest.
- Bitcoin chain standalone (both the e2e and the night-bitcoin-v2 miner scripts): mines past block 100, `wait-for-block 100` exits 0.
- `night-bitcoin-v2` template suite: Phase A now gets past the blocker —
  ```
  Bitcoin regtest ready.
  [PASS] Bitcoin Core RPC (port 18443) responds
  [PASS] Bitcoin Core is on regtest chain
  [PASS] Bitcoin Core has at least 1 block (faucet generated)
  ```

## Why CI stayed green

Two independent reasons, neither of which means the template worked:

1. The `template-tests` job only runs for templates whose directory changed. It was **skipped** on the current tip; the last run that actually exercised `night-bitcoin-v2` was 2026-08-03 (`f1247f32`), before bitcoin.org removed `/bin/`.
2. Templates resolve `@effectstream/*` from published npm, so an upstream hosting change breaks them with no commit in this repo. Nothing here pins the download host in a test.

## Scope / follow-ups (not in this PR)

`night-bitcoin-v2` does **not** fully pass yet. Three separate pre-existing defects found while verifying, worth their own PRs:

1. **False PASS** — `templates/*/packages/tests/run-tests.ts` catches a fatal infra error, logs it, then `finally` decides the exit code purely from assertion counters (`anyError()` = `count === 0 || failed > 0`). Any infra failure *after* the first passing assertion exits 0 and reports PASS. Observed live: an indexer hang reported `[PASS] night-bitcoin-v2` with Phases B/C never run. The same `anyError` is in 8 templates.
2. **No timeout/retry on the indexer binary download** — `packages/binaries/midnight-indexer/binary.js` uses `axios.get(..., {responseType:"stream"})` with axios's default infinite timeout, so a stalled connection hangs forever printing nothing.
3. **Dead sync heartbeat** — `latestState` is declared and read but never assigned in `packages/chains/midnight-contracts/src/get-wallet-info.ts`, so the 10s `[wait]` progress logger always returns early, making "slow" indistinguishable from "stalled".

For reference, `evm-midnight-v2` passes fully on the same image (41 tests, 0 failed), so the Midnight stack itself is healthy.

## Note for release

The fix must be **published** to unbreak templates — they install `@effectstream/bitcoin-core` from npm (`0.102.0` currently carries the dead URL), so this repo-side change alone does not fix a fresh `bun install` of a template.