### PR TITLE
fix(zk-cardano): add pgtyped config

### DIFF
--- a/templates/zk-cardano/packages/database/pgtypedconfig.json
+++ b/templates/zk-cardano/packages/database/pgtypedconfig.json
@@ -1,0 +1,21 @@
+{
+  "transforms": [
+    {
+      "mode": "sql",
+      "include": "**/*.sql",
+      "emitTemplate": "{{dir}}/{{name}}.queries.ts"
+    }
+  ],
+  "srcDir": "./sql",
+  "failOnError": false,
+  "camelCaseColumnNames": false,
+  "db": {
+    "dbName": "postgres",
+    "user": "postgres",
+    "password": "postgres",
+    "host": "localhost",
+    "port": 5432,
+    "ssl": false
+  },
+  "maxWorkerThreads": 1
+}


### PR DESCRIPTION
## Summary

- add the missing pgtyped configuration to the zk-cardano database package
- match the established configuration used by templates with SQL under packages/database/sql
- restore build:pgtypes so it processes queries.sql instead of silently succeeding after a config-load error

## Verification

- reproduced the missing-config error and exit-0 behavior from a standalone template copy
- ran build:pgtypes after the fix: 7 query types generated successfully
- ran build:pgtypes twice and confirmed deterministic output
- audited every template database package with pgtyped:update; all now have a sibling config
- ran the standalone zk-cardano suite: 19 passed, 0 failed

Fixes #852