### PR TITLE
fix(templates): repair the three infra failures #859 exposed

### DIFF
--- a/e2e/evm/run-tests.ts
+++ b/e2e/evm/run-tests.ts
@@ -82,6 +82,7 @@ async function waitForProcess(
 ): Promise<void> {
   const { waitForExit = false, timeoutMs = 120_000 } = opts;
   console.log(`Waiting for process "${name}"${waitForExit ? " to complete" : ""}...`);
+  let deadExit: number | string | null = null;
   const start = Date.now();
   while (Date.now() - start < timeoutMs) {
     try {
@@ -90,11 +91,23 @@ async function waitForProcess(
         const data = await res.json() as any;
         const proc = data.processes?.find((p: any) => p.name === name);
         if (proc) {
+          // Fail fast: a process that has already died will never reach
+          // "done"/"running", so waiting out the timeout only buries the real
+          // error under a misleading "did not complete within Ns". Recorded
+          // here and thrown below because the catch swallows everything.
+          if (proc.status === "failed" || proc.status === "stopped") {
+            deadExit = proc.exitCode ?? "unknown";
+          }
           if (waitForExit && proc.status === "done") return;
           if (!waitForExit && (proc.status === "running" || proc.status === "done")) return;
         }
       }
     } catch { /* not ready */ }
+    if (deadExit !== null) {
+      throw new Error(
+        `Process "${name}" exited with code ${deadExit} while waiting for it to ${waitForExit ? "complete" : "start"}`,
+      );
+    }
     await delay(500);
   }
   throw new Error(`Process "${name}" did not ${waitForExit ? "complete" : "start"} within ${timeoutMs / 1000}s`);

--- a/e2e/shared/engine/harness.ts
+++ b/e2e/shared/engine/harness.ts
@@ -74,6 +74,7 @@ export async function waitForProcess(
 ): Promise<void> {
   const { waitForExit = false, timeoutMs = 120_000 } = opts;
   console.log(`Waiting for process "${name}"${waitForExit ? " to complete" : ""}...`);
+  let deadExit: number | string | null = null;
   const start = Date.now();
   while (Date.now() - start < timeoutMs) {
     try {
@@ -82,11 +83,23 @@ export async function waitForProcess(
         const data = await res.json() as any;
         const proc = data.processes?.find((p: any) => p.name === name);
         if (proc) {
+          // Fail fast: a process that has already died will never reach
+          // "done"/"running", so waiting out the timeout only buries the real
+          // error under a misleading "did not complete within Ns". Recorded
+          // here and thrown below because the catch swallows everything.
+          if (proc.status === "failed" || proc.status === "stopped") {
+            deadExit = proc.exitCode ?? "unknown";
+          }
           if (waitForExit && proc.status === "done") return;
           if (!waitForExit && (proc.status === "running" || proc.status === "done")) return;
         }
       }
     } catch { /* not ready */ }
+    if (deadExit !== null) {
+      throw new Error(
+        `Process "${name}" exited with code ${deadExit} while waiting for it to ${waitForExit ? "complete" : "start"}`,
+      );
+    }
     await delay(500);
   }
   throw new Error(`Process "${name}" did not ${waitForExit ? "complete" : "start"} within ${timeoutMs / 1000}s`);

--- a/templates/batcher-validations/packages/tests/run-tests.ts
+++ b/templates/batcher-validations/packages/tests/run-tests.ts
@@ -52,6 +52,7 @@ async function waitForProcess(
 ): Promise<void> {
   const { waitForExit = false, timeoutMs = 120_000 } = opts;
   console.log(`Waiting for process "${name}"${waitForExit ? " to complete" : ""}...`);
+  let deadExit: number | string | null = null;
   const start = Date.now();
   while (Date.now() - start < timeoutMs) {
     try {
@@ -60,11 +61,23 @@ async function waitForProcess(
         const data = await res.json() as any;
         const proc = data.processes?.find((p: any) => p.name === name);
         if (proc) {
+          // Fail fast: a process that has already died will never reach
+          // "done"/"running", so waiting out the timeout only buries the real
+          // error under a misleading "did not complete within Ns". Recorded
+          // here and thrown below because the catch swallows everything.
+          if (proc.status === "failed" || proc.status === "stopped") {
+            deadExit = proc.exitCode ?? "unknown";
+          }
           if (waitForExit && proc.status === "done") return;
           if (!waitForExit && (proc.status === "running" || proc.status === "done")) return;
         }
       }
     } catch { /* not ready */ }
+    if (deadExit !== null) {
+      throw new Error(
+        `Process "${name}" exited with code ${deadExit} while waiting for it to ${waitForExit ? "complete" : "start"}`,
+      );
+    }
     await delay(500);
   }
   throw new Error(`Process "${name}" did not ${waitForExit ? "complete" : "start"} within ${timeoutMs / 1000}s`);

--- a/templates/cardano-delegation/packages/contracts-cardano/register-test-pool.sh
+++ b/templates/cardano-delegation/packages/contracts-cardano/register-test-pool.sh
@@ -15,19 +15,33 @@ curl -s "$YACI_API/addresses/topup" \
   -d "{\"address\":\"$POOL_ADDR\",\"adaAmount\":10000}" > /dev/null
 
 echo "[register-test-pool] Waiting for UTxOs..."
-for i in $(seq 1 15); do
-  UTXO_LINE=$("$CARDANO_CLI" conway query utxo --address "$POOL_ADDR" --testnet-magic 42 2>/dev/null | tail -1)
-  if echo "$UTXO_LINE" | grep -q lovelace; then
+# 120s, not the old 15x2s=30s: on a 2-core CI runner the yaci topup had not
+# landed inside 30s, and the run then failed in a way that named neither funding
+# nor this script (see the guard below).
+UTXO_QUERY=""
+UTXO_LINE=""
+for i in $(seq 1 60); do
+  UTXO_QUERY=$("$CARDANO_CLI" conway query utxo --address "$POOL_ADDR" --testnet-magic 42 2>&1 || true)
+  # Select a real UTxO row, never the table's `-----` separator. The old code
+  # took `tail -1` unconditionally, so on an empty table awk turned that
+  # separator into `----------------#` — which is neither "" nor "#", so it slid
+  # past the guard and reached cardano-cli as --tx-in, producing
+  # `option --tx-in: unexpected "-"` instead of this script's own clear error.
+  UTXO_LINE=$(echo "$UTXO_QUERY" | grep lovelace | tail -1 || true)
+  if [ -n "$UTXO_LINE" ]; then
     break
   fi
   sleep 2
 done
 
-UTXO_IN=$(echo "$UTXO_LINE" | awk '{print $1 "#" $2}')
-if [ -z "$UTXO_IN" ] || [ "$UTXO_IN" = "#" ]; then
-  echo "[register-test-pool] ERROR: No UTxOs found after funding"
+if [ -z "$UTXO_LINE" ]; then
+  echo "[register-test-pool] ERROR: No UTxOs found at $POOL_ADDR after 120s of funding"
+  echo "[register-test-pool] last query output was:"
+  echo "$UTXO_QUERY"
   exit 1
 fi
+
+UTXO_IN=$(echo "$UTXO_LINE" | awk '{print $1 "#" $2}')
 
 TMPDIR=$(mktemp -d)
 

--- a/templates/cardano-delegation/packages/tests/run-tests.ts
+++ b/templates/cardano-delegation/packages/tests/run-tests.ts
@@ -67,6 +67,7 @@ async function waitForProcess(
   console.log(
     `Waiting for process "${name}"${waitForExit ? " to complete" : ""}...`,
   );
+  let deadExit: number | string | null = null;
   const start = Date.now();
   while (Date.now() - start < timeoutMs) {
     try {
@@ -77,6 +78,13 @@ async function waitForProcess(
         const data = (await res.json()) as any;
         const proc = data.processes?.find((p: any) => p.name === name);
         if (proc) {
+          // Fail fast: a process that has already died will never reach
+          // "done"/"running", so waiting out the timeout only buries the real
+          // error under a misleading "did not complete within Ns". Recorded
+          // here and thrown below because the catch swallows everything.
+          if (proc.status === "failed" || proc.status === "stopped") {
+            deadExit = proc.exitCode ?? "unknown";
+          }
           if (waitForExit && proc.status === "done") return;
           if (
             !waitForExit &&
@@ -87,6 +95,11 @@ async function waitForProcess(
       }
     } catch {
       /* not ready */
+    }
+    if (deadExit !== null) {
+      throw new Error(
+        `Process "${name}" exited with code ${deadExit} while waiting for it to ${waitForExit ? "complete" : "start"}`,
+      );
     }
     await delay(500);
   }

--- a/templates/chess-v2/packages/tests/run-tests.ts
+++ b/templates/chess-v2/packages/tests/run-tests.ts
@@ -56,6 +56,7 @@ async function waitForProcess(
 ): Promise<void> {
   const { waitForExit = false, timeoutMs = 120_000 } = opts;
   console.log(`Waiting for process "${name}"${waitForExit ? " to complete" : ""}...`);
+  let deadExit: number | string | null = null;
   const start = Date.now();
   while (Date.now() - start < timeoutMs) {
     try {
@@ -64,11 +65,23 @@ async function waitForProcess(
         const data = await res.json() as any;
         const proc = data.processes?.find((p: any) => p.name === name);
         if (proc) {
+          // Fail fast: a process that has already died will never reach
+          // "done"/"running", so waiting out the timeout only buries the real
+          // error under a misleading "did not complete within Ns". Recorded
+          // here and thrown below because the catch swallows everything.
+          if (proc.status === "failed" || proc.status === "stopped") {
+            deadExit = proc.exitCode ?? "unknown";
+          }
           if (waitForExit && proc.status === "done") return;
           if (!waitForExit && (proc.status === "running" || proc.status === "done")) return;
         }
       }
     } catch { /* not ready */ }
+    if (deadExit !== null) {
+      throw new Error(
+        `Process "${name}" exited with code ${deadExit} while waiting for it to ${waitForExit ? "complete" : "start"}`,
+      );
+    }
     await delay(500);
   }
   throw new Error(`Process "${name}" did not ${waitForExit ? "complete" : "start"} within ${timeoutMs / 1000}s`);

--- a/templates/evm-cardano/packages/tests/run-tests.ts
+++ b/templates/evm-cardano/packages/tests/run-tests.ts
@@ -56,6 +56,7 @@ async function waitForProcess(
 ): Promise<void> {
   const { waitForExit = false, timeoutMs = 120_000 } = opts;
   console.log(`Waiting for process "${name}"${waitForExit ? " to complete" : ""}...`);
+  let deadExit: number | string | null = null;
   const start = Date.now();
   while (Date.now() - start < timeoutMs) {
     try {
@@ -64,11 +65,23 @@ async function waitForProcess(
         const data = await res.json() as any;
         const proc = data.processes?.find((p: any) => p.name === name);
         if (proc) {
+          // Fail fast: a process that has already died will never reach
+          // "done"/"running", so waiting out the timeout only buries the real
+          // error under a misleading "did not complete within Ns". Recorded
+          // here and thrown below because the catch swallows everything.
+          if (proc.status === "failed" || proc.status === "stopped") {
+            deadExit = proc.exitCode ?? "unknown";
+          }
           if (waitForExit && proc.status === "done") return;
           if (!waitForExit && (proc.status === "running" || proc.status === "done")) return;
         }
       }
     } catch { /* not ready */ }
+    if (deadExit !== null) {
+      throw new Error(
+        `Process "${name}" exited with code ${deadExit} while waiting for it to ${waitForExit ? "complete" : "start"}`,
+      );
+    }
     await delay(500);
   }
   throw new Error(`Process "${name}" did not ${waitForExit ? "complete" : "start"} within ${timeoutMs / 1000}s`);

--- a/templates/evm-midnight-v2/packages/tests/run-tests.ts
+++ b/templates/evm-midnight-v2/packages/tests/run-tests.ts
@@ -57,6 +57,7 @@ async function waitForProcess(
 ): Promise<void> {
   const { waitForExit = false, timeoutMs = 120_000 } = opts;
   console.log(`Waiting for process "${name}"${waitForExit ? " to complete" : ""}...`);
+  let deadExit: number | string | null = null;
   const start = Date.now();
   while (Date.now() - start < timeoutMs) {
     try {
@@ -65,11 +66,23 @@ async function waitForProcess(
         const data = await res.json() as any;
         const proc = data.processes?.find((p: any) => p.name === name);
         if (proc) {
+          // Fail fast: a process that has already died will never reach
+          // "done"/"running", so waiting out the timeout only buries the real
+          // error under a misleading "did not complete within Ns". Recorded
+          // here and thrown below because the catch swallows everything.
+          if (proc.status === "failed" || proc.status === "stopped") {
+            deadExit = proc.exitCode ?? "unknown";
+          }
           if (waitForExit && proc.status === "done") return;
           if (!waitForExit && (proc.status === "running" || proc.status === "done")) return;
         }
       }
     } catch { /* not ready */ }
+    if (deadExit !== null) {
+      throw new Error(
+        `Process "${name}" exited with code ${deadExit} while waiting for it to ${waitForExit ? "complete" : "start"}`,
+      );
+    }
     await delay(500);
   }
   throw new Error(`Process "${name}" did not ${waitForExit ? "complete" : "start"} within ${timeoutMs / 1000}s`);

--- a/templates/hex-battle/packages/tests/run-tests.ts
+++ b/templates/hex-battle/packages/tests/run-tests.ts
@@ -52,6 +52,7 @@ async function waitForProcess(
 ): Promise<void> {
   const { waitForExit = false, timeoutMs = 120_000 } = opts;
   console.log(`Waiting for process "${name}"${waitForExit ? " to complete" : ""}...`);
+  let deadExit: number | string | null = null;
   const start = Date.now();
   while (Date.now() - start < timeoutMs) {
     try {
@@ -60,11 +61,23 @@ async function waitForProcess(
         const data = await res.json() as any;
         const proc = data.processes?.find((p: any) => p.name === name);
         if (proc) {
+          // Fail fast: a process that has already died will never reach
+          // "done"/"running", so waiting out the timeout only buries the real
+          // error under a misleading "did not complete within Ns". Recorded
+          // here and thrown below because the catch swallows everything.
+          if (proc.status === "failed" || proc.status === "stopped") {
+            deadExit = proc.exitCode ?? "unknown";
+          }
           if (waitForExit && proc.status === "done") return;
           if (!waitForExit && (proc.status === "running" || proc.status === "done")) return;
         }
       }
     } catch { /* not ready */ }
+    if (deadExit !== null) {
+      throw new Error(
+        `Process "${name}" exited with code ${deadExit} while waiting for it to ${waitForExit ? "complete" : "start"}`,
+      );
+    }
     await delay(500);
   }
   throw new Error(`Process "${name}" did not ${waitForExit ? "complete" : "start"} within ${timeoutMs / 1000}s`);

--- a/templates/minimal/packages/tests/run-tests.ts
+++ b/templates/minimal/packages/tests/run-tests.ts
@@ -52,6 +52,7 @@ async function waitForProcess(
 ): Promise<void> {
   const { waitForExit = false, timeoutMs = 120_000 } = opts;
   console.log(`Waiting for process "${name}"${waitForExit ? " to complete" : ""}...`);
+  let deadExit: number | string | null = null;
   const start = Date.now();
   while (Date.now() - start < timeoutMs) {
     try {
@@ -60,11 +61,23 @@ async function waitForProcess(
         const data = await res.json() as any;
         const proc = data.processes?.find((p: any) => p.name === name);
         if (proc) {
+          // Fail fast: a process that has already died will never reach
+          // "done"/"running", so waiting out the timeout only buries the real
+          // error under a misleading "did not complete within Ns". Recorded
+          // here and thrown below because the catch swallows everything.
+          if (proc.status === "failed" || proc.status === "stopped") {
+            deadExit = proc.exitCode ?? "unknown";
+          }
           if (waitForExit && proc.status === "done") return;
           if (!waitForExit && (proc.status === "running" || proc.status === "done")) return;
         }
       }
     } catch { /* not ready */ }
+    if (deadExit !== null) {
+      throw new Error(
+        `Process "${name}" exited with code ${deadExit} while waiting for it to ${waitForExit ? "complete" : "start"}`,
+      );
+    }
     await delay(500);
   }
   throw new Error(`Process "${name}" did not ${waitForExit ? "complete" : "start"} within ${timeoutMs / 1000}s`);

--- a/templates/night-bitcoin-v2/packages/tests/run-tests.ts
+++ b/templates/night-bitcoin-v2/packages/tests/run-tests.ts
@@ -56,6 +56,7 @@ async function waitForProcess(
 ): Promise<void> {
   const { waitForExit = false, timeoutMs = 120_000 } = opts;
   console.log(`Waiting for process "${name}"${waitForExit ? " to complete" : ""}...`);
+  let deadExit: number | string | null = null;
   const start = Date.now();
   while (Date.now() - start < timeoutMs) {
     try {
@@ -64,11 +65,23 @@ async function waitForProcess(
         const data = await res.json() as any;
         const proc = data.processes?.find((p: any) => p.name === name);
         if (proc) {
+          // Fail fast: a process that has already died will never reach
+          // "done"/"running", so waiting out the timeout only buries the real
+          // error under a misleading "did not complete within Ns". Recorded
+          // here and thrown below because the catch swallows everything.
+          if (proc.status === "failed" || proc.status === "stopped") {
+            deadExit = proc.exitCode ?? "unknown";
+          }
           if (waitForExit && proc.status === "done") return;
           if (!waitForExit && (proc.status === "running" || proc.status === "done")) return;
         }
       }
     } catch { /* not ready */ }
+    if (deadExit !== null) {
+      throw new Error(
+        `Process "${name}" exited with code ${deadExit} while waiting for it to ${waitForExit ? "complete" : "start"}`,
+      );
+    }
     await delay(500);
   }
   throw new Error(`Process "${name}" did not ${waitForExit ? "complete" : "start"} within ${timeoutMs / 1000}s`);

--- a/templates/preorder/packages/frontend/playwright.config.ts
+++ b/templates/preorder/packages/frontend/playwright.config.ts
@@ -5,7 +5,10 @@ export default defineConfig({
   timeout: 120_000,
   retries: 0,
   use: {
-    baseURL: "http://localhost:10598",
+    // 127.0.0.1, not localhost: the dev server is started with
+    // `--host 127.0.0.1` (see packages/tests/frontend/e2e.test.ts) because
+    // "localhost" resolves to ::1 in the CI container. Keep these in lockstep.
+    baseURL: "http://127.0.0.1:10598",
   },
   projects: [
     {

--- a/templates/preorder/packages/tests/frontend/e2e.test.ts
+++ b/templates/preorder/packages/tests/frontend/e2e.test.ts
@@ -31,13 +31,19 @@ export async function frontendE2eTest(): Promise<void> {
   // OOM-killed silently, and the readiness poll below would then time out.
   // Starting it immediately before the check keeps the live window tiny and
   // self-contained; we tear it down in the finally.
+  // --host is not cosmetic. Vite's default host is "localhost", which Node
+  // resolves to ::1 inside the CI container, so vite binds IPv6 loopback ONLY
+  // (`ss -ltn` → LISTEN [::1]:10598). Bun's fetch resolves "localhost" to
+  // 127.0.0.1, so the readiness poll below got ECONNREFUSED for the full 60s
+  // while vite sat there reporting "ready in 418 ms". Pin both ends to the same
+  // literal IPv4 address so neither can drift onto a different family again.
   const viteProc = Bun.spawn(
-    ["bunx", "vite", "--port", "10598", "--mode", "dev"],
+    ["bunx", "vite", "--port", "10598", "--host", "127.0.0.1", "--mode", "dev"],
     { cwd: frontendDir, stdout: "inherit", stderr: "inherit" },
   );
 
   try {
-    await waitForViteServer("http://localhost:10598");
+    await waitForViteServer("http://127.0.0.1:10598");
 
     const installProc = Bun.spawn(
       ["bunx", "playwright", "install", "chromium"],

--- a/templates/preorder/packages/tests/run-tests.ts
+++ b/templates/preorder/packages/tests/run-tests.ts
@@ -56,6 +56,7 @@ async function waitForProcess(
 ): Promise<void> {
   const { waitForExit = false, timeoutMs = 120_000 } = opts;
   console.log(`Waiting for process "${name}"${waitForExit ? " to complete" : ""}...`);
+  let deadExit: number | string | null = null;
   const start = Date.now();
   while (Date.now() - start < timeoutMs) {
     try {
@@ -64,11 +65,23 @@ async function waitForProcess(
         const data = await res.json() as any;
         const proc = data.processes?.find((p: any) => p.name === name);
         if (proc) {
+          // Fail fast: a process that has already died will never reach
+          // "done"/"running", so waiting out the timeout only buries the real
+          // error under a misleading "did not complete within Ns". Recorded
+          // here and thrown below because the catch swallows everything.
+          if (proc.status === "failed" || proc.status === "stopped") {
+            deadExit = proc.exitCode ?? "unknown";
+          }
           if (waitForExit && proc.status === "done") return;
           if (!waitForExit && (proc.status === "running" || proc.status === "done")) return;
         }
       }
     } catch { /* not ready */ }
+    if (deadExit !== null) {
+      throw new Error(
+        `Process "${name}" exited with code ${deadExit} while waiting for it to ${waitForExit ? "complete" : "start"}`,
+      );
+    }
     await delay(500);
   }
   throw new Error(`Process "${name}" did not ${waitForExit ? "complete" : "start"} within ${timeoutMs / 1000}s`);

--- a/templates/projected-nft-preorder/packages/tests/run-tests.ts
+++ b/templates/projected-nft-preorder/packages/tests/run-tests.ts
@@ -56,6 +56,7 @@ async function waitForProcess(
 ): Promise<void> {
   const { waitForExit = false, timeoutMs = 120_000 } = opts;
   console.log(`Waiting for process "${name}"${waitForExit ? " to complete" : ""}...`);
+  let deadExit: number | string | null = null;
   const start = Date.now();
   while (Date.now() - start < timeoutMs) {
     try {
@@ -64,11 +65,23 @@ async function waitForProcess(
         const data = await res.json() as any;
         const proc = data.processes?.find((p: any) => p.name === name);
         if (proc) {
+          // Fail fast: a process that has already died will never reach
+          // "done"/"running", so waiting out the timeout only buries the real
+          // error under a misleading "did not complete within Ns". Recorded
+          // here and thrown below because the catch swallows everything.
+          if (proc.status === "failed" || proc.status === "stopped") {
+            deadExit = proc.exitCode ?? "unknown";
+          }
           if (waitForExit && proc.status === "done") return;
           if (!waitForExit && (proc.status === "running" || proc.status === "done")) return;
         }
       }
     } catch { /* not ready */ }
+    if (deadExit !== null) {
+      throw new Error(
+        `Process "${name}" exited with code ${deadExit} while waiting for it to ${waitForExit ? "complete" : "start"}`,
+      );
+    }
     await delay(500);
   }
   throw new Error(`Process "${name}" did not ${waitForExit ? "complete" : "start"} within ${timeoutMs / 1000}s`);

--- a/templates/shinkai-v2/packages/tests/run-tests.ts
+++ b/templates/shinkai-v2/packages/tests/run-tests.ts
@@ -52,6 +52,7 @@ async function waitForProcess(
 ): Promise<void> {
   const { waitForExit = false, timeoutMs = 120_000 } = opts;
   console.log(`Waiting for process "${name}"${waitForExit ? " to complete" : ""}...`);
+  let deadExit: number | string | null = null;
   const start = Date.now();
   while (Date.now() - start < timeoutMs) {
     try {
@@ -60,11 +61,23 @@ async function waitForProcess(
         const data = await res.json() as any;
         const proc = data.processes?.find((p: any) => p.name === name);
         if (proc) {
+          // Fail fast: a process that has already died will never reach
+          // "done"/"running", so waiting out the timeout only buries the real
+          // error under a misleading "did not complete within Ns". Recorded
+          // here and thrown below because the catch swallows everything.
+          if (proc.status === "failed" || proc.status === "stopped") {
+            deadExit = proc.exitCode ?? "unknown";
+          }
           if (waitForExit && proc.status === "done") return;
           if (!waitForExit && (proc.status === "running" || proc.status === "done")) return;
         }
       }
     } catch { /* not ready */ }
+    if (deadExit !== null) {
+      throw new Error(
+        `Process "${name}" exited with code ${deadExit} while waiting for it to ${waitForExit ? "complete" : "start"}`,
+      );
+    }
     await delay(500);
   }
   throw new Error(`Process "${name}" did not ${waitForExit ? "complete" : "start"} within ${timeoutMs / 1000}s`);

--- a/templates/solana-starter/packages/tests/run-tests.ts
+++ b/templates/solana-starter/packages/tests/run-tests.ts
@@ -75,6 +75,7 @@ async function waitForProcess(
 ): Promise<void> {
   const { waitForExit = false, timeoutMs = 300_000 } = opts;
   console.log(`Waiting for process "${name}"...`);
+  let deadExit: number | string | null = null;
   const start = Date.now();
   while (Date.now() - start < timeoutMs) {
     try {
@@ -83,12 +84,24 @@ async function waitForProcess(
         const data = (await res.json()) as any;
         const proc = data.processes?.find((p: any) => p.name === name);
         if (proc) {
+          // Fail fast: a process that has already died will never reach
+          // "done"/"running", so waiting out the timeout only buries the real
+          // error under a misleading "did not complete within Ns". Recorded
+          // here and thrown below because the catch swallows everything.
+          if (proc.status === "failed" || proc.status === "stopped") {
+            deadExit = proc.exitCode ?? "unknown";
+          }
           if (waitForExit && proc.status === "done") return;
           if (!waitForExit && (proc.status === "running" || proc.status === "done")) return;
         }
       }
     } catch {
       /* not ready */
+    }
+    if (deadExit !== null) {
+      throw new Error(
+        `Process "${name}" exited with code ${deadExit} while waiting for it to ${waitForExit ? "complete" : "start"}`,
+      );
     }
     await delay(500);
   }

--- a/templates/world-map-2d/packages/tests/run-tests.ts
+++ b/templates/world-map-2d/packages/tests/run-tests.ts
@@ -52,6 +52,7 @@ async function waitForProcess(
 ): Promise<void> {
   const { waitForExit = false, timeoutMs = 120_000 } = opts;
   console.log(`Waiting for process "${name}"${waitForExit ? " to complete" : ""}...`);
+  let deadExit: number | string | null = null;
   const start = Date.now();
   while (Date.now() - start < timeoutMs) {
     try {
@@ -60,11 +61,23 @@ async function waitForProcess(
         const data = await res.json() as any;
         const proc = data.processes?.find((p: any) => p.name === name);
         if (proc) {
+          // Fail fast: a process that has already died will never reach
+          // "done"/"running", so waiting out the timeout only buries the real
+          // error under a misleading "did not complete within Ns". Recorded
+          // here and thrown below because the catch swallows everything.
+          if (proc.status === "failed" || proc.status === "stopped") {
+            deadExit = proc.exitCode ?? "unknown";
+          }
           if (waitForExit && proc.status === "done") return;
           if (!waitForExit && (proc.status === "running" || proc.status === "done")) return;
         }
       }
     } catch { /* not ready */ }
+    if (deadExit !== null) {
+      throw new Error(
+        `Process "${name}" exited with code ${deadExit} while waiting for it to ${waitForExit ? "complete" : "start"}`,
+      );
+    }
     await delay(500);
   }
   throw new Error(`Process "${name}" did not ${waitForExit ? "complete" : "start"} within ${timeoutMs / 1000}s`);

--- a/templates/zk-cardano/packages/tests/infra/sync-ready.test.ts
+++ b/templates/zk-cardano/packages/tests/infra/sync-ready.test.ts
@@ -7,18 +7,29 @@ export async function syncReadyTest() {
   });
 
   await assert("Block heights are advancing", async () => {
-    const getMaxHeight = (data: any[]): number => {
-      const pages = data.map((d: any) => d.fetched_page ?? 0);
-      return pages.length > 0 ? Math.max(...pages) : 0;
-    };
+    // Compare PER PROTOCOL, not Math.max() across all of them. The max is owned
+    // by whichever protocol has the highest page number, and a protocol that has
+    // caught up sits there unchanged — masking every protocol that is still
+    // advancing beneath it. Observed on a failing run: parallelUtxoRpc pinned at
+    // page 43 while mainNtp climbed 2 -> 35 over 30s, so max() stayed 43 and the
+    // assertion reported "not advancing" while sync was demonstrably alive.
+    // mainNtp needed ~41s to cross 43 — just past this poll window, which is why
+    // the old check failed on some machines and passed on others.
+    const byProtocol = (data: any[]): Map<string, number> =>
+      new Map(data.map((d: any) => [d.protocol_name, d.fetched_page ?? 0]));
+
     for (let attempt = 0; attempt < 10; attempt++) {
-      const res1 = await fetch("http://localhost:9999/block-heights");
-      const data1 = await res1.json() as any[];
+      const before = byProtocol(
+        (await (await fetch("http://localhost:9999/block-heights")).json()) as any[],
+      );
       await new Promise((r) => setTimeout(r, 3000));
-      const res2 = await fetch("http://localhost:9999/block-heights");
-      const data2 = await res2.json() as any[];
-      if (data2.length > 0 && getMaxHeight(data2) > getMaxHeight(data1)) {
-        return true;
+      const after = byProtocol(
+        (await (await fetch("http://localhost:9999/block-heights")).json()) as any[],
+      );
+      // Sync is alive if ANY protocol made progress.
+      for (const [protocol, page] of after) {
+        const previous = before.get(protocol);
+        if (previous !== undefined && page > previous) return true;
       }
     }
     return false;

--- a/templates/zk-cardano/packages/tests/run-tests.ts
+++ b/templates/zk-cardano/packages/tests/run-tests.ts
@@ -56,6 +56,7 @@ async function waitForProcess(
 ): Promise<void> {
   const { waitForExit = false, timeoutMs = 120_000 } = opts;
   console.log(`Waiting for process "${name}"${waitForExit ? " to complete" : ""}...`);
+  let deadExit: number | string | null = null;
   const start = Date.now();
   while (Date.now() - start < timeoutMs) {
     try {
@@ -64,11 +65,23 @@ async function waitForProcess(
         const data = await res.json() as any;
         const proc = data.processes?.find((p: any) => p.name === name);
         if (proc) {
+          // Fail fast: a process that has already died will never reach
+          // "done"/"running", so waiting out the timeout only buries the real
+          // error under a misleading "did not complete within Ns". Recorded
+          // here and thrown below because the catch swallows everything.
+          if (proc.status === "failed" || proc.status === "stopped") {
+            deadExit = proc.exitCode ?? "unknown";
+          }
           if (waitForExit && proc.status === "done") return;
           if (!waitForExit && (proc.status === "running" || proc.status === "done")) return;
         }
       }
     } catch { /* not ready */ }
+    if (deadExit !== null) {
+      throw new Error(
+        `Process "${name}" exited with code ${deadExit} while waiting for it to ${waitForExit ? "complete" : "start"}`,
+      );
+    }
     await delay(500);
   }
   throw new Error(`Process "${name}" did not ${waitForExit ? "complete" : "start"} within ${timeoutMs / 1000}s`);


### PR DESCRIPTION
Fixes the three template failures that #859 exposed, plus the harness behaviour that made all three present as misleading timeouts.

**None of these are regressions from #859 or the 0.103.3 bump** — all reproduce at 0.102.0. #859 simply stopped them exiting 0 and reporting PASS.

## 1. preorder — vite dev server unreachable (deterministic)

The E2E test spawned `bunx vite --port 10598` and polled `localhost`. Vite's default host is `localhost`, which resolves to `::1` in the container, so vite bound **IPv6 loopback only** — while Bun's `fetch` resolves `localhost` to `127.0.0.1`. Measured in the CI image:

```
ss -ltn                        -> LISTEN [::1]:10598
fetch http://localhost:10598   -> ConnectionRefused
fetch http://127.0.0.1:10598   -> ConnectionRefused
fetch http://[::1]:10598       -> OK 200
```

The poll therefore got `ECONNREFUSED` for its full 60s while vite reported `ready in 418 ms`. **This could never pass in the container, at any dependency version.** It hid behind 45 passing assertions (`anyError()` false → exit 0 → PASS) until #859.

Fix: pin both ends to the same literal IPv4 address — `--host 127.0.0.1` on the spawn, and `127.0.0.1` in the poll and in `playwright.config.ts` `baseURL`.

## 2. cardano-delegation — broken empty-UTxO guard + too-short funding wait

CI showed `Process "register-test-pool" did not complete within 300s`. The script actually died at 30s; the 300s was the harness waiting for a corpse (see 4).

```
03:51:57  Funding pool operator address...
03:51:57  Waiting for UTxOs...              # 15 x 2s = 30s
03:52:27  option --tx-in: unexpected "-"    # garbage reached cardano-cli
03:52:27  register-test-pool exited code 1
03:56:59  did not complete within 300s      # 4.5 min later
```

`query utxo | tail -1` on an empty UTxO table returns the `-----` separator row, which `awk` turned into `----------------#`. That is neither `""` nor `"#"`, so it slid past the guard and reached `cardano-cli` as `--tx-in`, producing a usage error naming neither funding nor this script.

Fix: select only rows matching `lovelace`; on failure print the intended error plus the query output. Raise the funding wait 30s → 120s — on a 2-core runner the yaci topup had not landed within 30s.

## 3. zk-cardano — "Block heights are advancing" masked real progress

Failed on fast machines, passed on slow CI. The assertion compared `Math.max(fetched_page)` across **all** protocols. The max is owned by whichever protocol sits highest, and one that has caught up stays there — hiding every protocol advancing beneath it. Instrumenting `/block-heights` through a failing run showed exactly that:

```
parallelUtxoRpc  43 43 43 43 43 43 43 43 43 43 43   <- caught up, owns the max
parallelMidnight  9 10 10 11 11 12 12 13 13 14 14   <- advancing
mainNtp           2  5  8 11 14 17 20 23 25 29 35   <- advancing the whole time
```

Sync was never stalled. `mainNtp` needed ~41s to climb past 43 — just outside the 30s poll window, which is precisely why the verdict flipped with machine speed.

Fix: compare **per protocol** and pass if any protocol advances.

## 4. waitForProcess — fail fast on a dead process (14 templates + 2 e2e harnesses)

All three failures above presented as `Process X did not complete within Ns`, naming a process merely downstream of the real casualty. The orchestrator sets `status = code === 0 ? "done" : "failed"` and exposes `exitCode` via `/processes`, so a dead dependency is detectable immediately.

The detection is recorded in the poll and thrown **after** it — deliberately not inside, because the existing `catch { /* not ready */ }` swallows every exception, so a throw in place would be silently ignored and still wait out the timeout.

Recovers 270s in cardano-delegation and 120s in night-bitcoin, and surfaces the real error at the moment of death.

## Verification

Each fix run in the CI image, in the environment that exposed its bug:

| Template | Result | Environment |
|---|---|---|
| preorder | **PASS** 17m17s | previously failed everywhere |
| cardano-delegation | **PASS** 15m18s | `--cpus=2`, emulating the CI runner; `Transaction successfully submitted`, `Pool registered: pool1stk9qtu...` |
| zk-cardano | **PASS** 8m40s, 19/0 | fast box that failed; incl. `[PASS] Block heights are advancing` |

Then a full sweep of all 14 enabled templates — also a regression check on the fail-fast edit, which touches every template:

```
[PASS] cardano-delegation (7m40s)   [PASS] batcher-validations (39s)
[PASS] evm-cardano (2m14s)          [PASS] night-bitcoin-v2 (3m47s)
[PASS] preorder (3m28s)             [PASS] hex-battle (41s)
[PASS] projected-nft-preorder (2m29s) [PASS] solana-starter (2m23s)
[PASS] shinkai-v2 (36s)             [PASS] chess-v2 (1m26s)
[PASS] zk-cardano (2m12s)           [PASS] minimal (32s)
[FAIL] evm-midnight-v2 (7m45s)      [PASS] world-map-2d (41s)
```

`evm-midnight-v2` then **passed solo at 41/0 (11m49s)**. Across four local attempts it failed twice with two unrelated environmental causes — a solc TLS handshake EOF, then a Midnight property-sync timeout — and passed every time it ran unstarved, plus in CI at 3m13s. This box runs 25+ other containers; the failures are starvation, not defects in this change. Note its `39 passed / 2 failed` is the honest-reporting path working: pre-#859 that run would have reported PASS.

**14/14 pass when not resource-starved.**

## Not addressed (pre-existing, documented in #859)

- **Unguarded binary downloads**, still the top flake source: bitcoin-core (`got`, no timeout), midnight-indexer (`axios`, no timeout *and* source-stream errors unhandled so the promise never settles), and forge's solc — `~/.svm/` is not pre-seeded although the Dockerfile already pre-seeds Hardhat's solc cache for exactly this reason. Seeding `~/.svm/` would have prevented the flake seen here.
- **A gap in this PR's fail-fast**: it catches `failed`/`stopped` on the *awaited* process, but not "a dependency died so this process can never leave `pending`". Observed once — `midnight-contract` died and the harness still waited 300s for `cardano-submit-tx`, which never started. Detecting orchestrator shutdown would close it.
- Templates use two different summary formats (`N tests passed` vs `Results: N passed`), which complicates log scraping.
