### PR TITLE
ci: validate external pull requests in upstream

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,6 +1,23 @@
-on: [push]
+# Pull requests must be a first-class trigger: a push to an external fork runs
+# only in that fork and cannot report checks to this repository. Keep pushes on
+# the default branch for post-merge validation, and use the PR merge ref for one
+# pre-merge run (rather than duplicating every same-repository branch push).
+on:
+  push:
+    branches: [v-next]
+  pull_request:
+    # Expensive jobs skip drafts. Re-run when a draft becomes reviewable, and
+    # cancel an in-progress run through the PR-scoped concurrency group when a
+    # pull request is converted back to draft.
+    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft]
 
 name: Effectstream Test Workflow
+
+# This workflow executes untrusted pull-request code. It does not need secrets
+# or repository writes; fork PRs also receive GitHub's read-only token and
+# first-time-contributor approval boundary.
+permissions:
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/docs/site/docs/home/1000-effectstream-engine/1100-contributions.md
+++ b/docs/site/docs/home/1000-effectstream-engine/1100-contributions.md
@@ -20,6 +20,8 @@ In your PR description, please include:
 
 Once you submit the Pull Request, our team will review your contribution, provide feedback if necessary, and merge it once it's ready. Thank you for helping to improve EffectStream
 
+Pull requests are tested in the EffectStream repository against their proposed merge result. For a first-time contribution from a fork, GitHub may pause the workflow until a maintainer selects **Approve workflows to run**. These checks use a read-only repository token and do not receive repository secrets.
+
 ## Running the tests
 
 ### Unit tests


### PR DESCRIPTION
## Summary

- run the test workflow for `pull_request` activity, including draft transitions
- keep `push` validation on `v-next` so internal pull requests are not tested twice
- explicitly restrict the workflow token to `contents: read`
- document first-time fork contributor approval behavior

## Why

The workflow was registered only for `push`. A push from an external contributor runs in the contributor fork and does not attach checks to the upstream pull request. The workflow already contained pull-request diff logic and draft guards, but those paths were unreachable.

This uses the unprivileged `pull_request` event. It intentionally does not use `pull_request_target`, because the workflow checks out and executes contributor code.

## Static verification

- workflow YAML parsed successfully with assertions for the exact triggers and permissions
- `git diff --check` passed
- the final diff contains only the workflow and contributor guide
- static inspection found no secrets, write permissions, self-hosted runners, or privileged trigger

No CI/CD tests were run per instruction. The head commit contains `[skip ci]`, so push and pull-request workflows are intentionally skipped for this PR.

## Activation note

After this reaches `v-next`, already-open external pull requests may need a new head push, reopen, or ready-for-review event to create their first upstream workflow run.