### PR TITLE
fix(sm): add Cardano signer key hashes compatibly

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1111,6 +1111,7 @@
         "@effectstream/event-client": "workspace:*",
         "@effectstream/log": "workspace:*",
         "@effectstream/utils": "workspace:*",
+        "@noble/hashes": "^2.2.0",
         "@pgtyped/runtime": "^2.4.2",
         "@sinclair/typebox": "0.34.41",
         "assert-never": "^1.4.0",

--- a/docs/site/blog/2026-06-25-farcaster-template.md
+++ b/docs/site/blog/2026-06-25-farcaster-template.md
@@ -82,7 +82,7 @@ The `2_000_000n` lovelace (2 ADA) output is required by the Cardano minimum UTxO
 
 The state machine iterates the pairs explicitly.
 
-**4. Voter identity** comes from `inputCredentials` -- the first vkey witness hash on the Cardano transaction. This is more crypto-native than an address: it is the hash of the actual signing key, regardless of which address the user controls. The state machine uses it as the deduplication key.
+**4. Voter identity** comes from `signerKeyHashes` -- the first vkey witness hash on the Cardano transaction. This is more crypto-native than an address: it is the hash of the actual signing key, regardless of which address the user controls. The state machine uses it as the deduplication key. The older `inputCredentials` field is deprecated because it actually contains raw verification keys.
 
 **5. Block ingestion** runs through Dolos MiniBF (a UTxORPC relay) connected to the YACI devnet. `PrimitiveTypeCardanoTransfer` watches for transactions that match the grammar prefix, extracts the metadata, and feeds a typed input into the state machine for each block.
 
@@ -96,7 +96,7 @@ The wallet log in the UI makes the full flow visible:
 
 ### grammar.ts
 
-The grammar declares what inputs the app recognizes. `cardanoTransfer` is a builtin that captures `txId`, `metadata`, `inputCredentials`, and `outputs` from any Cardano transfer -- we alias it under our own name:
+The grammar declares what inputs the app recognizes. `cardanoTransfer` is a builtin that captures `txId`, `metadata`, deprecated `inputCredentials`, `outputs`, and `signerKeyHashes` from any Cardano transfer -- we alias it under our own name:
 
 ```ts
 export const grammar = {
@@ -111,12 +111,14 @@ const VALID_MOVIES  = new Set(["dune2","gladiator2","wicked","alien","joker2"]);
 const VALID_RATINGS = new Set(["best","meh","worst"]);
 
 stm.addStateTransition("cardano-vote", function* (data) {
-  const { txId, metadata, inputCredentials } = data.parsedInput;
+  const { txId, metadata, inputCredentials, signerKeyHashes } = data.parsedInput;
 
   // Voter = first vkey witness hash (signing key identity, not address).
   let voter = txId;
   try {
-    const creds = JSON.parse(inputCredentials);
+    const hashes = JSON.parse(signerKeyHashes ?? "[]");
+    // Fall back only for old SDK payloads or historical tuples.
+    const creds = hashes.length ? hashes : JSON.parse(inputCredentials ?? "[]");
     if (creds[0]) voter = creds[0];
   } catch {}
 

--- a/docs/site/docs/home/1200-templates/1212-evm-cardano.md
+++ b/docs/site/docs/home/1200-templates/1212-evm-cardano.md
@@ -127,7 +127,7 @@ the cost of coupling your throughput to your slowest source.
 | EVM sync (`ConfigSyncProtocolType.EVM_RPC_PARALLEL`) | `packages/node/config.dev.ts` | Reading the local Hardhat chain with `confirmationDepth: 1` |
 | Cardano sync (`ConfigSyncProtocolType.CARDANO_UTXORPC_PARALLEL`) | `packages/node/config.dev.ts` | Reading Cardano blocks from Dolos over UTxO-RPC from `origin` |
 | `PrimitiveTypeEVMERC721` (`@effectstream/sm/builtin`) | `packages/node/config.dev.ts` | Decoding ERC-721 `Transfer` logs into `{ to, from, tokenId, isBurn }` |
-| `PrimitiveTypeCardanoTransfer` (`@effectstream/sm/builtin`) | `packages/node/config.dev.ts` | Decoding Cardano transactions into `{ txId, metadata, inputCredentials, outputs }` |
+| `PrimitiveTypeCardanoTransfer` (`@effectstream/sm/builtin`) | `packages/node/config.dev.ts` | Decoding Cardano transactions into `{ txId, metadata, inputCredentials, outputs, signerKeyHashes }` |
 | Builtin grammars (`@effectstream/sm/grammar`) | `packages/node/grammar.ts` | Typing both primitives' payloads without writing a schema by hand |
 | `Stm` state transitions (`@effectstream/sm`) | `packages/node/state-machine.ts` | Two transitions writing into one shared `events` table |
 | `World.resolve` (`@effectstream/coroutine`) | `packages/node/state-machine.ts` | Running pgtyped queries inside a state transition |
@@ -214,8 +214,9 @@ export const grammar = {
 The keys match the `stateMachinePrefix` of each primitive in `packages/node/config.dev.ts`
 (`nft-transfer` and `cardano-transfer`) — that is what routes a decoded payload to a
 transition. `evmErc721` yields `{ to, from, tokenId, isBurn }`; `cardanoTransfer` yields
-`{ txId, metadata, inputCredentials, outputs }`, where `inputCredentials` and `outputs` are
-JSON strings.
+`{ txId, metadata, inputCredentials, outputs, signerKeyHashes }`. `outputs` and
+`signerKeyHashes` are JSON strings. The deprecated `inputCredentials` is also a JSON
+string, but contains raw verification keys and is retained only for compatibility.
 
 ### State machine
 
@@ -242,7 +243,9 @@ transaction hash — a simplification of the demo, not a framework limitation.
 
 The Cardano transition is shaped by the UTxO model: one transaction fans out into several
 outputs, so it parses the JSON payload and inserts one row per output, attributing the
-sender to the first input credential:
+sender to the first signer key hash. When replaying a historical tuple that predates
+`signerKeyHashes`, it falls back to the deprecated raw verification key so old data remains
+processable:
 
 ```ts
 // packages/node/state-machine.ts

--- a/docs/site/docs/home/200-chains/203-cardano.md
+++ b/docs/site/docs/home/200-chains/203-cardano.md
@@ -206,8 +206,9 @@ Captures ADA and native asset transfers. Tracks outputs (destination UTxOs) and 
 | :--- | :--- |
 | `txId` | Transaction hash |
 | `metadata` | JSON-stringified transaction metadata |
-| `inputCredentials` | JSON array of verification key hashes that signed inputs |
+| `inputCredentials` | **Deprecated.** JSON array of raw verification keys retained for compatibility |
 | `outputs` | JSON array of `{index, address, coin, assets[]}` |
+| `signerKeyHashes` | JSON array of 28-byte Cardano verification key hashes for transaction signers |
 
 ## 2. Batcher Adapters (Write)
 

--- a/e2e/cardano/database/migrations/create-user-tables.sql
+++ b/e2e/cardano/database/migrations/create-user-tables.sql
@@ -25,7 +25,8 @@ CREATE TABLE IF NOT EXISTS cardano_transfers (
   tx_id TEXT NOT NULL,
   metadata TEXT,
   input_credentials JSONB NOT NULL,
-  outputs JSONB NOT NULL
+  outputs JSONB NOT NULL,
+  signer_key_hashes JSONB NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS cardano_delegations (

--- a/e2e/cardano/node.ts
+++ b/e2e/cardano/node.ts
@@ -45,12 +45,20 @@ stm.addStateTransition("cardano-mint-burn", function* (data) {
 });
 
 stm.addStateTransition("cardano-transfer", function* (data) {
-  const { txId, metadata, inputCredentials, outputs } = data.parsedInput;
+  const { txId, metadata, inputCredentials, outputs, signerKeyHashes } =
+    data.parsedInput;
   console.log(`[STM] cardano-transfer: txId=${txId}`);
   yield* World.promise(pool.query(
-    `INSERT INTO cardano_transfers (block_height, tx_id, metadata, input_credentials, outputs)
-     VALUES ($1, $2, $3, $4, $5)`,
-    [data.blockHeight, txId, metadata || null, inputCredentials, outputs],
+    `INSERT INTO cardano_transfers (block_height, tx_id, metadata, input_credentials, outputs, signer_key_hashes)
+     VALUES ($1, $2, $3, $4, $5, $6)`,
+    [
+      data.blockHeight,
+      txId,
+      metadata || null,
+      inputCredentials,
+      outputs,
+      signerKeyHashes,
+    ],
   ));
 });
 

--- a/e2e/cardano/sync/transfer.test.ts
+++ b/e2e/cardano/sync/transfer.test.ts
@@ -19,7 +19,16 @@ export async function transferTest(db: Client): Promise<void> {
         payload.txId.length > 0 &&
         Array.isArray(payload.outputs) &&
         payload.outputs.length > 0 &&
-        Array.isArray(payload.inputCredentials)
+        Array.isArray(payload.inputCredentials) &&
+        payload.inputCredentials.every(
+          (key: unknown) =>
+            typeof key === "string" && /^[0-9a-f]{64}$/.test(key),
+        ) &&
+        Array.isArray(payload.signerKeyHashes) &&
+        payload.signerKeyHashes.every(
+          (hash: unknown) =>
+            typeof hash === "string" && /^[0-9a-f]{56}$/.test(hash),
+        )
       );
     },
   );
@@ -28,16 +37,27 @@ export async function transferTest(db: Client): Promise<void> {
     tx_id: string;
     outputs: any;
     input_credentials: any;
+    signer_key_hashes: any;
   }>(
     "Transfer: STM wrote cardano_transfers",
     db,
-    `SELECT tx_id, outputs, input_credentials
+    `SELECT tx_id, outputs, input_credentials, signer_key_hashes
      FROM cardano_transfers
      ORDER BY id ASC;`,
     (res) => res.rows.length >= 1,
     (res) => {
       const row = res.rows[0];
-      return row.tx_id.length > 0;
+      return (
+        row.tx_id.length > 0 &&
+        Array.isArray(row.input_credentials) &&
+        row.input_credentials.every((key: unknown) =>
+          typeof key === "string" && /^[0-9a-f]{64}$/.test(key)
+        ) &&
+        Array.isArray(row.signer_key_hashes) &&
+        row.signer_key_hashes.every((hash: unknown) =>
+          typeof hash === "string" && /^[0-9a-f]{56}$/.test(hash)
+        )
+      );
     },
   );
 }

--- a/packages/node-sdk/sm/package.json
+++ b/packages/node-sdk/sm/package.json
@@ -25,6 +25,7 @@
     "@effectstream/event-client": "workspace:*",
     "@effectstream/log": "workspace:*",
     "@effectstream/utils": "workspace:*",
+    "@noble/hashes": "^2.2.0",
     "pg": "8.21.0",
     "pg-tx": "^1.0.1",
     "@sinclair/typebox": "0.34.41",

--- a/packages/node-sdk/sm/primitives/src/cardano-transfer/transfer-grammar.ts
+++ b/packages/node-sdk/sm/primitives/src/cardano-transfer/transfer-grammar.ts
@@ -3,6 +3,21 @@ import { Type } from "@sinclair/typebox";
 export const transferGrammar = [
   ["txId", Type.String()],
   ["metadata", Type.String()],
-  ["inputCredentials", Type.String()],
+  [
+    "inputCredentials",
+    Type.String({
+      deprecated: true,
+      description:
+        "Deprecated: JSON array of raw verification keys. Use signerKeyHashes.",
+    }),
+  ],
   ["outputs", Type.String()],
+  // The default lets state machines parse historical four-field tuples.
+  [
+    "signerKeyHashes",
+    Type.String({
+      default: "[]",
+      description: "JSON array of Cardano verification key hashes.",
+    }),
+  ],
 ] as const;

--- a/packages/node-sdk/sm/primitives/src/cardano-transfer/transfer-primitive.test.ts
+++ b/packages/node-sdk/sm/primitives/src/cardano-transfer/transfer-primitive.test.ts
@@ -1,0 +1,61 @@
+import { expect, test } from "bun:test";
+import { CardanoTransferPrimitive } from "../mod.ts";
+import { PrimitiveRegistry } from "../../PrimitiveRegistry.ts";
+
+const VERIFICATION_KEY = Uint8Array.from({ length: 32 }, (_, index) => index);
+const CREDENTIAL_HASH =
+  "491112dd01155c07dab485f71b572e0cae759e2cd38b1c0e97554297";
+
+function makePrimitive() {
+  PrimitiveRegistry.primitives = {};
+  return new CardanoTransferPrimitive({
+    instanceName: "CardanoTransfer",
+    startBlockHeight: 0,
+    stateMachinePrefix: undefined,
+    predicate: { match: { cardano: {} } },
+  } as any);
+}
+
+function inputCredentialsFor(vkeys: Uint8Array[] | undefined): string[] {
+  const witnesses =
+    vkeys === undefined
+      ? undefined
+      : { vkeywitness: vkeys.map((vkey) => ({ vkey })) };
+  const tx = {
+    hash: new Uint8Array(32),
+    outputs: [],
+    witnesses,
+  };
+  const iterator = makePrimitive().getPayload(
+    0 as any,
+    {
+      output: { payload: { tx } },
+    } as any,
+  );
+  const result = iterator.next().value as any;
+  return result.data[0].accountingPayload.inputCredentials;
+}
+
+test("hashes witness verification keys into Cardano input credentials", () => {
+  const credentials = inputCredentialsFor([VERIFICATION_KEY]);
+
+  expect(credentials).toEqual([CREDENTIAL_HASH]);
+  expect(credentials[0]).toMatch(/^[0-9a-f]{56}$/);
+});
+
+test("deduplicates input credentials in first-seen order", () => {
+  const secondVkey = new Uint8Array(32).fill(0xff);
+  const credentials = inputCredentialsFor([
+    VERIFICATION_KEY,
+    secondVkey,
+    VERIFICATION_KEY,
+  ]);
+
+  expect(credentials).toHaveLength(2);
+  expect(credentials[0]).toBe(CREDENTIAL_HASH);
+  expect(credentials[1]).toMatch(/^[0-9a-f]{56}$/);
+});
+
+test("emits an empty credential list when witnesses are absent", () => {
+  expect(inputCredentialsFor(undefined)).toEqual([]);
+});

--- a/packages/node-sdk/sm/primitives/src/cardano-transfer/transfer-primitive.test.ts
+++ b/packages/node-sdk/sm/primitives/src/cardano-transfer/transfer-primitive.test.ts
@@ -1,22 +1,29 @@
 import { expect, test } from "bun:test";
+import { parseRawStmInput, toKeyedJsonGrammar } from "@effectstream/concise";
 import { CardanoTransferPrimitive } from "../mod.ts";
 import { PrimitiveRegistry } from "../../PrimitiveRegistry.ts";
+import { transferGrammar } from "./transfer-grammar.ts";
 
 const VERIFICATION_KEY = Uint8Array.from({ length: 32 }, (_, index) => index);
+const VERIFICATION_KEY_HEX =
+  "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f";
 const CREDENTIAL_HASH =
   "491112dd01155c07dab485f71b572e0cae759e2cd38b1c0e97554297";
 
-function makePrimitive() {
+function makePrimitive(stateMachinePrefix?: string) {
   PrimitiveRegistry.primitives = {};
   return new CardanoTransferPrimitive({
     instanceName: "CardanoTransfer",
     startBlockHeight: 0,
-    stateMachinePrefix: undefined,
+    stateMachinePrefix,
     predicate: { match: { cardano: {} } },
   } as any);
 }
 
-function inputCredentialsFor(vkeys: Uint8Array[] | undefined): string[] {
+function payloadFor(
+  vkeys: Uint8Array[] | undefined,
+  stateMachinePrefix?: string,
+) {
   const witnesses =
     vkeys === undefined
       ? undefined
@@ -26,36 +33,74 @@ function inputCredentialsFor(vkeys: Uint8Array[] | undefined): string[] {
     outputs: [],
     witnesses,
   };
-  const iterator = makePrimitive().getPayload(
+  const iterator = makePrimitive(stateMachinePrefix).getPayload(
     0 as any,
     {
       output: { payload: { tx } },
     } as any,
   );
   const result = iterator.next().value as any;
-  return result.data[0].accountingPayload.inputCredentials;
+  return result.data[0];
 }
 
-test("hashes witness verification keys into Cardano input credentials", () => {
-  const credentials = inputCredentialsFor([VERIFICATION_KEY]);
+test("keeps deprecated inputCredentials as raw verification keys", () => {
+  const { accountingPayload } = payloadFor([VERIFICATION_KEY]);
 
-  expect(credentials).toEqual([CREDENTIAL_HASH]);
-  expect(credentials[0]).toMatch(/^[0-9a-f]{56}$/);
+  expect(accountingPayload.inputCredentials).toEqual([VERIFICATION_KEY_HEX]);
+  expect(accountingPayload.inputCredentials[0]).toMatch(/^[0-9a-f]{64}$/);
 });
 
-test("deduplicates input credentials in first-seen order", () => {
+test("emits Cardano credential hashes as signerKeyHashes", () => {
+  const { accountingPayload } = payloadFor([VERIFICATION_KEY]);
+
+  expect(accountingPayload.signerKeyHashes).toEqual([CREDENTIAL_HASH]);
+  expect(accountingPayload.signerKeyHashes[0]).toMatch(/^[0-9a-f]{56}$/);
+});
+
+test("deduplicates legacy keys and signer hashes in first-seen order", () => {
   const secondVkey = new Uint8Array(32).fill(0xff);
-  const credentials = inputCredentialsFor([
+  const { accountingPayload } = payloadFor([
     VERIFICATION_KEY,
     secondVkey,
     VERIFICATION_KEY,
   ]);
 
-  expect(credentials).toHaveLength(2);
-  expect(credentials[0]).toBe(CREDENTIAL_HASH);
-  expect(credentials[1]).toMatch(/^[0-9a-f]{56}$/);
+  expect(accountingPayload.inputCredentials).toHaveLength(2);
+  expect(accountingPayload.inputCredentials[0]).toBe(VERIFICATION_KEY_HEX);
+  expect(accountingPayload.signerKeyHashes).toHaveLength(2);
+  expect(accountingPayload.signerKeyHashes[0]).toBe(CREDENTIAL_HASH);
+  expect(accountingPayload.signerKeyHashes[1]).toMatch(/^[0-9a-f]{56}$/);
 });
 
-test("emits an empty credential list when witnesses are absent", () => {
-  expect(inputCredentialsFor(undefined)).toEqual([]);
+test("emits empty legacy and signer lists when witnesses are absent", () => {
+  const { accountingPayload } = payloadFor(undefined);
+
+  expect(accountingPayload.inputCredentials).toEqual([]);
+  expect(accountingPayload.signerKeyHashes).toEqual([]);
+});
+
+test("appends signerKeyHashes without shifting legacy STM fields", () => {
+  const { stateMachinePayload } = payloadFor(
+    [VERIFICATION_KEY],
+    "cardano-transfer",
+  );
+
+  expect(stateMachinePayload.slice(3, 5)).toEqual([
+    JSON.stringify([VERIFICATION_KEY_HEX]),
+    "[]",
+  ]);
+  expect(JSON.parse(stateMachinePayload[5])).toEqual([CREDENTIAL_HASH]);
+});
+
+test("defaults signerKeyHashes when parsing historical STM tuples", () => {
+  const grammar = { "cardano-transfer": transferGrammar } as const;
+  const parsed = parseRawStmInput(
+    ["cardano-transfer", "tx-id", "", "[]", "[]"],
+    grammar,
+    toKeyedJsonGrammar(grammar),
+  );
+
+  expect(parsed.data.inputCredentials).toBe("[]");
+  expect(parsed.data.outputs).toBe("[]");
+  expect(parsed.data.signerKeyHashes).toBe("[]");
 });

--- a/packages/node-sdk/sm/primitives/src/cardano-transfer/transfer-primitive.ts
+++ b/packages/node-sdk/sm/primitives/src/cardano-transfer/transfer-primitive.ts
@@ -10,9 +10,10 @@
  * Extraction: for each matched transaction, `getPayload()` maps `tx.outputs` into
  * structured objects with `{index, address, coin, assets[]}`. Coin values are extracted
  * from the protobuf BigInt (either `int` for small values or `bigUInt` for large).
- * Input credentials are derived by hashing each `tx.witnesses.vkeywitness[].vkey`
- * with BLAKE2b-224, yielding the verification key hashes that identify who authorized
- * the spend.
+ * `inputCredentials` retains the raw `tx.witnesses.vkeywitness[].vkey` values for
+ * backward compatibility, but is deprecated because those values are not credentials.
+ * `signerKeyHashes` hashes each verification key with BLAKE2b-224, yielding the
+ * Cardano key hashes that identify who authorized the transaction.
  * Transaction metadata is extracted from `tx.auxiliary.metadata`.
  *
  * Predicate: user-provided (typically `has_address` to watch specific addresses).
@@ -113,10 +114,18 @@ export class CardanoTransferPrimitive extends Primitive<
     });
 
     const inputCredentials: string[] = [];
+    const signerKeyHashes: string[] = [];
     if (tx.witnesses) {
       for (const w of tx.witnesses.vkeywitness) {
-        const credential = verificationKeyToCredentialHex(w.vkey);
-        if (!inputCredentials.includes(credential)) inputCredentials.push(credential);
+        const verificationKey = uint8ArrayToHexString(w.vkey);
+        if (!inputCredentials.includes(verificationKey)) {
+          inputCredentials.push(verificationKey);
+        }
+
+        const signerKeyHash = verificationKeyToCredentialHex(w.vkey);
+        if (!signerKeyHashes.includes(signerKeyHash)) {
+          signerKeyHashes.push(signerKeyHash);
+        }
       }
     }
 
@@ -127,6 +136,7 @@ export class CardanoTransferPrimitive extends Primitive<
       metadata: metadata ? JSON.stringify(metadata) : null,
       inputCredentials,
       outputs,
+      signerKeyHashes,
     };
 
     const stateMachinePayload: any = this.stateMachinePrefix
@@ -135,6 +145,7 @@ export class CardanoTransferPrimitive extends Primitive<
           metadata: metadata ? JSON.stringify(metadata) : "",
           inputCredentials: JSON.stringify(inputCredentials),
           outputs: JSON.stringify(outputs),
+          signerKeyHashes: JSON.stringify(signerKeyHashes),
         })
       : null;
 

--- a/packages/node-sdk/sm/primitives/src/cardano-transfer/transfer-primitive.ts
+++ b/packages/node-sdk/sm/primitives/src/cardano-transfer/transfer-primitive.ts
@@ -10,8 +10,9 @@
  * Extraction: for each matched transaction, `getPayload()` maps `tx.outputs` into
  * structured objects with `{index, address, coin, assets[]}`. Coin values are extracted
  * from the protobuf BigInt (either `int` for small values or `bigUInt` for large).
- * Input credentials are extracted from `tx.witnesses.vkeywitness[].vkey` — these are
- * the public key hashes that signed the transaction, identifying who authorized the spend.
+ * Input credentials are derived by hashing each `tx.witnesses.vkeywitness[].vkey`
+ * with BLAKE2b-224, yielding the verification key hashes that identify who authorized
+ * the spend.
  * Transaction metadata is extracted from `tx.auxiliary.metadata`.
  *
  * Predicate: user-provided (typically `has_address` to watch specific addresses).
@@ -42,6 +43,7 @@ import {
   addressToHex,
   assetQuantityToString,
   metadataToJson,
+  verificationKeyToCredentialHex,
 } from "../cardano-utils/cardano-helpers.ts";
 
 export class CardanoTransferPrimitive extends Primitive<
@@ -113,8 +115,8 @@ export class CardanoTransferPrimitive extends Primitive<
     const inputCredentials: string[] = [];
     if (tx.witnesses) {
       for (const w of tx.witnesses.vkeywitness) {
-        const hash = uint8ArrayToHexString(w.vkey);
-        if (!inputCredentials.includes(hash)) inputCredentials.push(hash);
+        const credential = verificationKeyToCredentialHex(w.vkey);
+        if (!inputCredentials.includes(credential)) inputCredentials.push(credential);
       }
     }
 

--- a/packages/node-sdk/sm/primitives/src/cardano-utils/cardano-helpers.ts
+++ b/packages/node-sdk/sm/primitives/src/cardano-utils/cardano-helpers.ts
@@ -1,3 +1,4 @@
+import { blake2b } from "@noble/hashes/blake2.js";
 import { uint8ArrayToHexString } from "@effectstream/utils";
 import type { cardano } from "@utxorpc/spec";
 
@@ -29,6 +30,10 @@ export function stakeCredentialToHex(cred: cardano.StakeCredential): { type: "ke
 
 export function addressToHex(address: Uint8Array): string {
   return uint8ArrayToHexString(address);
+}
+
+export function verificationKeyToCredentialHex(vkey: Uint8Array): string {
+  return uint8ArrayToHexString(blake2b(vkey, { dkLen: 28 }));
 }
 
 export function metadataToJson(metadata: cardano.Metadata[]): Record<string, unknown> | null {

--- a/templates/evm-cardano/README.md
+++ b/templates/evm-cardano/README.md
@@ -120,7 +120,7 @@ the cost of coupling your throughput to your slowest source.
 | EVM sync (`ConfigSyncProtocolType.EVM_RPC_PARALLEL`) | `packages/node/config.dev.ts` | Reading the local Hardhat chain with `confirmationDepth: 1` |
 | Cardano sync (`ConfigSyncProtocolType.CARDANO_UTXORPC_PARALLEL`) | `packages/node/config.dev.ts` | Reading Cardano blocks from Dolos over UTxO-RPC from `origin` |
 | `PrimitiveTypeEVMERC721` (`@effectstream/sm/builtin`) | `packages/node/config.dev.ts` | Decoding ERC-721 `Transfer` logs into `{ to, from, tokenId, isBurn }` |
-| `PrimitiveTypeCardanoTransfer` (`@effectstream/sm/builtin`) | `packages/node/config.dev.ts` | Decoding Cardano transactions into `{ txId, metadata, inputCredentials, outputs }` |
+| `PrimitiveTypeCardanoTransfer` (`@effectstream/sm/builtin`) | `packages/node/config.dev.ts` | Decoding Cardano transactions into `{ txId, metadata, inputCredentials, outputs, signerKeyHashes }` |
 | Builtin grammars (`@effectstream/sm/grammar`) | `packages/node/grammar.ts` | Typing both primitives' payloads without writing a schema by hand |
 | `Stm` state transitions (`@effectstream/sm`) | `packages/node/state-machine.ts` | Two transitions writing into one shared `events` table |
 | `World.resolve` (`@effectstream/coroutine`) | `packages/node/state-machine.ts` | Running pgtyped queries inside a state transition |
@@ -207,8 +207,9 @@ export const grammar = {
 The keys match the `stateMachinePrefix` of each primitive in `packages/node/config.dev.ts`
 (`nft-transfer` and `cardano-transfer`) — that is what routes a decoded payload to a
 transition. `evmErc721` yields `{ to, from, tokenId, isBurn }`; `cardanoTransfer` yields
-`{ txId, metadata, inputCredentials, outputs }`, where `inputCredentials` and `outputs` are
-JSON strings.
+`{ txId, metadata, inputCredentials, outputs, signerKeyHashes }`. `outputs` and
+`signerKeyHashes` are JSON strings. The deprecated `inputCredentials` is also a JSON
+string, but contains raw verification keys and is retained only for compatibility.
 
 ### State machine
 
@@ -235,7 +236,9 @@ transaction hash — a simplification of the demo, not a framework limitation.
 
 The Cardano transition is shaped by the UTxO model: one transaction fans out into several
 outputs, so it parses the JSON payload and inserts one row per output, attributing the
-sender to the first input credential:
+sender to the first signer key hash. When replaying a historical tuple that predates
+`signerKeyHashes`, it falls back to the deprecated raw verification key so old data remains
+processable:
 
 ```ts
 // packages/node/state-machine.ts

--- a/templates/evm-cardano/packages/node/state-machine.ts
+++ b/templates/evm-cardano/packages/node/state-machine.ts
@@ -37,12 +37,15 @@ stm.addStateTransition("nft-transfer", function* (data) {
 });
 
 stm.addStateTransition("cardano-transfer", function* (data) {
-  const { txId, inputCredentials, outputs } = data.parsedInput as {
-    txId: string;
-    metadata: string;
-    inputCredentials: string;
-    outputs: string;
-  };
+  const { txId, inputCredentials, signerKeyHashes, outputs } =
+    data.parsedInput as {
+      txId: string;
+      metadata: string;
+      /** @deprecated Raw verification keys; use signerKeyHashes. */
+      inputCredentials: string;
+      signerKeyHashes?: string;
+      outputs: string;
+    };
 
   let parsedOutputs: Array<{
     index: number;
@@ -58,7 +61,10 @@ stm.addStateTransition("cardano-transfer", function* (data) {
 
   let fromCredential: string | null = null;
   try {
-    const creds: string[] = JSON.parse(inputCredentials);
+    const hashes: string[] = JSON.parse(signerKeyHashes ?? "[]");
+    // Old SDKs and historical tuples lack hashes, so retain their legacy identity.
+    const creds: string[] =
+      hashes.length > 0 ? hashes : JSON.parse(inputCredentials);
     if (creds.length > 0) fromCredential = creds[0];
   } catch {}
 


### PR DESCRIPTION
## Summary

- preserve deprecated `inputCredentials` exactly as the existing 64-character raw verification keys
- add `signerKeyHashes` with the correct 28-byte BLAKE2b-224 Cardano verification key hashes
- append the new grammar field with a `[]` default so historical four-field tuples remain parseable
- update Cardano E2E coverage, public docs, the EVM–Cardano template, and the Farcaster movie-poll example

## Compatibility

This avoids changing the meaning, type, or tuple position of `inputCredentials`. Existing consumers continue to receive the same values.

`signerKeyHashes` is appended after the existing fields. New primitive payloads always populate it; historical tuples parse it as `"[]"`. The EVM–Cardano template prefers the new hashes and falls back to the legacy field for SDK 0.102 or historical payloads.

## Template impact

The only checked-in template consumer is `templates/evm-cardano`. Changing `inputCredentials` in place would silently change its persisted Cardano `from_address` identities. The Farcaster movie-poll tutorial used the same field as a voter deduplication key, where an in-place change could allow one duplicate vote after an upgrade because old and new identities would differ. The referenced external `effectstream/farcaster-app` repository has no current Cardano credential usage.

## Testing

- `bun install --frozen-lockfile`
- `bun test packages/node-sdk/sm` — 30 pass, 0 fail
- `bun run assets:check`
- EVM–Cardano state machine bundles against its pinned SDK 0.102 dependencies
- `git diff --check`
- Cardano E2E assertions now verify both 64-character legacy keys and 56-character signer hashes

Fixes #853
