### PR TITLE
fix(templates/single-file): pin the SDK in a manifest instead of the import

### DIFF
--- a/packages/node-sdk/node/test/examples.test.ts
+++ b/packages/node-sdk/node/test/examples.test.ts
@@ -56,16 +56,21 @@ test("single-file facade rejects malformed declarations early", async () => {
   })).toThrow(/64 hexadecimal/);
 });
 
-test("single-file template contains one source file and one exact import", async () => {
+test("single-file template is one source file plus a manifest, importing only the SDK", async () => {
   const templateDir = new URL("../../../../templates/single-file/", import.meta.url);
   const files = [...new Bun.Glob("**/*").scanSync({
     cwd: templateDir.pathname,
     onlyFiles: true,
-  })];
-  expect(files).toEqual(["minimal.ts"]);
+  })].sort();
+  expect(files).toEqual(["minimal.ts", "package.json"]);
 
   const source = await Bun.file(new URL("minimal.ts", templateDir)).text();
   const imports = [...source.matchAll(/from\s+["']([^"']+)["']/g)].map((match) => match[1]);
-  expect(imports).toEqual(["@effectstream/node-sdk@0.103.4"]);
+  expect(imports).toEqual(["@effectstream/node-sdk"]);
   expect(source).not.toMatch(/contract-counter|wallet|proofServer|generated|child_process/);
+
+  // The version is pinned in the manifest, never in the import specifier, so
+  // `update-packages.ts` can bump it without a release turning this test red.
+  const manifest = await Bun.file(new URL("package.json", templateDir)).json();
+  expect(manifest.dependencies["@effectstream/node-sdk"]).toMatch(/^\d+\.\d+\.\d+$/);
 });

--- a/templates/single-file/minimal.ts
+++ b/templates/single-file/minimal.ts
@@ -1,10 +1,20 @@
-/** Requires Bun with auto-install enabled. Run: bun minimal.ts, then open http://localhost:9999. */
+/**
+ * One file, one dependency. Run: `bun install && bun start`, then open
+ * http://localhost:9999.
+ *
+ * The SDK version is pinned in package.json rather than in the import
+ * specifier. Bun's auto-install cache cannot resolve packages that import
+ * themselves by name (`@noble/hashes/crypto`, reached transitively via viem),
+ * because that resolution needs a node_modules anchor the cache never creates.
+ * `bun install` materializes one, so the import below stays a plain bare
+ * specifier.
+ */
 import {
   midnightContract,
   pglite,
   runNode,
   type MidnightNetwork,
-} from "@effectstream/node-sdk@0.103.4";
+} from "@effectstream/node-sdk";
 
 const NETWORK: MidnightNetwork = "preview"; // Change to "preprod" for the mirror.
 const CONTRACTS = {

--- a/templates/single-file/package.json
+++ b/templates/single-file/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "single-file",
+  "private": true,
+  "scripts": {
+    "start": "bun minimal.ts"
+  },
+  "dependencies": {
+    "@effectstream/node-sdk": "0.104.0"
+  }
+}


### PR DESCRIPTION
## Problem

The single-file template cannot run from the registry today, for two independent reasons.

**1. The pinned version was never published.** `minimal.ts` imports `@effectstream/node-sdk@0.103.4`, but the release went `0.103.3` → `0.104.0`. `0.103.4` is not on npm, so the checked-in file cannot resolve at all.

**2. Bumping the pin to `0.104.0` still fails**, now at load time — before any user code runs:

```
error: Cannot find module '@noble/hashes/crypto'
from '~/.bun/install/cache/@noble/hashes@1.8.0@@@1/esm/utils.js'
```

`@noble/hashes` 1.x imports **itself by name** to select a per-environment build (`esm/cryptoNode.js` on node, `esm/crypto.js` in browsers). Resolving a bare specifier means walking up the tree for a `node_modules` directory; bun's auto-install cache has none, so the self-reference cannot resolve.

It arrives transitively and is not fixable from our side:

```
viem@2.37.3 → ox@0.9.3 → @noble/curves@1.9.1 (pins exactly 1.8.0) → @noble/hashes@1.8.0
```

Every `@noble/hashes` 1.x self-imports; only 2.x uses relative paths. `@effectstream/sm` already requires `^2.2.0` — the 1.x copy comes solely from the viem branch, and clears only when viem/ox move up.

This is the same failure class this template's original PR fixed for our own packages (internal self-imports rewritten to relative paths); we just can't rewrite a third party's source.

## Change

Add `templates/single-file/package.json` pinning the SDK, and make the import a plain bare specifier. `bun install` materializes the `node_modules` anchor the self-reference needs.

- `templates/` is **not** a workspace (root globs `packages/**`, `e2e/**`), so this does not join the monorepo install.
- `single-file` is **not** in `run-template-tests.ts` `ENABLED`, so this adds no CI surface.
- Run instructions become `bun install && bun start`. Still one source file.

The test is now version-agnostic in both directions: the import must be exactly `@effectstream/node-sdk`, and the manifest pin only has to match `\d+\.\d+\.\d+`. The previous assertion hardcoded `0.103.4`, which would have turned red on the first release bump that `update-packages.ts` applied to the template.

## Validation

- `packages/node-sdk/node/test/examples.test.ts` — 7 pass / 0 fail
- From a copy of `templates/single-file/`: `bun install && bun start` serves the page, `[Midnight:preview] Fetching blocks from 420281` (resolves the live tip rather than scanning from 0), and SIGTERM releases port 9999 cleanly

## Note, not addressed here

`chore(release): v0.104.0` bumped the workspace `package.json` versions but left `bun.lock` at `0.103.3`; a plain `bun install` rewrites 39 lines. Deliberately left out of this PR to keep it focused.