### PR TITLE
fix(batcher): make a Midnight batcher restart survivable — store/restore correctness and sync tuning

### DIFF
--- a/packages/batcher/README.md
+++ b/packages/batcher/README.md
@@ -34,6 +34,31 @@ NIGHT" want very different answers.
 | `MIDNIGHT_WALLET_SYNC_TIMEOUT_MS` | `14400000` (4 h) | A full chain replay. A backstop, not a health check — a genuinely stuck sync is caught within ~60 s by emission-silence detection, so this only needs to exceed a real cold sync with headroom. Raise it for chains longer than preprod. |
 | `MIDNIGHT_WALLET_FUNDING_TIMEOUT_MS` | `600000` (10 min) | Waiting for funds to arrive once the wallet is synced. Keep it short: an unfunded wallet should fail in minutes rather than inherit the sync budget. |
 | `MIDNIGHT_DUST_REGISTRATION_PRECHECK_TIMEOUT_MS` | `600000` (10 min) | The NIGHT→dust registration precheck ("unshielded and dust are both strictly complete"). In `dust-only` sync mode the unshielded sub-wallet has been stopped, so this wait can never succeed — it exists to give up in bounded time. |
+| `MIDNIGHT_DUST_STATE_SAVE_INTERVAL_MS` | `300000` (5 min) | How often a running wallet checkpoints its dust state. Bounds how much chain a crash makes it replay. `0` keeps only the shutdown checkpoint. |
+
+A stalled sync is detected separately and much sooner: if the dust wallet stops
+emitting state for 60 seconds the wallet is rebuilt from its last checkpoint and
+the sync retried. That is a *silence* check, not an elapsed-time one, so a cold
+sync that is progressing normally is never interrupted no matter how long it
+takes.
+
+### Midnight dust sync batching
+
+The dust wallet's sync batching is tuned for backend throughput rather than UI
+responsiveness. Dust sync runs on the main event loop, so these trade sync speed
+against how responsive the rest of the process (including the HTTP server, which
+accepts requests while wallets are still syncing) stays during a cold start.
+
+| Env var | Default | Browser SDK default |
+| --- | --- | --- |
+| `MIDNIGHT_DUST_SYNC_BATCH_SIZE` | `100` | 10 |
+| `MIDNIGHT_DUST_SYNC_BATCH_TIMEOUT_MS` | `1` | 1 |
+| `MIDNIGHT_DUST_SYNC_BATCH_SPACING_MS` | `1` | 4 |
+
+Larger batches mean fewer intermediate state snapshots and less memory churn.
+Keep spacing above `0`: at `0` the catch-up sync starves everything else on the
+loop. These defaults are not yet measured against a long chain — treat them as
+reasonable, not optimal.
 
 Dust wallet state is checkpointed to disk (`dust-state/`, one file per network
 and seed) so a restart resumes from the last snapshot instead of replaying the

--- a/packages/batcher/README.md
+++ b/packages/batcher/README.md
@@ -43,6 +43,15 @@ rejected: it is renamed to `<snapshot>.rejected` and the wallet cold-syncs.
 That costs a resync, and it is logged at error level for exactly that reason —
 but it never wedges wallet init, which is what those cases used to do.
 
+`getHealthInfo()` (served by `/queue-stats`) reports a `dustSync` entry per
+wallet so a slow start is distinguishable from a broken one — `state` is
+`syncing` / `stalled` / `complete` / `unknown`, alongside `restoredFrom` (0
+means a full replay), `appliedIndex`, `target`, `behind`, `lastAdvanceAgeMs`,
+and `snapshot` (`cold` / `restored` / `rejected`). `dustClock` reports whether
+dust generation is being projected at wall clock (`live`) or has fallen back to
+the wallet's last applied event (`sync-time`), which on a quiet chain can look
+like starvation.
+
 ## Standalone usage
 
 A minimal end-to-end example using `FileStorage`, the EffectstreamL2 adapter, and the bundled HTTP server.

--- a/packages/batcher/README.md
+++ b/packages/batcher/README.md
@@ -21,6 +21,28 @@ npm install @effectstream/batcher-sdk
 > `@midnightntwrk/wallet-sdk-dust-wallet` >= 4.0.0). Override with the
 > `MIDNIGHT_DUST_SYNC_BATCH_{SIZE,TIMEOUT_MS,SPACING_MS}` env vars.
 
+### Midnight wallet sync and funding timeouts
+
+A dust cold sync is the expensive part of starting a Midnight fee wallet: on
+preprod it measures ~66 minutes (~1.44 M dust indices), while the unshielded
+sync takes about a second. The three deadlines below are deliberately separate,
+because "the chain is still replaying" and "nobody has sent this wallet any
+NIGHT" want very different answers.
+
+| Env var | Default | What it bounds |
+| --- | --- | --- |
+| `MIDNIGHT_WALLET_SYNC_TIMEOUT_MS` | `14400000` (4 h) | A full chain replay. A backstop, not a health check — a genuinely stuck sync is caught within ~60 s by emission-silence detection, so this only needs to exceed a real cold sync with headroom. Raise it for chains longer than preprod. |
+| `MIDNIGHT_WALLET_FUNDING_TIMEOUT_MS` | `600000` (10 min) | Waiting for funds to arrive once the wallet is synced. Keep it short: an unfunded wallet should fail in minutes rather than inherit the sync budget. |
+| `MIDNIGHT_DUST_REGISTRATION_PRECHECK_TIMEOUT_MS` | `600000` (10 min) | The NIGHT→dust registration precheck ("unshielded and dust are both strictly complete"). In `dust-only` sync mode the unshielded sub-wallet has been stopped, so this wait can never succeed — it exists to give up in bounded time. |
+
+Dust wallet state is checkpointed to disk (`dust-state/`, one file per network
+and seed) so a restart resumes from the last snapshot instead of replaying the
+chain. A snapshot recorded on another network, one that fails to decode after
+an SDK upgrade, or one whose offset sits past the indexer's event log is
+rejected: it is renamed to `<snapshot>.rejected` and the wallet cold-syncs.
+That costs a resync, and it is logged at error level for exactly that reason —
+but it never wedges wallet init, which is what those cases used to do.
+
 ## Standalone usage
 
 A minimal end-to-end example using `FileStorage`, the EffectstreamL2 adapter, and the bundled HTTP server.

--- a/packages/batcher/README.md
+++ b/packages/batcher/README.md
@@ -57,8 +57,17 @@ accepts requests while wallets are still syncing) stays during a cold start.
 
 Larger batches mean fewer intermediate state snapshots and less memory churn.
 Keep spacing above `0`: at `0` the catch-up sync starves everything else on the
-loop. These defaults are not yet measured against a long chain — treat them as
-reasonable, not optimal.
+loop.
+
+**These defaults are now measured on preprod (1.44 M dust indices) and every
+direction of change is worse for a process that serves HTTP while syncing.**
+Raising `size` to 500 buys 21% throughput and costs 3.7× the worst event-loop
+stall (430 ms → 1 577 ms); 2000 buys 18% and costs 3 814 ms, and is unreachable
+anyway because the 1 ms batch window closes batches long before 2 000 events
+arrive. Dropping `size` to 50 costs 12% throughput for a 246 ms worst stall —
+offered as a deliberate latency-first setting, not a better default. `timeout`
+1 → 25 is noise and 1 → 100 costs 5%. `spacing` 1 → 0 buys 2.4% and costs 5×
+the median stall; 1 → 5 or 25 costs 3% for no tail-latency benefit.
 
 Dust wallet state is checkpointed to disk (`dust-state/`, one file per network
 and seed) so a restart resumes from the last snapshot instead of replaying the
@@ -67,6 +76,26 @@ an SDK upgrade, or one whose offset sits past the indexer's event log is
 rejected: it is renamed to `<snapshot>.rejected` and the wallet cold-syncs.
 That costs a resync, and it is logged at error level for exactly that reason —
 but it never wedges wallet init, which is what those cases used to do.
+
+### The HTTP port waits for adapters to be servable
+
+Restoring a preprod dust snapshot is one **synchronous** WASM deserialize —
+measured at ~46 s for 5.1 MB — during which no request handler can run at all.
+The server used to be listening throughout, so every restart was a ~46-second
+window where connections were accepted and nothing answered.
+
+`Batcher.init()` therefore holds the port closed until every adapter that
+implements `whenServable()` reports it is past that work, then starts the
+server for the rest of startup — including the ~58-minute cold sync, which
+yields between batches and stays serveable (and is precisely when `/health` and
+`/queue-stats` matter most). A refused connection is a better answer than a
+hung one: the client finds out immediately and can retry or fail over.
+
+`httpServerReadinessTimeoutMs` (default `300000`, 5 min) bounds that wait; on
+expiry the server starts anyway and says so. It is a backstop against a broken
+adapter, not a startup knob — while the loop is inside a synchronous restore
+this timer cannot fire either, so it effectively expires the moment the block
+ends. Adapters that do not implement `whenServable()` are unaffected.
 
 `getHealthInfo()` (served by `/queue-stats`) reports a `dustSync` entry per
 wallet so a slow start is distinguishable from a broken one — `state` is

--- a/packages/batcher/adapters/adapter.ts
+++ b/packages/batcher/adapters/adapter.ts
@@ -300,6 +300,31 @@ export interface BlockchainAdapter<TOutput> {
   getHealthInfo?(): Record<string, unknown>;
 
   /**
+   * (Optional) Resolves once this adapter is past any startup work that blocks
+   * the main event loop, so it is safe to accept HTTP traffic.
+   *
+   * The batcher holds the HTTP port closed until every adapter that implements
+   * this says so. Adapters that do not implement it are treated as immediately
+   * servable, which is the previous behaviour.
+   *
+   * Why this exists: the Midnight balancing adapter restores its dust wallet by
+   * deserializing the snapshot in WASM **synchronously on the main thread** —
+   * measured at ~46 s for a 5.1 MB preprod snapshot. The server used to be
+   * listening throughout, so every restart was a ~46-second window in which
+   * connections were accepted and no handler could run, because no handler can
+   * run while the loop is blocked. A refused connection is strictly better than
+   * one that hangs: the client learns immediately and can retry or fail over.
+   *
+   * Contract: resolve when the blocking phase is over, **however it ended** —
+   * including on failure. This gate must never be the reason a batcher has no
+   * endpoints; a rejection or a throw is logged and treated as servable, and a
+   * promise that never settles is bounded by `httpServerReadinessTimeoutMs`.
+   * It says nothing about whether the adapter can submit transactions yet —
+   * that is `isReady()`.
+   */
+  whenServable?(): Promise<void>;
+
+  /**
    * (Optional) Recover adapter state after batcher initialization.
    * This is called after storage.init() but before processing starts,
    * allowing adapters to rebuild internal state from persisted inputs.

--- a/packages/batcher/adapters/midnight-balancing-adapter.ts
+++ b/packages/batcher/adapters/midnight-balancing-adapter.ts
@@ -49,11 +49,13 @@ import type {
   ShieldedTokenTransfer,
 } from "@midnightntwrk/wallet-sdk-facade";
 import {
+  type DustStateAutosaveHandle,
   getInitialDustState,
   getInitialShieldedState,
   type NetworkUrls,
   registerNightForDust,
   resolveFacadeDustBalance,
+  startDustStateAutosave,
   suspendAuxWalletSyncForFees,
   waitForDustFunds,
   waitForDustFundsWithRetry,
@@ -128,6 +130,20 @@ export interface MidnightBalancingAdapterConfig {
   // overhead (coins exist with ~0 generated value right after creation — a
   // bare `availableCoins.length > 0` check passes while balancing is doomed).
   minSpendableDustPerCoin?: bigint;
+  /**
+   * Directory for dust state snapshots, relative to CWD. Defaults to
+   * `dust-state`. One file per (network, seed); restoring one is what turns a
+   * multi-hour restart back into seconds.
+   */
+  dustStateDir?: string;
+  /**
+   * How often each wallet checkpoints its dust state while running. Defaults to
+   * `MIDNIGHT_DUST_STATE_SAVE_INTERVAL_MS` (5 minutes); 0 keeps only the
+   * shutdown checkpoint. Bounds how much chain a crash makes the batcher
+   * replay — before this, state was written during init and never again, so a
+   * week of uptime meant a week of replay.
+   */
+  dustStateSaveIntervalMs?: number;
   // Reject inputs whose serialized payload exceeds this many characters at
   // intake (pre-queue). Defaults to 500k chars (~250 KB of tx bytes) — well
   // above any legitimate balanced+padded tx, well below abuse territory.
@@ -1028,6 +1044,11 @@ export class MidnightBalancingAdapter
    * wallet belongs to the caller: this adapter must not stop it on close.
    */
   private walletIsInjected: boolean[];
+  /**
+   * Periodic dust-state checkpointing, one per wallet. Also covers the injected
+   * wallet, which had no persistence of any kind.
+   */
+  private dustStateAutosaves: (DustStateAutosaveHandle | null)[];
   private availableDustUtxoCounts: (number | null)[];
   /** Tracks wallets that recently failed due to missing dust. Cleared when dust is confirmed available. */
   private walletDustExhausted: boolean[];
@@ -1084,6 +1105,7 @@ export class MidnightBalancingAdapter
     this.walletResults = new Array(seeds.length).fill(null);
     this.walletAddresses = new Array(seeds.length).fill(null);
     this.walletIsInjected = new Array(seeds.length).fill(false);
+    this.dustStateAutosaves = new Array(seeds.length).fill(null);
     this.walletInitialized = new Array(seeds.length).fill(false);
     this.availableDustUtxoCounts = new Array(seeds.length).fill(null);
     this.walletDustExhausted = new Array(seeds.length).fill(false);
@@ -1164,6 +1186,7 @@ export class MidnightBalancingAdapter
           networkId: this.walletNetworkId,
           syncMode: 'dust-only',
           balanceWaitTimeoutMs: this.walletFundingTimeoutMs,
+          dustStateDir: this.config.dustStateDir,
         });
 
         this.walletResults[index] = walletResult;
@@ -1184,6 +1207,8 @@ export class MidnightBalancingAdapter
         await this.updateWorkerPoolForWallet(index);
       }
 
+      this.startDustStateCheckpointing(index, seed);
+
       const wr = this.walletResults[index]!;
       this.walletAddresses[index] = wr.zswapSecretKeys.coinPublicKey.toString();
       this.log.log(`Wallet ${label} addresses:`);
@@ -1196,6 +1221,37 @@ export class MidnightBalancingAdapter
     } catch (error) {
       this.log.error(`Wallet ${label}: initialization failed:`, error);
     }
+  }
+
+  /**
+   * Keep this wallet's dust snapshot advancing for as long as it runs.
+   *
+   * Without it the snapshot was written only during init, so an adapter that
+   * had been up for a week restored a week-old snapshot and replayed a week of
+   * chain. Covers the injected wallet too, which had no persistence at all —
+   * safe because the snapshot records its own dust public key and
+   * `saveDustState` refuses to write it under a seed it does not belong to, so
+   * a caller that pairs a wallet with the wrong seed gets a loud warning
+   * instead of another wallet's state on disk.
+   */
+  private startDustStateCheckpointing(index: number, seed: string): void {
+    // Persistence no-ops on `undeployed` by design (chain resets invalidate
+    // cached state), so serializing every few minutes there is pure waste.
+    if (String(this.walletNetworkId).toLowerCase() === "undeployed") return;
+    const dustWallet = (this.walletResults[index]?.wallet as {
+      dust?: { serializeState?: () => Promise<string> };
+    } | undefined)?.dust;
+    if (typeof dustWallet?.serializeState !== "function") return;
+    this.dustStateAutosaves[index] = startDustStateAutosave(
+      dustWallet as { serializeState: () => Promise<string> },
+      {
+        networkId: String(this.walletNetworkId),
+        seed,
+        dustStateDir: this.config.dustStateDir,
+        intervalMs: this.config.dustStateSaveIntervalMs,
+        label: `Wallet ${index + 1}/${this.walletSeeds.length}`,
+      },
+    );
   }
 
   private async ensureWalletFunds(walletIndex: number): Promise<void> {
@@ -2370,6 +2426,24 @@ export class MidnightBalancingAdapter
     // Before anything that can throw: a leaked interval keeps the process
     // alive after shutdown.
     this.ledgerParams.close();
+
+    // Checkpoint dust state BEFORE anything stops the wallets — a stopped
+    // wallet cannot serialize, which is why shutdown used to lose everything
+    // since the last init-time save. Each handle takes one final snapshot.
+    await Promise.all(
+      this.dustStateAutosaves.map(async (handle, index) => {
+        try {
+          await handle?.stop();
+        } catch (error) {
+          this.log.warn(
+            `Wallet ${index + 1}/${this.walletSeeds.length}: final dust checkpoint failed: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+          );
+        }
+      }),
+    );
+    this.dustStateAutosaves = new Array(this.walletSeeds.length).fill(null);
     const executorHandle = this.validationExecutorHandle;
     this.validationExecutorHandle = null;
     if (executorHandle) {

--- a/packages/batcher/adapters/midnight-balancing-adapter.ts
+++ b/packages/batcher/adapters/midnight-balancing-adapter.ts
@@ -1058,6 +1058,59 @@ export async function waitForDustThenEnforceTtl(args: {
 // ---------------------------------------------------------------------------
 
 /**
+ * A latch that opens once every wallet has finished the startup work that
+ * blocks the event loop. Backs `whenServable()`; see
+ * `BlockchainAdapter.whenServable` for why the HTTP port waits on it.
+ *
+ * Extracted from the adapter so the semantics — all-of, idempotent, openable
+ * in bulk — can be tested without building wallets against a network.
+ */
+export interface ServableGate {
+  /** Resolves when the last wallet is marked. Never rejects. */
+  readonly promise: Promise<void>;
+  /** Mark one wallet past its blocking startup. Safe to call repeatedly. */
+  mark(index: number): void;
+  /** Open the gate regardless — the failure backstop. */
+  markAll(): void;
+  /** How many wallets are still unaccounted for. Diagnostics and tests. */
+  pending(): number;
+}
+
+export function createServableGate(count: number): ServableGate {
+  const marked = new Array<boolean>(Math.max(0, count)).fill(false);
+  let release!: () => void;
+  const promise = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  // A gate nobody will ever mark must start open, not closed: an adapter with
+  // no wallets blocks nothing.
+  if (marked.length === 0) release();
+
+  const openIfComplete = (): void => {
+    if (marked.every(Boolean)) release();
+  };
+  return {
+    promise,
+    mark(index: number): void {
+      // Out of range is ignored rather than thrown: this is called from
+      // `finally` blocks, and a gate must never be the thing that turns a
+      // failed wallet into a failed process.
+      if (!Number.isInteger(index) || index < 0 || index >= marked.length) return;
+      if (marked[index]) return;
+      marked[index] = true;
+      openIfComplete();
+    },
+    markAll(): void {
+      marked.fill(true);
+      release();
+    },
+    pending(): number {
+      return marked.filter((m) => !m).length;
+    },
+  };
+}
+
+/**
  * Midnight Balancing Adapter (Party B)
  *
  * Receives serialized delegated transactions (hex), balances them with local
@@ -1133,6 +1186,16 @@ export class MidnightBalancingAdapter
 
   private isInitialized = false;
   private initializationPromise: Promise<void> | null = null;
+  /**
+   * Per wallet: has it finished the startup work that blocks the event loop?
+   *
+   * That work is `DustWallet.restore` — one synchronous WASM deserialize of the
+   * whole snapshot, measured at ~46 s for preprod's 5.1 MB (sweep brief §2). The
+   * dust *sync* that follows is not in this set: it yields between batches, with
+   * a worst measured stall of 906 ms, so a server can serve through it. Only the
+   * restore is a true black hole.
+   */
+  private readonly servableGate: ServableGate;
   private publicDataProvider: PublicDataProvider | null = null;
   private batchCounter = 0;
 
@@ -1183,7 +1246,35 @@ export class MidnightBalancingAdapter
     // Start with 0 slots per wallet; updated in ensureWalletFunds once UTXO counts are known.
     this.pool = new WorkerPool(new Array(seeds.length).fill(0));
 
+    this.servableGate = createServableGate(seeds.length);
+
     this.initializationPromise = this.initialize();
+  }
+
+  /**
+   * Resolves when no wallet is still inside a blocking restore, so the batcher
+   * can bind its HTTP port (see `BlockchainAdapter.whenServable`).
+   *
+   * Never rejects, and never waits for sync to *finish*: a cold sync runs for
+   * ~58 minutes on preprod and an operator needs `/health` for every one of
+   * them — that visibility is exactly what Phase 2's `3fd156dd` added.
+   */
+  whenServable(): Promise<void> {
+    return this.servableGate.promise;
+  }
+
+  /**
+   * Mark one wallet as past its blocking startup, idempotently.
+   *
+   * Called from three places on purpose, because "the restore is over" has three
+   * endings: the wallet emitted its first sync sample (the normal one — the
+   * progress subscription is attached *after* `buildWalletFacade` returns, so a
+   * sample proves the deserialize is done), the wallet was handed in already
+   * built, or `initializeWallet` returned by any path including failure. A gate
+   * that only closed on success would hold the port shut on a broken wallet.
+   */
+  private markWalletServable(index: number): void {
+    this.servableGate.mark(index);
   }
 
   // -----------------------------------------------------------------------
@@ -1219,6 +1310,11 @@ export class MidnightBalancingAdapter
     } catch (error) {
       this.log.error("Initialization failed:", error);
       throw error;
+    } finally {
+      // Last backstop: something before the per-wallet loop threw (a bad
+      // network id, an indexer provider that would not construct), so no
+      // wallet ever ran its own `finally`. The port must still open.
+      this.servableGate.markAll();
     }
   }
 
@@ -1229,6 +1325,9 @@ export class MidnightBalancingAdapter
         this.log.log(`Wallet ${label}: using shared wallet...`);
         this.walletResults[index] = await this.config.walletResult;
         this.walletIsInjected[index] = true;
+        // An injected wallet was built — and restored — by whoever handed it
+        // in, so this adapter never blocks the loop for it.
+        this.markWalletServable(index);
         // The seed registry never saw this wallet — it was handed in, not
         // derived. Claim it by identity or two adapters with different nominal
         // seeds end up on the same coins.
@@ -1309,6 +1408,11 @@ export class MidnightBalancingAdapter
       this.log.log(`Wallet ${label}: ready`);
     } catch (error) {
       this.log.error(`Wallet ${label}: initialization failed:`, error);
+    } finally {
+      // Backstop for every path that never produced a sync sample: a wallet
+      // whose dust state was unavailable, or one that threw. Whatever happened,
+      // nothing of ours is blocking the loop for this wallet any more.
+      this.markWalletServable(index);
     }
   }
 
@@ -1328,6 +1432,10 @@ export class MidnightBalancingAdapter
       snapshotRejected?: boolean;
     },
   ): void {
+    // The progress subscription is attached after `buildWalletFacade` returns,
+    // so the first sample is proof that the synchronous restore is behind us.
+    this.markWalletServable(index);
+
     const previous = this.walletSyncHealth[index];
     const now = Date.now();
     const advanced = !previous || sample.appliedIndex > previous.appliedIndex;

--- a/packages/batcher/adapters/midnight-balancing-adapter.ts
+++ b/packages/batcher/adapters/midnight-balancing-adapter.ts
@@ -57,9 +57,11 @@ import {
   registerNightForDust,
   resolveDustCoinValuesAt,
   resolveFacadeDustBalance,
+  resolveWalletSyncTimeoutMs,
   startDustStateAutosave,
   suspendAuxWalletSyncForFees,
   waitForDustFunds,
+  waitForShieldedSyncComplete,
   waitForDustFundsWithRetry,
   type WalletResult,
 } from "@effectstream/midnight-contracts";
@@ -1235,6 +1237,21 @@ export class MidnightBalancingAdapter
         this.log.log(`Wallet ${label}: waiting for funds...`);
         await this.ensureWalletFunds(index);
 
+        // Same rule as the built path: never suspend a shielded wallet that
+        // padding still needs, while it is mid-replay.
+        if (this.shieldedPaddingPossible()) {
+          this.log.log(`Wallet ${label}: waiting for shielded sync (padding enabled)...`);
+          const complete = await waitForShieldedSyncComplete(
+            this.walletResults[index]!.wallet,
+            resolveWalletSyncTimeoutMs(),
+          );
+          if (!complete) {
+            this.log.error(
+              `Wallet ${label}: shielded wallet is still behind and is being suspended ` +
+                `anyway — shielded padding will fail for this wallet`,
+            );
+          }
+        }
         await suspendAuxWalletSyncForFees(this.walletResults[index]!.wallet);
       } else {
         this.log.log(`Wallet ${label}: building with retry-aware dust sync...`);
@@ -1256,6 +1273,9 @@ export class MidnightBalancingAdapter
           balanceWaitTimeoutMs: this.walletFundingTimeoutMs,
           dustStateDir: this.config.dustStateDir,
           onSyncProgress: (sample) => this.recordDustSyncProgress(index, sample),
+          // Padding is a real shielded spend, so it needs shielded state that
+          // was not cut off mid-replay.
+          requireShieldedSync: this.shieldedPaddingPossible(),
         });
 
         this.walletResults[index] = walletResult;
@@ -1427,9 +1447,7 @@ export class MidnightBalancingAdapter
       // enable padding even if the config default is off, so budget for the
       // worst case (2 UTXOs/slot) to avoid over-committing.
       const utxoCount = this.availableDustUtxoCounts[walletIndex] ?? 0;
-      const paddingPossible = !!(this.config.addShieldedPadding ||
-        this.config.shieldedPaddingTokenID);
-      const costPerTx = paddingPossible ? 2 : 1;
+      const costPerTx = this.shieldedPaddingPossible() ? 2 : 1;
       const maxPerWallet = this.config.maxSlotsPerWallet ?? 1;
       const slots = Math.min(Math.floor(utxoCount / costPerTx), maxPerWallet);
       this.pool.setSlots(walletIndex, slots);
@@ -1475,9 +1493,7 @@ export class MidnightBalancingAdapter
       );
 
       const utxoCount = this.availableDustUtxoCounts[walletIndex] ?? 0;
-      const paddingPossible = !!(this.config.addShieldedPadding ||
-        this.config.shieldedPaddingTokenID);
-      const costPerTx = paddingPossible ? 2 : 1;
+      const costPerTx = this.shieldedPaddingPossible() ? 2 : 1;
       const maxPerWallet = this.config.maxSlotsPerWallet ?? 1;
       const slots = Math.min(Math.floor(utxoCount / costPerTx), maxPerWallet);
       this.pool.setSlots(walletIndex, slots);
@@ -1487,6 +1503,19 @@ export class MidnightBalancingAdapter
     } catch (e) {
       this.log.warn(`Wallet ${label}: could not read dust UTXO count:`, e);
     }
+  }
+
+  /**
+   * Can any transaction on this target get shielded padding?
+   *
+   * The token ID alone is enough: per-input `addShieldedPadding` overrides can
+   * turn padding on for a single transaction even when the adapter default is
+   * off. Whatever answers this question decides both worker-slot cost and
+   * whether the shielded wallet must finish syncing before being suspended, and
+   * those two must never disagree.
+   */
+  private shieldedPaddingPossible(): boolean {
+    return !!(this.config.addShieldedPadding || this.config.shieldedPaddingTokenID);
   }
 
   private async getDustBalance(walletIndex: number): Promise<bigint> {

--- a/packages/batcher/adapters/midnight-balancing-adapter.ts
+++ b/packages/batcher/adapters/midnight-balancing-adapter.ts
@@ -50,6 +50,7 @@ import type {
 } from "@midnightntwrk/wallet-sdk-facade";
 import {
   type DustStateAutosaveHandle,
+  dustProgressFromState,
   getInitialDustState,
   getInitialShieldedState,
   type NetworkUrls,
@@ -100,6 +101,45 @@ import {
 // ---------------------------------------------------------------------------
 // Config & types
 // ---------------------------------------------------------------------------
+
+/** A wallet's dust sync as last observed. Cached; never re-read on demand. */
+export interface DustSyncSample {
+  appliedIndex: bigint;
+  /** Highest index the indexer told us about; 0 when it has told us nothing. */
+  target: bigint;
+  isConnected: boolean;
+  /** When this sample was taken. */
+  updatedAtMs: number;
+  /** When `appliedIndex` last increased. */
+  advancedAtMs: number;
+}
+
+export type DustSyncState = "syncing" | "stalled" | "complete" | "unknown";
+
+/**
+ * Is this wallet syncing, stuck, or done?
+ *
+ * A dust cold sync takes ~66 minutes on preprod, during which health info said
+ * only `walletsReady: 0` — indistinguishable from a wallet whose snapshot
+ * offset is past the indexer's event log and which will never start at all.
+ * Both look like a hang; one wants patience and the other wants the snapshot
+ * deleted.
+ *
+ * Order matters. Completeness is checked first because a caught-up wallet stops
+ * emitting: ageing it into "stalled" would page someone for a healthy batcher.
+ * `isConnected` is part of that check — the offset-past-log failure sits at a
+ * high `appliedIndex` with a target of 0, which would otherwise satisfy
+ * `applied >= target`.
+ */
+export function classifyDustSyncState(
+  sample: DustSyncSample | null | undefined,
+  nowMs: number,
+  stalledAfterMs: number,
+): DustSyncState {
+  if (!sample) return "unknown";
+  if (sample.isConnected && sample.appliedIndex >= sample.target) return "complete";
+  return nowMs - sample.advancedAtMs > stalledAfterMs ? "stalled" : "syncing";
+}
 
 export interface MidnightBalancingAdapterConfig {
   indexer: string;
@@ -206,6 +246,20 @@ const DEFAULT_MIN_SPENDABLE_DUST = (DUST_FEE_OVERHEAD_SPECKS * 3n) / 2n;
 const DEFAULT_MAX_INPUT_CHARS = 500_000;
 /** Throttle for background dust-state refreshes triggered by capacity checks. */
 const DUST_REFRESH_THROTTLE_MS = 5_000;
+/**
+ * How long a wallet may go without applying a dust event before health info
+ * calls it stalled rather than syncing. Matches the wallet's own stall timeout,
+ * so the two agree about what "stuck" means.
+ */
+const DUST_SYNC_STALLED_AFTER_MS = 60_000;
+
+/** Cached dust sync position for one wallet, plus where its restore resumed from. */
+interface WalletDustSyncHealth extends DustSyncSample {
+  /** Snapshot offset this wallet resumed from; 0 for a full cold sync. */
+  restoredFromOffset: bigint;
+  /** True when a snapshot was rejected and this wallet cold-synced instead. */
+  snapshotRejected: boolean;
+}
 const createTtl = (): Date => new Date(Date.now() + TTL_DURATION_MS);
 
 /** A deterministic pre-spend verdict: remove the row and charge no retry. */
@@ -1050,6 +1104,12 @@ export class MidnightBalancingAdapter
    * wallet, which had no persistence of any kind.
    */
   private dustStateAutosaves: (DustStateAutosaveHandle | null)[];
+  /**
+   * Last observed dust sync position per wallet, plus where it resumed from.
+   * Sampled during init (where a cold sync can run for an hour with nothing
+   * else to show for it) and refreshed whenever dust state is read afterwards.
+   */
+  private walletSyncHealth: (WalletDustSyncHealth | null)[];
   private availableDustUtxoCounts: (number | null)[];
   /** Tracks wallets that recently failed due to missing dust. Cleared when dust is confirmed available. */
   private walletDustExhausted: boolean[];
@@ -1113,6 +1173,7 @@ export class MidnightBalancingAdapter
     this.walletAddresses = new Array(seeds.length).fill(null);
     this.walletIsInjected = new Array(seeds.length).fill(false);
     this.dustStateAutosaves = new Array(seeds.length).fill(null);
+    this.walletSyncHealth = new Array(seeds.length).fill(null);
     this.walletInitialized = new Array(seeds.length).fill(false);
     this.availableDustUtxoCounts = new Array(seeds.length).fill(null);
     this.walletDustExhausted = new Array(seeds.length).fill(false);
@@ -1194,6 +1255,7 @@ export class MidnightBalancingAdapter
           syncMode: 'dust-only',
           balanceWaitTimeoutMs: this.walletFundingTimeoutMs,
           dustStateDir: this.config.dustStateDir,
+          onSyncProgress: (sample) => this.recordDustSyncProgress(index, sample),
         });
 
         this.walletResults[index] = walletResult;
@@ -1228,6 +1290,38 @@ export class MidnightBalancingAdapter
     } catch (error) {
       this.log.error(`Wallet ${label}: initialization failed:`, error);
     }
+  }
+
+  /**
+   * Fold one sync observation into this wallet's cached health. Called with
+   * every throttled sample during init and again whenever dust state is read
+   * afterwards, so `getHealthInfo()` can answer "syncing or stuck?" without
+   * touching the chain.
+   */
+  private recordDustSyncProgress(
+    index: number,
+    sample: {
+      appliedIndex: bigint;
+      highestRelevantWalletIndex: bigint;
+      isConnected: boolean;
+      restoredFromOffset?: bigint;
+      snapshotRejected?: boolean;
+    },
+  ): void {
+    const previous = this.walletSyncHealth[index];
+    const now = Date.now();
+    const advanced = !previous || sample.appliedIndex > previous.appliedIndex;
+    this.walletSyncHealth[index] = {
+      appliedIndex: sample.appliedIndex,
+      target: sample.highestRelevantWalletIndex,
+      isConnected: sample.isConnected,
+      updatedAtMs: now,
+      advancedAtMs: advanced ? now : previous.advancedAtMs,
+      // Later samples (from a dust-state read) carry no restore context; keep
+      // what init established rather than reporting every wallet as cold.
+      restoredFromOffset: sample.restoredFromOffset ?? previous?.restoredFromOffset ?? 0n,
+      snapshotRejected: sample.snapshotRejected ?? previous?.snapshotRejected ?? false,
+    };
   }
 
   /**
@@ -1529,6 +1623,8 @@ export class MidnightBalancingAdapter
     // that actually has spendable dust.
     const { values, liveClock } = resolveDustCoinValuesAt(dustState, new Date());
     this.dustValuesUseLiveClock = liveClock;
+    const progress = dustProgressFromState(dustState);
+    if (progress) this.recordDustSyncProgress(walletIndex, progress);
     return {
       total: values.length,
       spendable: values.filter((v) => v >= minValue).length,
@@ -2391,9 +2487,41 @@ export class MidnightBalancingAdapter
    * Uses cached state only — no chain/indexer calls, safe to poll.
    */
   getHealthInfo(): Record<string, unknown> {
+    const now = Date.now();
     return {
       wallets: this.walletSeeds.length,
       walletsReady: this.walletInitialized.filter(Boolean).length,
+      // Without this a slow start and a permanently broken one look the same:
+      // a preprod dust cold sync runs for ~66 minutes, and a snapshot whose
+      // offset is past the indexer's log never finishes at all.
+      dustSync: this.walletSeeds.map((_seed, i) => {
+        const h = this.walletSyncHealth[i];
+        return {
+          wallet: i + 1,
+          state: classifyDustSyncState(h, now, DUST_SYNC_STALLED_AFTER_MS),
+          // Where the restore resumed from — 0 means this wallet replayed the
+          // whole chain, which is the number that explains a slow start.
+          restoredFrom: h ? h.restoredFromOffset.toString() : null,
+          appliedIndex: h ? h.appliedIndex.toString() : null,
+          target: h && h.target > 0n ? h.target.toString() : null,
+          behind: h && h.target > h.appliedIndex
+            ? (h.target - h.appliedIndex).toString()
+            : "0",
+          connected: h?.isConnected ?? false,
+          lastAdvanceAgeMs: h ? now - h.advancedAtMs : null,
+          snapshot: !h
+            ? "unknown"
+            : h.snapshotRejected
+            ? "rejected"
+            : h.restoredFromOffset > 0n
+            ? "restored"
+            : "cold",
+        };
+      }),
+      // "live" means dust generation was projected at wall clock. "sync-time"
+      // means it fell back to the wallet's last applied event, which on a quiet
+      // chain can be far in the past and reads as false starvation.
+      dustClock: this.dustValuesUseLiveClock ? "live" : "sync-time",
       dustUtxos: this.availableDustUtxoCounts.map((c) => c ?? 0),
       dustExhausted: this.walletInitialized.every(
         (ok, i) => !ok || this.walletDustExhausted[i],

--- a/packages/batcher/adapters/midnight-balancing-adapter.ts
+++ b/packages/batcher/adapters/midnight-balancing-adapter.ts
@@ -54,6 +54,7 @@ import {
   getInitialShieldedState,
   type NetworkUrls,
   registerNightForDust,
+  resolveDustCoinValuesAt,
   resolveFacadeDustBalance,
   startDustStateAutosave,
   suspendAuxWalletSyncForFees,
@@ -1052,6 +1053,12 @@ export class MidnightBalancingAdapter
   private availableDustUtxoCounts: (number | null)[];
   /** Tracks wallets that recently failed due to missing dust. Cleared when dust is confirmed available. */
   private walletDustExhausted: boolean[];
+  /**
+   * Whether the last dust reading was projected at wall clock or fell back to
+   * the wallet's own (possibly stale) sync time. Surfaced in health info: a gate
+   * reading dust at a syncTime that is hours behind looks like starvation.
+   */
+  private dustValuesUseLiveClock = true;
   /** Timestamp of the last background dust-state refresh (throttling). */
   private lastDustRefreshAt = 0;
   /** True while a background dust refresh is in flight. */
@@ -1515,11 +1522,15 @@ export class MidnightBalancingAdapter
       wr.wallet.dust as { state: Rx.Observable<unknown> },
       { timeoutMs: 30_000 },
     );
-    const coins = (dustState as { availableCoins?: Array<{ generatedNow?: bigint | string }> })
-      .availableCoins ?? [];
-    const values = coins.map((c) => BigInt(c.generatedNow ?? 0));
+    // Project generation at wall clock. `availableCoins` evaluates at the
+    // wallet's syncTime, which only advances when a dust EVENT is applied —
+    // measured 377 days behind on a quiet chain — so reading it directly
+    // under-reports generated dust and can starve the coin picker on a wallet
+    // that actually has spendable dust.
+    const { values, liveClock } = resolveDustCoinValuesAt(dustState, new Date());
+    this.dustValuesUseLiveClock = liveClock;
     return {
-      total: coins.length,
+      total: values.length,
       spendable: values.filter((v) => v >= minValue).length,
       values,
     };

--- a/packages/batcher/core/batcher.ts
+++ b/packages/batcher/core/batcher.ts
@@ -489,12 +489,9 @@ export class Batcher<T extends DefaultBatcherInput = DefaultBatcherInput> {
       );
     }
 
-    // Start HTTP server if enabled — but not before every adapter is past the
-    // startup work that can freeze the event loop. Binding the port first turns
-    // a Midnight restart into a ~46-second window where connections are
-    // accepted and nothing answers (see `BlockchainAdapter.whenServable`).
+    // Start HTTP server if enabled. `startHttpServer()` itself waits for every
+    // adapter to be past its loop-blocking startup — see there for why.
     if (this.enableHttpServer) {
-      await this.waitForAdaptersServable();
       await this.startHttpServer();
     }
 
@@ -1110,12 +1107,20 @@ export class Batcher<T extends DefaultBatcherInput = DefaultBatcherInput> {
   /**
    * Start the HTTP server for the batcher
    * This provides REST API endpoints for interacting with the batcher
+   *
+   * Binding is held until every adapter is past its loop-blocking startup —
+   * the wait lives HERE rather than in `init()` because there are three ways
+   * to reach this method (`init()`, the Effection `runBatcher` path via
+   * `runHttpServer()`, and a direct call), and a gate on only one of them
+   * leaves the black hole open on the others.
    */
   async startHttpServer(): Promise<void> {
     if (this.httpServer) {
       console.log("⚠️ HTTP server already running");
       return;
     }
+
+    await this.waitForAdaptersServable();
 
     try {
       this.httpServer = await startBatcherHttpServer(this, this.port);

--- a/packages/batcher/core/batcher.ts
+++ b/packages/batcher/core/batcher.ts
@@ -11,6 +11,7 @@ import type { BatchingCriteriaConfig, BatcherConfig } from "./config.ts";
 import {
   applyBatcherConfigDefaults,
   DEFAULT_BATCHING_CRITERIA,
+  DEFAULT_CONFIG_VALUES,
   validateBatcherConfig,
   validateBatchingCriteria,
   validatePreInit,
@@ -113,6 +114,8 @@ export class Batcher<T extends DefaultBatcherInput = DefaultBatcherInput> {
   private readonly port: number;
   /** Whether to enable HTTP server */
   private readonly enableHttpServer: boolean;
+  /** How long `init()` waits for adapters to become servable before binding. */
+  private readonly httpServerReadinessTimeoutMs: number;
   /** Whether to enable event system */
   private readonly enableEventSystem: boolean;
   /** Shutdown state tracking */
@@ -260,6 +263,9 @@ export class Batcher<T extends DefaultBatcherInput = DefaultBatcherInput> {
     );
     this.port = this.config.port!;
     this.enableHttpServer = this.config.enableHttpServer!;
+    this.httpServerReadinessTimeoutMs =
+      this.config.httpServerReadinessTimeoutMs ??
+        DEFAULT_CONFIG_VALUES.httpServerReadinessTimeoutMs;
     this.enableEventSystem = this.config.enableEventSystem!;
     this.namespace = this.config.namespace ?? this.namespace;
   }
@@ -483,8 +489,12 @@ export class Batcher<T extends DefaultBatcherInput = DefaultBatcherInput> {
       );
     }
 
-    // Start HTTP server if enabled
+    // Start HTTP server if enabled — but not before every adapter is past the
+    // startup work that can freeze the event loop. Binding the port first turns
+    // a Midnight restart into a ~46-second window where connections are
+    // accepted and nothing answers (see `BlockchainAdapter.whenServable`).
     if (this.enableHttpServer) {
+      await this.waitForAdaptersServable();
       await this.startHttpServer();
     }
 
@@ -1039,6 +1049,62 @@ export class Batcher<T extends DefaultBatcherInput = DefaultBatcherInput> {
       await this.storage.removeProcessedInputs(scoped, target);
     }
     return scoped.length;
+  }
+
+  /**
+   * Hold the HTTP port closed until every adapter that implements
+   * `whenServable()` reports it is past its loop-blocking startup work.
+   *
+   * A refused connection is a better answer than a hung one: the client finds
+   * out immediately instead of holding a socket open against a process that
+   * cannot run a handler at all. Bounded by `httpServerReadinessTimeoutMs` and
+   * never fatal — a gate that could stop the server from ever starting would be
+   * a worse failure than the one it prevents.
+   */
+  private async waitForAdaptersServable(): Promise<void> {
+    const gates: Promise<void>[] = [];
+    for (const [target, adapter] of Object.entries(this.adapters)) {
+      if (typeof adapter.whenServable !== "function") continue;
+      try {
+        gates.push(
+          Promise.resolve(adapter.whenServable()).catch((error) => {
+            console.warn(
+              `⚠️ Adapter '${target}' failed to report readiness; ` +
+                `treating it as ready to serve:`,
+              error,
+            );
+          }),
+        );
+      } catch (error) {
+        console.warn(
+          `⚠️ Adapter '${target}' threw from whenServable(); ` +
+            `treating it as ready to serve:`,
+          error,
+        );
+      }
+    }
+    if (gates.length === 0) return;
+
+    const timeoutMs = this.httpServerReadinessTimeoutMs;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      const outcome = await Promise.race([
+        Promise.all(gates).then(() => "ready" as const),
+        new Promise<"timeout">((resolve) => {
+          timer = setTimeout(() => resolve("timeout"), timeoutMs);
+          (timer as unknown as { unref?: () => void }).unref?.();
+        }),
+      ]);
+      if (outcome === "timeout") {
+        console.warn(
+          `⚠️ Adapters did not report readiness within ${timeoutMs}ms; ` +
+            `starting the HTTP server anyway. Requests may stall if an adapter ` +
+            `is still blocking the event loop.`,
+        );
+      }
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
   }
 
   /**

--- a/packages/batcher/core/config.ts
+++ b/packages/batcher/core/config.ts
@@ -178,6 +178,20 @@ export interface BatcherConfig<
   enableHttpServer?: boolean;
   enableEventSystem?: boolean;
 
+  /**
+   * How long `init()` will hold the HTTP port closed waiting for adapters that
+   * implement `whenServable()` (see {@link BlockchainAdapter.whenServable}).
+   * On expiry the server starts anyway, loudly — a listening batcher is more
+   * useful to an operator than one with no endpoints at all.
+   *
+   * This is a backstop against a broken adapter, not a tuning knob for slow
+   * startup. It barely constrains the case it was written for: while the event
+   * loop is inside a synchronous restore, this timer cannot fire either, so it
+   * effectively expires when the block ends — the same moment `whenServable()`
+   * resolves. It bites only on an adapter that stays unready *while yielding*.
+   */
+  httpServerReadinessTimeoutMs?: number;
+
   // Batching behavior
   batchingCriteria?: PerAdapterBatchingCriteria<TInput, TAdapters>;
 
@@ -235,6 +249,9 @@ export const DEFAULT_CONFIG_VALUES = {
   port: 3000,
   enableHttpServer: true,
   enableEventSystem: false,
+  // 5 minutes: ~6.5× the measured 46 s preprod dust restore, and only ever
+  // reached by an adapter that is unready while yielding — see the field docs.
+  httpServerReadinessTimeoutMs: 300000,
   maxRetries: 3,
   retryDelayMs: 1000,
   rateLimit: {
@@ -308,6 +325,12 @@ export const BatcherConfigSchema = Type.Object({
   ),
   enableEventSystem: Type.Optional(
     Type.Boolean({ default: DEFAULT_CONFIG_VALUES.enableEventSystem }),
+  ),
+  httpServerReadinessTimeoutMs: Type.Optional(
+    Type.Number({
+      minimum: 0,
+      default: DEFAULT_CONFIG_VALUES.httpServerReadinessTimeoutMs,
+    }),
   ),
 
   rateLimit: Type.Optional(RateLimitConfigSchema),

--- a/packages/batcher/test/dust-sync-health.test.ts
+++ b/packages/batcher/test/dust-sync-health.test.ts
@@ -1,0 +1,107 @@
+// An operator has to be able to tell a syncing batcher from a stuck one.
+//
+// A Midnight fee wallet's dust cold sync takes ~66 minutes on preprod. For that
+// whole window `getHealthInfo()` reported `walletsReady: 0` and nothing else —
+// identical to a batcher whose snapshot offset sits past the indexer's event
+// log and which will never start at all (Phase 1 §2). Both look like a hang;
+// one wants patience, the other wants the snapshot deleted.
+//
+// The classifier is pure so health info stays what it claims to be: cached
+// state only, no chain calls, safe to poll.
+
+import { describe, expect, test } from "bun:test";
+import {
+  classifyDustSyncState,
+  type DustSyncSample,
+} from "../adapters/midnight-balancing-adapter.ts";
+
+const NOW = 1_700_000_000_000;
+const STALLED_AFTER_MS = 60_000;
+
+const sample = (over: Partial<DustSyncSample> = {}): DustSyncSample => ({
+  appliedIndex: 500_000n,
+  target: 1_438_641n,
+  isConnected: true,
+  updatedAtMs: NOW - 1_000,
+  advancedAtMs: NOW - 1_000,
+  ...over,
+});
+
+describe("dust sync state classification", () => {
+  test("advancing through a long replay is syncing, not stuck", () => {
+    expect(classifyDustSyncState(sample(), NOW, STALLED_AFTER_MS)).toEqual("syncing");
+  });
+
+  test("caught up and connected is complete", () => {
+    expect(
+      classifyDustSyncState(
+        sample({ appliedIndex: 1_438_641n, target: 1_438_641n }),
+        NOW,
+        STALLED_AFTER_MS,
+      ),
+    ).toEqual("complete");
+  });
+
+  test("a wallet at the tip stays complete however long it sits quiet", () => {
+    // Emissions stop once there is nothing to apply. Ageing a complete wallet
+    // into "stalled" would page someone for a healthy batcher.
+    expect(
+      classifyDustSyncState(
+        sample({
+          appliedIndex: 1_438_641n,
+          target: 1_438_641n,
+          updatedAtMs: NOW - 86_400_000,
+          advancedAtMs: NOW - 86_400_000,
+        }),
+        NOW,
+        STALLED_AFTER_MS,
+      ),
+    ).toEqual("complete");
+  });
+
+  test("no progress for longer than the stall window is stalled", () => {
+    expect(
+      classifyDustSyncState(sample({ advancedAtMs: NOW - 61_000 }), NOW, STALLED_AFTER_MS),
+    ).toEqual("stalled");
+  });
+
+  test("the measured offset-past-log signature reads as stalled", () => {
+    // Restored at 999999, nothing applied, never connected, no target ever
+    // learned — the failure that used to look exactly like a slow sync.
+    expect(
+      classifyDustSyncState(
+        {
+          appliedIndex: 999_999n,
+          target: 0n,
+          isConnected: false,
+          updatedAtMs: NOW - 90_000,
+          advancedAtMs: NOW - 90_000,
+        },
+        NOW,
+        STALLED_AFTER_MS,
+      ),
+    ).toEqual("stalled");
+  });
+
+  test("a fresh cold sync that has not emitted yet is syncing, not stalled", () => {
+    // Nothing has happened yet because nothing has had time to; calling that
+    // stalled would make every start look broken for its first minute.
+    expect(
+      classifyDustSyncState(
+        {
+          appliedIndex: 0n,
+          target: 0n,
+          isConnected: false,
+          updatedAtMs: NOW - 5_000,
+          advancedAtMs: NOW - 5_000,
+        },
+        NOW,
+        STALLED_AFTER_MS,
+      ),
+    ).toEqual("syncing");
+  });
+
+  test("a wallet nobody has sampled is unknown, not healthy", () => {
+    expect(classifyDustSyncState(null, NOW, STALLED_AFTER_MS)).toEqual("unknown");
+  });
+});

--- a/packages/batcher/test/http-listen-after-restore.test.ts
+++ b/packages/batcher/test/http-listen-after-restore.test.ts
@@ -1,0 +1,300 @@
+// A request must never fall into a frozen batcher.
+//
+// Measured on preprod (sweep brief §2): restarting with a snapshot costs 47.7 s,
+// and **46 s of that is a single synchronous block** — `DustWallet.restore`
+// deserializing 5.1 MB of `DustLocalState` in WASM on the main thread. Meanwhile
+// the HTTP server is already accepting traffic: `MidnightBalancingAdapter` fires
+// `initialize()` from its constructor without awaiting it, and `Batcher.init()`
+// starts `startHttpServer()` regardless. Every restart is therefore a ~46-second
+// black hole in which connections are accepted and nothing answers — worse than
+// the cold sync it replaces, where the worst single stall is 906 ms.
+//
+// The acceptance criterion is not "return a 503": while the event loop is inside
+// the WASM call, no handler of any kind runs, so no response can be produced.
+// The criterion is that a request **never hangs** — either the port is not yet
+// listening (the client fails immediately and can retry or fail over), or the
+// server answers promptly. That makes this an ORDERING property: do not bind
+// the port until the adapter is past the startup work that can freeze the loop.
+//
+// Deliberately NOT addressed here: moving sync/restore off the main event loop.
+// That is master-plan Q6 and an architecture change.
+
+import { describe, expect, test } from "bun:test";
+import { createNewBatcher } from "../core/batcher.ts";
+import type { Batcher } from "../core/batcher.ts";
+import type { DefaultBatcherInput } from "../core/types.ts";
+import { createServableGate } from "../adapters/midnight-balancing-adapter.ts";
+
+/** Ask the OS for a port nothing is on, then hand it to the batcher. */
+async function freePort(): Promise<number> {
+  const probe = Bun.serve({ port: 0, fetch: () => new Response("probe") });
+  const port = probe.port ?? 0;
+  await probe.stop(true);
+  if (port === 0) throw new Error("could not obtain a free port");
+  return port;
+}
+
+const storage = () =>
+  ({
+    init: async () => {},
+    addInput: async () => {},
+    getPendingInputs: async () => [],
+    getAllInputs: async () => [],
+    getInputsByTarget: async () => [],
+    removeProcessedInputs: async () => {},
+    getInputCountAndSize: async () => ({ count: 0, size: 0 }),
+    incrementRetryCount: async () => {},
+    clearAllInputs: async () => {},
+    updateInput: async () => {},
+    clearAll: async () => {},
+  }) as unknown as Parameters<typeof createNewBatcher>[1];
+
+const stubAdapter = (extra: Record<string, unknown> = {}) =>
+  ({
+    submitBatch: async () => "0xhash",
+    estimateBatchFee: () => "0",
+    buildBatchData: () => null,
+    getChainName: () => "stub",
+    getAccountAddress: () => "batcher",
+    isReady: () => true,
+    verifySignature: () => true,
+    ...extra,
+  }) as unknown as Parameters<Batcher<DefaultBatcherInput>["addBlockchainAdapter"]>[1];
+
+/** Did this request settle — either way — without hanging? */
+async function probeRequest(
+  port: number,
+): Promise<{ outcome: "answered" | "refused"; elapsedMs: number }> {
+  const startedAt = Date.now();
+  const outcome = await fetch(`http://127.0.0.1:${port}/health`, {
+    signal: AbortSignal.timeout(5_000),
+  }).then(() => "answered" as const, () => "refused" as const);
+  return { outcome, elapsedMs: Date.now() - startedAt };
+}
+
+/**
+ * Keep probing for `windowMs`. Returns the moment the port answers, or
+ * "stayed-closed".
+ *
+ * A single probe after a fixed sleep is not enough and the first draft of this
+ * test proved it: `Batcher.init()` needs ~800 ms to reach `startHttpServer`
+ * (building the OpenAPI server dominates), so a 50 ms sleep made the test pass
+ * against UNFIXED code — it was measuring startup latency, not ordering. The
+ * window here is comfortably longer than that path.
+ *
+ * Every probe also stands in for the real acceptance criterion: a request must
+ * settle, not hang. The maximum observed latency is returned so the test can
+ * say so out loud.
+ */
+async function pollUntilAnswered(
+  port: number,
+  windowMs: number,
+): Promise<{ result: "answered" | "stayed-closed"; maxLatencyMs: number }> {
+  const deadline = Date.now() + windowMs;
+  let maxLatencyMs = 0;
+  while (Date.now() < deadline) {
+    const probe = await probeRequest(port);
+    maxLatencyMs = Math.max(maxLatencyMs, probe.elapsedMs);
+    if (probe.outcome === "answered") return { result: "answered", maxLatencyMs };
+    await Bun.sleep(25);
+  }
+  return { result: "stayed-closed", maxLatencyMs };
+}
+
+/** Longer than the ~800 ms `init()` needs to reach `startHttpServer`. */
+const ORDERING_WINDOW_MS = 2_000;
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+describe("the HTTP port is not bound until adapters are past their blocking startup", () => {
+  test("a request during a slow restore fails fast instead of hanging", async () => {
+    const port = await freePort();
+    const restore = deferred();
+
+    const batcher = createNewBatcher(
+      { pollingIntervalMs: 1000, port, enableHttpServer: true, enableEventSystem: false },
+      storage(),
+    );
+    batcher.addBlockchainAdapter(
+      "stub",
+      stubAdapter({ whenServable: () => restore.promise }),
+    );
+
+    const init = batcher.init({ startPolling: false });
+
+    const during = await pollUntilAnswered(port, ORDERING_WINDOW_MS);
+    expect(during.result).toEqual("stayed-closed");
+    // The whole point: every probe settled, none sat in a 46-second black hole.
+    expect(during.maxLatencyMs).toBeLessThan(1_000);
+
+    restore.resolve();
+    await init;
+
+    const after = await probeRequest(port);
+    expect(after.outcome).toEqual("answered");
+
+    await batcher.stopHttpServer();
+  });
+
+  test("an adapter that never declares itself servable does not deny the port forever", async () => {
+    // A wedged or badly-implemented adapter must degrade to today's behaviour
+    // (a listening, possibly-stalling server), not to a batcher with no
+    // endpoints at all — an operator needs /health more than ever at that point.
+    const port = await freePort();
+
+    const batcher = createNewBatcher(
+      {
+        pollingIntervalMs: 1000,
+        port,
+        enableHttpServer: true,
+        enableEventSystem: false,
+        httpServerReadinessTimeoutMs: 100,
+      },
+      storage(),
+    );
+    batcher.addBlockchainAdapter(
+      "stub",
+      stubAdapter({ whenServable: () => new Promise<void>(() => {}) }),
+    );
+
+    await batcher.init({ startPolling: false });
+
+    expect((await probeRequest(port)).outcome).toEqual("answered");
+    await batcher.stopHttpServer();
+  });
+
+  test("an adapter that does not implement whenServable is unaffected", async () => {
+    const port = await freePort();
+
+    const batcher = createNewBatcher(
+      { pollingIntervalMs: 1000, port, enableHttpServer: true, enableEventSystem: false },
+      storage(),
+    );
+    batcher.addBlockchainAdapter("stub", stubAdapter());
+
+    await batcher.init({ startPolling: false });
+
+    expect((await probeRequest(port)).outcome).toEqual("answered");
+    await batcher.stopHttpServer();
+  });
+
+  test("a whenServable that throws or rejects still lets the server start", async () => {
+    // Readiness reporting is a courtesy; it must never be able to take the
+    // HTTP server down with it.
+    const port = await freePort();
+
+    const batcher = createNewBatcher(
+      { pollingIntervalMs: 1000, port, enableHttpServer: true, enableEventSystem: false },
+      storage(),
+    );
+    batcher.addBlockchainAdapter(
+      "a",
+      stubAdapter({ whenServable: () => Promise.reject(new Error("boom")) }),
+    );
+    batcher.addBlockchainAdapter(
+      "b",
+      stubAdapter({
+        whenServable: () => {
+          throw new Error("boom synchronously");
+        },
+      }),
+    );
+
+    await batcher.init({ startPolling: false });
+
+    expect((await probeRequest(port)).outcome).toEqual("answered");
+    await batcher.stopHttpServer();
+  });
+
+  test("every adapter must be servable before the port opens", async () => {
+    // One slow wallet is enough to freeze the loop, so the gate is the slowest
+    // adapter, not the first one to finish.
+    const port = await freePort();
+    const slow = deferred();
+
+    const batcher = createNewBatcher(
+      { pollingIntervalMs: 1000, port, enableHttpServer: true, enableEventSystem: false },
+      storage(),
+    );
+    batcher.addBlockchainAdapter("fast", stubAdapter({ whenServable: () => Promise.resolve() }));
+    batcher.addBlockchainAdapter("slow", stubAdapter({ whenServable: () => slow.promise }));
+
+    const init = batcher.init({ startPolling: false });
+
+    expect((await pollUntilAnswered(port, ORDERING_WINDOW_MS)).result)
+      .toEqual("stayed-closed");
+
+    slow.resolve();
+    await init;
+
+    expect((await probeRequest(port)).outcome).toEqual("answered");
+    await batcher.stopHttpServer();
+  });
+});
+
+describe("the servable gate behind MidnightBalancingAdapter.whenServable", () => {
+  // Tested as a unit rather than by driving the adapter: a real adapter builds
+  // real wallets and opens real sockets, so the first draft of these tests
+  // timed out against `http://x` while the SDK retried. The adapter's three
+  // call sites are wiring; the semantics are here, and §2 exercises both live.
+
+  const isOpen = async (gate: { promise: Promise<void> }): Promise<boolean> =>
+    await Promise.race([gate.promise.then(() => true), Bun.sleep(20).then(() => false)]);
+
+  test("opens only once EVERY wallet is past its restore", async () => {
+    const gate = createServableGate(2);
+    expect(gate.pending()).toEqual(2);
+    expect(await isOpen(gate)).toBe(false);
+
+    // One wallet finishing is not enough: the other can still freeze the loop,
+    // and a frozen loop serves nobody.
+    gate.mark(0);
+    expect(gate.pending()).toEqual(1);
+    expect(await isOpen(gate)).toBe(false);
+
+    gate.mark(1);
+    expect(gate.pending()).toEqual(0);
+    expect(await isOpen(gate)).toBe(true);
+  });
+
+  test("marking the same wallet twice does not open the gate early", async () => {
+    // The adapter marks from a sync sample AND from a `finally`, so double
+    // marks are the normal case, not an edge case.
+    const gate = createServableGate(2);
+    gate.mark(0);
+    gate.mark(0);
+    gate.mark(0);
+    expect(await isOpen(gate)).toBe(false);
+    expect(gate.pending()).toEqual(1);
+  });
+
+  test("markAll opens the gate — the failure backstop", async () => {
+    // The failure mode this prevents: a broken wallet holds the HTTP port shut,
+    // so the operator loses /health exactly when they need it to find out the
+    // wallet is broken.
+    const gate = createServableGate(3);
+    gate.markAll();
+    expect(await isOpen(gate)).toBe(true);
+    expect(gate.pending()).toEqual(0);
+  });
+
+  test("an adapter with no wallets starts open, and a stray index cannot throw", async () => {
+    expect(await isOpen(createServableGate(0))).toBe(true);
+
+    const gate = createServableGate(1);
+    // Called from `finally` blocks: a gate must never turn a failed wallet
+    // into a failed process.
+    expect(() => {
+      gate.mark(-1);
+      gate.mark(7);
+      gate.mark(Number.NaN);
+    }).not.toThrow();
+    expect(await isOpen(gate)).toBe(false);
+  });
+});

--- a/packages/batcher/test/http-listen-after-restore.test.ts
+++ b/packages/batcher/test/http-listen-after-restore.test.ts
@@ -212,6 +212,36 @@ describe("the HTTP port is not bound until adapters are past their blocking star
     await batcher.stopHttpServer();
   });
 
+  test("startHttpServer() waits too, not just init()", async () => {
+    // There are three ways to reach the listener: init(), the Effection
+    // `runBatcher` path (which spawns runHttpServer() → startHttpServer()
+    // and never goes through init()), and a direct call. The first version of
+    // this fix gated only init(), which left the black hole wide open on the
+    // Effection path. The wait belongs at the choke point.
+    const port = await freePort();
+    const restore = deferred();
+
+    const batcher = createNewBatcher(
+      { pollingIntervalMs: 1000, port, enableHttpServer: true, enableEventSystem: false },
+      storage(),
+    );
+    batcher.addBlockchainAdapter(
+      "stub",
+      stubAdapter({ whenServable: () => restore.promise }),
+    );
+
+    const started = batcher.startHttpServer();
+
+    expect((await pollUntilAnswered(port, ORDERING_WINDOW_MS)).result)
+      .toEqual("stayed-closed");
+
+    restore.resolve();
+    await started;
+
+    expect((await probeRequest(port)).outcome).toEqual("answered");
+    await batcher.stopHttpServer();
+  });
+
   test("every adapter must be servable before the port opens", async () => {
     // One slow wallet is enough to freeze the loop, so the gate is the slowest
     // adapter, not the first one to finish.

--- a/packages/chains/midnight-contracts/src/constants.ts
+++ b/packages/chains/midnight-contracts/src/constants.ts
@@ -9,8 +9,42 @@ export const CONSTANTS = {
     /** Wallet sync progress logging throttle interval */
     WALLET_SYNC_THROTTLE_MS: 10_000,
 
-    /** Wallet sync timeout (10 minutes) */
-    WALLET_SYNC_TIMEOUT_MS: 600_000,
+    /**
+     * Wallet sync timeout (4 hours). Override with
+     * `MIDNIGHT_WALLET_SYNC_TIMEOUT_MS`.
+     *
+     * This is a backstop, not a health check. A dust cold sync on preprod was
+     * measured at ~66 minutes (1,438,641 indices at ~365 idx/s) against a real
+     * chain at block 2,143,432 — the previous 10-minute default failed every
+     * default-configured cold sync, which made it a bug rather than a tunable.
+     * Mainnet is longer still, so the default buys headroom rather than a tight
+     * fit; a genuinely stuck sync is caught in ~60 s by the emission-silence
+     * detector in `waitForDustFundsWithRetry`, not by this number.
+     */
+    WALLET_SYNC_TIMEOUT_MS: 14_400_000,
+
+    /**
+     * How long to wait for funds to ARRIVE once a wallet is synced (10
+     * minutes). Override with `MIDNIGHT_WALLET_FUNDING_TIMEOUT_MS`.
+     *
+     * Deliberately separate from the sync timeout: waiting for a chain replay
+     * and waiting for someone to send NIGHT are different questions, and
+     * sharing one number meant an unfunded wallet inherited the multi-hour sync
+     * budget and hung instead of failing.
+     */
+    WALLET_FUNDING_TIMEOUT_MS: 600_000,
+
+    /**
+     * Deadline for `registerNightForDust`'s "unshielded + dust are strictly
+     * complete" precheck (10 minutes). Override with
+     * `MIDNIGHT_DUST_REGISTRATION_PRECHECK_TIMEOUT_MS`.
+     *
+     * Also separate from the sync timeout, and for a sharper reason: in
+     * dust-only mode the unshielded sub-wallet this waits on has been stopped,
+     * so the wait can never succeed. It must stay bounded by something small
+     * enough to give up on. (Unshielded sync itself is ~1 s on preprod.)
+     */
+    DUST_REGISTRATION_PRECHECK_TIMEOUT_MS: 600_000,
 
     /** Additional fee overhead for dust transactions (in smallest unit) */
     DUST_FEE_OVERHEAD: 300_000_000_000_000n,

--- a/packages/chains/midnight-contracts/src/dust-state.ts
+++ b/packages/chains/midnight-contracts/src/dust-state.ts
@@ -55,12 +55,23 @@ function isUndeployedNetwork(networkId: string): boolean {
 export interface DustStateOptions {
   /** Network id the snapshot body is expected to carry. Default: `networkId`. */
   snapshotNetworkId?: string;
+  /**
+   * Dust public key this seed's wallet must have, as a decimal string — see
+   * `deriveDustPublicKey`. When given, a snapshot belonging to a different
+   * wallet is neither loaded nor written, which is what keeps a caller that
+   * pairs the wrong seed with a wallet (the adapter's injected-wallet path)
+   * from handing one wallet's dust state to another. Opt-in because it costs a
+   * key derivation; every caller in this package opts in.
+   */
+  expectedPublicKey?: string;
 }
 
 /** The facts we can check about a snapshot without the wallet SDK. */
 export interface DustSnapshotFacts {
   /** Network id the snapshot recorded for itself. */
   networkId: string;
+  /** Dust public key of the wallet that wrote it, as a decimal string. */
+  publicKey: string;
   /** `progress.appliedIndex` at save time; 0 when the field was absent. */
   offset: bigint;
   /**
@@ -115,7 +126,8 @@ export function readDustSnapshotFacts(serializedState: string): DustSnapshotFact
 
   const publicKey = s.publicKey;
   if (!publicKey || typeof publicKey !== "object" || Array.isArray(publicKey)) return null;
-  if ((publicKey as Record<string, unknown>).publicKey === undefined) return null;
+  const dustPublicKey = (publicKey as Record<string, unknown>).publicKey;
+  if (dustPublicKey === undefined || dustPublicKey === null) return null;
 
   if (!isHexString(s.state)) return null;
   if (s.protocolVersion === undefined || s.protocolVersion === null) return null;
@@ -125,7 +137,12 @@ export function readDustSnapshotFacts(serializedState: string): DustSnapshotFact
   const offset = hasOffset ? toOffset(s.offset) : 0n;
   if (offset === null) return null;
 
-  return { networkId: s.networkId, offset, hasOffset };
+  return {
+    networkId: s.networkId,
+    publicKey: String(dustPublicKey),
+    offset,
+    hasOffset,
+  };
 }
 
 function sameNetwork(a: string, b: string): boolean {
@@ -180,6 +197,30 @@ function isMissingFile(e: unknown): boolean {
 }
 
 /**
+ * Persist the directory entry created by a rename. Best-effort: opening a
+ * directory for fsync is a POSIX behaviour that not every platform or
+ * filesystem supports, and failing to durably record the rename is strictly
+ * better than failing the save.
+ */
+function syncDirectory(dirPath: string): void {
+  let dirFd: number | undefined;
+  try {
+    dirFd = fs.openSync(dirPath, "r");
+    fs.fsyncSync(dirFd);
+  } catch {
+    /* not supported here; the file's own fsync still happened */
+  } finally {
+    if (dirFd !== undefined) {
+      try {
+        fs.closeSync(dirFd);
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+}
+
+/**
  * Save serialized dust wallet state to disk.
  * No-ops for "undeployed" networks (chain resets make cached state invalid).
  *
@@ -218,6 +259,13 @@ export function saveDustState(
     );
     return null;
   }
+  if (options?.expectedPublicKey && incoming.publicKey !== options.expectedPublicKey) {
+    log.warn(
+      `Refusing to save dust state to ${filePath}: the snapshot belongs to dust wallet ` +
+        `${incoming.publicKey}, but this file is keyed for ${options.expectedPublicKey}.`,
+    );
+    return null;
+  }
   const existing = readSnapshotFactsAt(filePath);
   if (existing && incoming.offset < existing.offset) {
     log.warn(
@@ -233,8 +281,20 @@ export function saveDustState(
     // concurrent writers (multi-wallet / multi-product processes) would
     // otherwise interleave into one file.
     const tmpPath = `${filePath}.${process.pid}.tmp`;
-    fs.writeFileSync(tmpPath, serializedState, "utf-8");
+    // fsync before rename, and again on the directory afterwards. Phase 1's
+    // kill -9 matrix (14/14 clean) proved rename atomicity against process
+    // death, which is all the page cache needs to survive — but a kernel panic
+    // or power loss can still lose the data or reorder it past the rename, and
+    // the whole point of the snapshot is that it is there after a hard stop.
+    const fd = fs.openSync(tmpPath, "w");
+    try {
+      fs.writeFileSync(fd, serializedState, "utf-8");
+      fs.fsyncSync(fd);
+    } finally {
+      fs.closeSync(fd);
+    }
     fs.renameSync(tmpPath, filePath);
+    syncDirectory(path.dirname(filePath));
     log.info(`Dust state saved to ${filePath}`);
     return filePath;
   } catch (e) {
@@ -289,6 +349,13 @@ export function loadDustState(
     log.warn(
       `Ignoring dust state at ${filePath}: recorded networkId "${facts.networkId}" ` +
         `does not match "${expectedNetworkId}". Syncing this wallet from scratch.`,
+    );
+    return null;
+  }
+  if (options?.expectedPublicKey && facts.publicKey !== options.expectedPublicKey) {
+    log.warn(
+      `Ignoring dust state at ${filePath}: it belongs to dust wallet ${facts.publicKey}, ` +
+        `not ${options.expectedPublicKey}. Syncing this wallet from scratch.`,
     );
     return null;
   }

--- a/packages/chains/midnight-contracts/src/dust-state.ts
+++ b/packages/chains/midnight-contracts/src/dust-state.ts
@@ -42,8 +42,155 @@ function isUndeployedNetwork(networkId: string): boolean {
 }
 
 /**
+ * Options shared by save/load.
+ *
+ * `snapshotNetworkId` exists for one caller and should stay that way: the
+ * dust-restore harness (test/dust-restore-harness.ts) deliberately drives a
+ * wallet bound to `undeployed` while keying persistence under a *named* id,
+ * because a local stack can only ever be `undeployed` and persistence no-ops
+ * there — the only way to exercise restore locally at all (Phase 1 §2). Every
+ * production caller wants the default, where the id the snapshot recorded must
+ * equal the id we are loading it for.
+ */
+export interface DustStateOptions {
+  /** Network id the snapshot body is expected to carry. Default: `networkId`. */
+  snapshotNetworkId?: string;
+}
+
+/** The facts we can check about a snapshot without the wallet SDK. */
+export interface DustSnapshotFacts {
+  /** Network id the snapshot recorded for itself. */
+  networkId: string;
+  /** `progress.appliedIndex` at save time; 0 when the field was absent. */
+  offset: bigint;
+  /**
+   * False when the SDK wrote no `offset`. The field is optional in
+   * `SnapshotSchema`, and a missing one silently degrades restore into a full
+   * replay (`Serialization.ts:100` reads `snapshot.offset ?? 0n`) — worth a
+   * warning, not a rejection: a full replay is what we would do anyway.
+   */
+  hasOffset: boolean;
+}
+
+function isHexString(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0 && value.length % 2 === 0 &&
+    /^[0-9a-fA-F]+$/.test(value);
+}
+
+function toOffset(value: unknown): bigint | null {
+  if (typeof value === "bigint") return value >= 0n ? value : null;
+  if (typeof value === "number") {
+    return Number.isSafeInteger(value) && value >= 0 ? BigInt(value) : null;
+  }
+  if (typeof value === "string" && /^\d+$/.test(value)) return BigInt(value);
+  return null;
+}
+
+/**
+ * Validate a serialized snapshot against the shape
+ * `wallet-sdk-dust-wallet@4.2.0` writes (`Serialization.ts:62-70`) and pull out
+ * the two facts we can act on. Returns null for anything we would rather
+ * cold-sync than hand to `DustWallet.restore`.
+ *
+ * This is a *shape* check, not a decode: `state` carries raw
+ * `ledger.DustLocalState` bytes whose meaning belongs to `@midnight-ntwrk/
+ * ledger-v8`, and there is no format-version envelope to check it against
+ * (master-plan Q4). A snapshot that passes here can still fail to decode after
+ * a ledger upgrade, which is why the restore call site *also* falls back to a
+ * cold sync instead of throwing.
+ *
+ * Deliberately not strict beyond the recorded fields: an SDK that adds a field
+ * must not silently disable persistence. An SDK that *renames* one will fail
+ * here — loudly, in the log, degrading to a cold sync rather than to garbage.
+ */
+export function readDustSnapshotFacts(serializedState: string): DustSnapshotFacts | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(serializedState);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+  const s = parsed as Record<string, unknown>;
+
+  const publicKey = s.publicKey;
+  if (!publicKey || typeof publicKey !== "object" || Array.isArray(publicKey)) return null;
+  if ((publicKey as Record<string, unknown>).publicKey === undefined) return null;
+
+  if (!isHexString(s.state)) return null;
+  if (s.protocolVersion === undefined || s.protocolVersion === null) return null;
+  if (typeof s.networkId !== "string" || s.networkId.length === 0) return null;
+
+  const hasOffset = s.offset !== undefined && s.offset !== null;
+  const offset = hasOffset ? toOffset(s.offset) : 0n;
+  if (offset === null) return null;
+
+  return { networkId: s.networkId, offset, hasOffset };
+}
+
+function sameNetwork(a: string, b: string): boolean {
+  return a.trim().toLowerCase() === b.trim().toLowerCase();
+}
+
+function readSnapshotFactsAt(filePath: string): DustSnapshotFacts | null {
+  try {
+    return readDustSnapshotFacts(fs.readFileSync(filePath, "utf-8"));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Move an unusable snapshot aside so the next process start cannot restore it
+ * again, without destroying the evidence an operator needs to explain a
+ * surprise cold sync. One `.rejected` file is kept per wallet; a second
+ * rejection overwrites it (rename is atomic, so there is never a window with
+ * neither file).
+ */
+export function quarantineDustState(
+  baseDir: string,
+  networkId: string,
+  seed: string,
+  reason: string,
+): string | null {
+  if (isUndeployedNetwork(networkId)) return null;
+  const filePath = getDustStatePath(baseDir, networkId, seed);
+  const rejectedPath = `${filePath}.rejected`;
+  try {
+    fs.renameSync(filePath, rejectedPath);
+    log.warn(
+      `Dust state ${filePath} was unusable (${reason}); moved to ${rejectedPath}. ` +
+        `This wallet will sync from scratch.`,
+    );
+    return rejectedPath;
+  } catch (e) {
+    if (!isMissingFile(e)) {
+      log.warn(
+        `Failed to quarantine unusable dust state ${filePath}: ${
+          e instanceof Error ? e.message : String(e)
+        }`,
+      );
+    }
+    return null;
+  }
+}
+
+function isMissingFile(e: unknown): boolean {
+  return (e as { code?: string } | null)?.code === "ENOENT";
+}
+
+/**
  * Save serialized dust wallet state to disk.
  * No-ops for "undeployed" networks (chain resets make cached state invalid).
+ *
+ * Refuses to write a snapshot that is malformed, belongs to another network,
+ * or whose `offset` regresses below the one already on disk. The regression
+ * rule is the one that matters operationally: Phase 1 §2 measured the batcher
+ * re-persisting a *poisoned* snapshot on the stall path (gwi:707) and again on
+ * final failure (gwi:721), so an unusable state outlived the process and every
+ * restart repeated the same ~5-minute failure. A save may move a snapshot
+ * forward or leave it where it is; it may never move it backwards.
+ *
  * @param seed - Wallet seed hex string (used to derive stable file path)
  */
 export function saveDustState(
@@ -51,9 +198,35 @@ export function saveDustState(
   networkId: string,
   seed: string,
   serializedState: string,
+  options?: DustStateOptions,
 ): string | null {
   if (isUndeployedNetwork(networkId)) return null;
   const filePath = getDustStatePath(baseDir, networkId, seed);
+
+  const incoming = readDustSnapshotFacts(serializedState);
+  if (!incoming) {
+    log.warn(
+      `Refusing to save malformed dust state to ${filePath} — keeping whatever is already there.`,
+    );
+    return null;
+  }
+  const expectedNetworkId = options?.snapshotNetworkId ?? networkId;
+  if (!sameNetwork(incoming.networkId, expectedNetworkId)) {
+    log.warn(
+      `Refusing to save dust state to ${filePath}: snapshot records networkId ` +
+        `"${incoming.networkId}" but this wallet is on "${expectedNetworkId}".`,
+    );
+    return null;
+  }
+  const existing = readSnapshotFactsAt(filePath);
+  if (existing && incoming.offset < existing.offset) {
+    log.warn(
+      `Refusing to save dust state to ${filePath}: offset would regress ` +
+        `${existing.offset} -> ${incoming.offset}. Keeping the newer snapshot.`,
+    );
+    return null;
+  }
+
   try {
     fs.mkdirSync(path.dirname(filePath), { recursive: true });
     // Atomic: a torn write leaves a wallet unable to restore its state, and
@@ -73,18 +246,57 @@ export function saveDustState(
 /**
  * Load previously saved dust wallet state from disk.
  * Always returns null for "undeployed" networks.
+ *
+ * Returns null — i.e. "cold-sync this wallet" — for any snapshot we would
+ * otherwise hand to `DustWallet.restore` without knowing it is usable:
+ * malformed or truncated JSON, missing required fields, or a snapshot recorded
+ * on a different network. `networkId` is the one identity field the snapshot
+ * carries and Phase 1 §2 measured that nobody ever compared it: the SDK's
+ * `restore` only reads the configured id in `startWithSeed`/`startWithSecretKey`
+ * (`DustWallet.ts:295-300`), so a snapshot from another chain restored silently.
+ *
+ * Rejection is logged at warn level and never throws: a cold sync is expensive
+ * (~66 min on preprod) but survivable; handing bad state to `restore` is not —
+ * it throws synchronously out of wallet init.
+ *
  * @param seed - Wallet seed hex string (used to derive stable file path)
  */
 export function loadDustState(
   baseDir: string,
   networkId: string,
   seed: string,
+  options?: DustStateOptions,
 ): string | null {
   if (isUndeployedNetwork(networkId)) return null;
   const filePath = getDustStatePath(baseDir, networkId, seed);
+  let raw: string;
   try {
-    return fs.readFileSync(filePath, "utf-8");
+    raw = fs.readFileSync(filePath, "utf-8");
   } catch {
     return null;
   }
+
+  const facts = readDustSnapshotFacts(raw);
+  if (!facts) {
+    log.warn(
+      `Ignoring dust state at ${filePath}: malformed, truncated, or missing required ` +
+        `fields. Syncing this wallet from scratch.`,
+    );
+    return null;
+  }
+  const expectedNetworkId = options?.snapshotNetworkId ?? networkId;
+  if (!sameNetwork(facts.networkId, expectedNetworkId)) {
+    log.warn(
+      `Ignoring dust state at ${filePath}: recorded networkId "${facts.networkId}" ` +
+        `does not match "${expectedNetworkId}". Syncing this wallet from scratch.`,
+    );
+    return null;
+  }
+  if (!facts.hasOffset) {
+    log.warn(
+      `Dust state at ${filePath} carries no offset — restore will replay the whole ` +
+        `event log rather than resuming.`,
+    );
+  }
+  return raw;
 }

--- a/packages/chains/midnight-contracts/src/dust-state.ts
+++ b/packages/chains/midnight-contracts/src/dust-state.ts
@@ -275,12 +275,12 @@ export function saveDustState(
     return null;
   }
 
+  // Atomic: a torn write leaves a wallet unable to restore its state, and
+  // concurrent writers (multi-wallet / multi-product processes) would
+  // otherwise interleave into one file.
+  const tmpPath = `${filePath}.${process.pid}.tmp`;
   try {
     fs.mkdirSync(path.dirname(filePath), { recursive: true });
-    // Atomic: a torn write leaves a wallet unable to restore its state, and
-    // concurrent writers (multi-wallet / multi-product processes) would
-    // otherwise interleave into one file.
-    const tmpPath = `${filePath}.${process.pid}.tmp`;
     // fsync before rename, and again on the directory afterwards. Phase 1's
     // kill -9 matrix (14/14 clean) proved rename atomicity against process
     // death, which is all the page cache needs to survive — but a kernel panic
@@ -299,6 +299,14 @@ export function saveDustState(
     return filePath;
   } catch (e) {
     log.warn(`Failed to save dust state to ${filePath}: ${e instanceof Error ? e.message : String(e)}`);
+    // A failed write or rename otherwise leaves the `.pid.tmp` behind forever
+    // (Phase 1's atomic-write review). Now that saves happen every few minutes
+    // rather than once at init, a leak here would accumulate.
+    try {
+      fs.unlinkSync(tmpPath);
+    } catch {
+      /* nothing to clean up, or we cannot — either way the save already failed */
+    }
     return null;
   }
 }

--- a/packages/chains/midnight-contracts/src/dust-state.ts
+++ b/packages/chains/midnight-contracts/src/dust-state.ts
@@ -196,6 +196,101 @@ function isMissingFile(e: unknown): boolean {
   return (e as { code?: string } | null)?.code === "ENOENT";
 }
 
+/** The exact shape {@link saveDustState} gives its temp file, and only that. */
+const TMP_SUFFIX_PATTERN = /^\.(\d+)\.tmp$/;
+
+/**
+ * Is this pid running? `EPERM` means the process exists and belongs to someone
+ * else — very much alive — so only `ESRCH` counts as gone.
+ */
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (e) {
+    return (e as { code?: string }).code === "EPERM";
+  }
+}
+
+/**
+ * Delete `<snapshot>.<pid>.tmp` siblings left behind by processes that died
+ * mid-save, and report what went.
+ *
+ * `saveDustState`'s `catch` block already unlinks the temp file when a *write*
+ * fails. It cannot help when the process is killed: `SIGKILL` runs no catch
+ * block, and the preprod kill matrix measured **8 of 14 `kill -9`s leaking a
+ * full 5.1 MB temp file** (sweep brief §2 step 4). A crash-looping batcher
+ * therefore leaks a whole snapshot per restart, unbounded. Phase 1 predicted
+ * this from code review but could not observe it at a 13.7 KB payload, where
+ * the write is over too fast to be caught.
+ *
+ * Two files are deliberately never swept:
+ *
+ * - **Anything owned by a live pid.** That temp file is that process's
+ *   in-flight write, and removing it makes its `rename` fail — trading an
+ *   unbounded leak for a lost checkpoint is not an improvement.
+ * - **Anything owned by THIS pid.** It is either the write currently in
+ *   flight, or the residue of one whose `catch` block already tried; deleting
+ *   our own active temp file would be self-inflicted.
+ *
+ * A dead pid that has since been *reused* by an unrelated process makes us skip
+ * a file we could have removed. That is the safe direction: the leak survives
+ * one more cycle, nobody's write is destroyed, and the next sweep sees a
+ * different pid table.
+ *
+ * Scoped to siblings of this wallet's snapshot: every wallet sweeps its own on
+ * save and on load, so a shared state directory is covered without one wallet
+ * reaching into another's files.
+ */
+export function sweepStaleDustStateTmpFiles(
+  baseDir: string,
+  networkId: string,
+  seed: string,
+): string[] {
+  if (isUndeployedNetwork(networkId)) return [];
+  const filePath = getDustStatePath(baseDir, networkId, seed);
+  const dirPath = path.dirname(filePath);
+  const base = path.basename(filePath);
+
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(dirPath);
+  } catch {
+    // No directory yet, or unreadable. Nothing to sweep either way.
+    return [];
+  }
+
+  const removed: string[] = [];
+  for (const entry of entries) {
+    if (!entry.startsWith(`${base}.`)) continue;
+    const match = TMP_SUFFIX_PATTERN.exec(entry.slice(base.length));
+    if (!match) continue;
+    const pid = Number(match[1]);
+    // `process.kill(0, ...)` signals the entire process group, so a
+    // non-positive "pid" must never reach the liveness check. Nothing we write
+    // can produce one; a file that claims otherwise is not ours to delete.
+    if (!Number.isSafeInteger(pid) || pid <= 0) continue;
+    if (pid === process.pid) continue;
+    if (isProcessAlive(pid)) continue;
+
+    const orphanPath = path.join(dirPath, entry);
+    try {
+      fs.unlinkSync(orphanPath);
+      removed.push(orphanPath);
+    } catch {
+      // Raced with the owner's own cleanup, or we lack permission. Either way
+      // the next save or load tries again.
+    }
+  }
+  if (removed.length > 0) {
+    log.info(
+      `Swept ${removed.length} stale dust-state temp file(s) left by killed ` +
+        `processes: ${removed.join(", ")}`,
+    );
+  }
+  return removed;
+}
+
 /**
  * Persist the directory entry created by a rename. Best-effort: opening a
  * directory for fsync is a POSIX behaviour that not every platform or
@@ -243,6 +338,11 @@ export function saveDustState(
 ): string | null {
   if (isUndeployedNetwork(networkId)) return null;
   const filePath = getDustStatePath(baseDir, networkId, seed);
+
+  // Before the validity guards, not after: a batcher that crash-loops while
+  // its snapshot is being rejected (offset regression, network mismatch) still
+  // returns here every checkpoint, and that is exactly the process that leaks.
+  sweepStaleDustStateTmpFiles(baseDir, networkId, seed);
 
   const incoming = readDustSnapshotFacts(serializedState);
   if (!incoming) {
@@ -337,6 +437,13 @@ export function loadDustState(
 ): string | null {
   if (isUndeployedNetwork(networkId)) return null;
   const filePath = getDustStatePath(baseDir, networkId, seed);
+
+  // Startup is the one moment we know the previous run's writer is gone, so it
+  // is where a leak from a killed process is cheapest to clear — and it runs
+  // even when there is no snapshot to load, which is the crash-loop case that
+  // never reached a successful save.
+  sweepStaleDustStateTmpFiles(baseDir, networkId, seed);
+
   let raw: string;
   try {
     raw = fs.readFileSync(filePath, "utf-8");

--- a/packages/chains/midnight-contracts/src/get-wallet-info.ts
+++ b/packages/chains/midnight-contracts/src/get-wallet-info.ts
@@ -493,6 +493,55 @@ async function waitForDustWalletProgressCatchUp(
   log.info("Dust wallet sync catch-up complete");
 }
 
+/**
+ * Wait for the shielded sub-wallet to be strictly complete. Resolves `true` if
+ * it got there within `timeoutMs`, `false` otherwise — never throws.
+ *
+ * Needed before `suspendAuxWalletSyncForFees` on any wallet that will do a
+ * shielded spend. Master-plan Q2: fee wallets run `syncMode: 'dust-only'`,
+ * which keeps the aux wallets running (`stopAuxWalletsImmediately: false`) but
+ * stops them the moment *dust* sync completes — however far behind shielded
+ * still is. Shielded state is not persisted either, so every start replays it
+ * from genesis and truncates it again. `applyShieldedPadding` then spends
+ * against that partial state and its failure is swallowed with a warn per
+ * transaction, which is how a padding-enabled deployment degrades silently.
+ *
+ * Returns a boolean rather than throwing because padding is per-input on some
+ * targets: a slow shielded sync should be visible and survivable, not fatal to
+ * a batcher that may never need padding.
+ */
+export async function waitForShieldedSyncComplete(
+  wallet: WalletFacade,
+  timeoutMs: number,
+): Promise<boolean> {
+  if (timeoutMs <= 0) return false;
+  const startedAt = Date.now();
+  try {
+    await Rx.firstValueFrom(
+      wallet.state().pipe(
+        Rx.filter((s: any) =>
+          s?.shielded?.state?.progress?.isStrictlyComplete?.() ?? false
+        ),
+        Rx.timeout({
+          first: timeoutMs,
+          with: () => Rx.throwError(() => new Error("shielded sync timeout")),
+        }),
+      ),
+    );
+    log.info(
+      `Shielded wallet sync complete after ${((Date.now() - startedAt) / 1000).toFixed(0)}s`,
+    );
+    return true;
+  } catch (e) {
+    log.warn(
+      `Shielded wallet did not finish syncing (${
+        e instanceof Error ? e.message : String(e)
+      })`,
+    );
+    return false;
+  }
+}
+
 /** Stop shielded + unshielded sync after dust is ready (dust-only ergonomics). */
 export async function suspendAuxWalletSyncForFees(wallet: WalletFacade): Promise<void> {
   log.info("Stopping shielded and unshielded wallet sync (dust-only mode)");
@@ -834,6 +883,20 @@ export interface DustSyncWithRetryOptions {
    * yet.
    */
   onSyncProgress?: (sample: DustSyncProgressSample) => void;
+  /**
+   * Wait for the shielded sub-wallet to finish syncing before suspending it.
+   * Set this whenever the wallet will make a shielded spend (the batcher's
+   * shielded padding): dust-only mode otherwise stops shielded the moment DUST
+   * sync completes, leaving a partially replayed shielded state that padding
+   * silently fails against. Costs whatever shielded sync still needs; skip it
+   * when nothing will spend shielded coins. Default: false.
+   */
+  requireShieldedSync?: boolean;
+  /**
+   * Deadline for {@link requireShieldedSync}. Default:
+   * {@link resolveWalletSyncTimeoutMs}. Exceeding it is logged, not fatal.
+   */
+  shieldedSyncTimeoutMs?: number;
 }
 
 /** One throttled observation of a dust wallet catching up. */
@@ -876,6 +939,8 @@ export async function waitForDustFundsWithRetry(
     syncMode = 'dust-only',
     dustStateDir = DEFAULT_DUST_STATE_DIR,
     onSyncProgress,
+    requireShieldedSync = false,
+    shieldedSyncTimeoutMs = resolveWalletSyncTimeoutMs(),
   } = options;
 
   const networkIdStr = String(networkId);
@@ -1165,6 +1230,23 @@ export async function waitForDustFundsWithRetry(
       }
 
       if (syncMode === 'dust-only') {
+        // Dust-only stops shielded the moment DUST is done. A wallet that will
+        // spend shielded coins needs its shielded state whole first, or the
+        // spend fails against a half-replayed one.
+        if (requireShieldedSync) {
+          log.info("Waiting for shielded sync before suspending aux wallets (padding enabled)...");
+          const complete = await waitForShieldedSyncComplete(
+            walletResult!.wallet,
+            shieldedSyncTimeoutMs,
+          );
+          if (!complete) {
+            log.error(
+              "Shielded wallet is still behind and is being suspended anyway. " +
+                "Shielded padding will fail for this wallet until it is restarted " +
+                "with more time to sync.",
+            );
+          }
+        }
         await suspendAuxWalletSyncForFees(walletResult!.wallet);
       }
 

--- a/packages/chains/midnight-contracts/src/get-wallet-info.ts
+++ b/packages/chains/midnight-contracts/src/get-wallet-info.ts
@@ -451,6 +451,29 @@ const DUST_STALL_TIMEOUT_MS = 60_000;
 const DUST_MAX_RETRIES = 5;
 const DUST_COMPLETION_GAP = 50n;
 
+/**
+ * Did this sync attempt move the wallet forward at all?
+ *
+ * The only honest baseline is where the attempt *started* — the offset it
+ * restored from — not "is appliedIndex non-zero". Phase 1 §2 measured why:
+ * a wallet restored from a snapshot whose offset is past the indexer's log
+ * sits at `appliedIndex === offset` forever, which is non-zero, so `gwi:712`'s
+ * `appliedIndex === 0n` check never fired and the useless state was written
+ * back to disk on every failed attempt (gwi:707, gwi:721). A snapshot that
+ * produced zero progress over a full attempt is worth nothing and must not
+ * displace whatever is already stored.
+ *
+ * A stalled-but-advancing sync is the opposite case and the reason the
+ * stall-path save exists at all: 128 -> 5000 means the next attempt resumes
+ * 4872 events further along.
+ */
+export function dustSyncAttemptMadeProgress(
+  attemptStartIndex: bigint,
+  lastAppliedIndex: bigint,
+): boolean {
+  return lastAppliedIndex > attemptStartIndex;
+}
+
 export interface DustSyncWithRetryOptions {
   networkUrls: Required<NetworkUrls>;
   seed: string;
@@ -504,8 +527,13 @@ export async function waitForDustFundsWithRetry(
   // Lazy import keeps node:fs out of the browser's static graph — this retry
   // flow is node-side (long-running dust sync with disk caching), while the
   // module as a whole is bundled for browsers via `./wallet-info`.
-  const { loadDustState, saveDustState, getDustStatePath, quarantineDustState } =
-    await import("./dust-state.ts");
+  const {
+    loadDustState,
+    saveDustState,
+    getDustStatePath,
+    quarantineDustState,
+    readDustSnapshotFacts,
+  } = await import("./dust-state.ts");
 
   // Pre-load cached state from disk before building any wallet.
   // Uses seed-based path so we don't need the dust address yet.
@@ -555,17 +583,38 @@ export async function waitForDustFundsWithRetry(
     }
   }
 
+  /** Where the wallet already was when this attempt began; see {@link dustSyncAttemptMadeProgress}. */
+  async function readDustAppliedIndex(wr: WalletResult): Promise<bigint> {
+    try {
+      const ds = await getInitialDustState(
+        (wr.wallet as any).dust as { state: Rx.Observable<unknown> },
+        { timeoutMs: 30_000 },
+      );
+      return dustProgressFromState(ds)?.appliedIndex ?? 0n;
+    } catch {
+      return 0n;
+    }
+  }
+
   // Build or reuse wallet
   let walletResult = existingWalletResult ?? null;
 
   let dustSyncedState: any = null;
   let lastAppliedIndex = 0n;
+  let attemptStartIndex = 0n;
 
   for (let attempt = 1; attempt <= maxRetries; attempt++) {
     lastAppliedIndex = 0n;
+    attemptStartIndex = 0n;
     try {
       if (!walletResult) {
         const stateToRestore = inMemoryState ?? cachedState;
+        // Progress this attempt is measured against the offset we resume from.
+        // A rejected snapshot resets this to 0 below, because the wallet then
+        // cold-starts and genuinely does begin at genesis.
+        attemptStartIndex = stateToRestore
+          ? (readDustSnapshotFacts(stateToRestore)?.offset ?? 0n)
+          : 0n;
         if (attempt > 1) {
           if (stateToRestore) {
             log.info(`Retry ${attempt}/${maxRetries}: rebuilding wallet from ${inMemoryState ? 'in-memory' : 'cached'} state...`);
@@ -583,9 +632,16 @@ export async function waitForDustFundsWithRetry(
           stateToRestore,
           {
             stopAuxWalletsImmediately: syncMode !== 'dust-only',
-            onSnapshotRejected: discardSnapshot,
+            onSnapshotRejected: (reason) => {
+              discardSnapshot(reason);
+              attemptStartIndex = 0n;
+            },
           },
         );
+      } else if (attempt === 1) {
+        // A wallet handed in by the caller is already somewhere; progress has
+        // to be measured from there, not from zero.
+        attemptStartIndex = await readDustAppliedIndex(walletResult);
       }
 
 
@@ -720,24 +776,36 @@ export async function waitForDustFundsWithRetry(
       return { walletResult, dustBalance };
     } catch (e) {
       const isStall = e instanceof Error && e.message === "stall";
+      // A failed attempt may only write back state that moved forward. Phase 1
+      // §2 measured the alternative: a wallet frozen at a snapshot offset past
+      // the indexer's log was re-persisted on every failed attempt, so the
+      // outage survived restarts.
+      const madeProgress = dustSyncAttemptMadeProgress(attemptStartIndex, lastAppliedIndex);
+      if (!madeProgress) {
+        log.warn(
+          `Dust sync attempt ${attempt}/${maxRetries} applied no new events ` +
+            `(stuck at ${lastAppliedIndex}); refusing to persist that state.`,
+        );
+      }
 
       if (isStall && attempt < maxRetries) {
         log.warn(`Dust sync stalled on attempt ${attempt}/${maxRetries}. Stopping wallet and rebuilding from state...`);
         if (walletResult) {
-          await serializeAndSave(walletResult);
+          if (madeProgress) await serializeAndSave(walletResult);
           await stopWallet(walletResult);
           walletResult = null;
         }
-        // If target was 0 on this attempt, the state is likely invalid — don't restore it
-        if (lastAppliedIndex === 0n) {
-          log.warn("No sync progress was made (appliedIndex=0), discarding in-memory state for clean rebuild");
+        // State that produced nothing must not be restored again either —
+        // otherwise the next attempt repeats this one exactly.
+        if (!madeProgress) {
+          log.warn("No sync progress was made, discarding in-memory state for clean rebuild");
           inMemoryState = null;
         }
         continue;
       }
 
-      // Non-stall error or final attempt — save what we have and throw
-      if (walletResult) {
+      // Non-stall error or final attempt — checkpoint real progress and throw
+      if (walletResult && madeProgress) {
         await serializeAndSave(walletResult);
       }
 

--- a/packages/chains/midnight-contracts/src/get-wallet-info.ts
+++ b/packages/chains/midnight-contracts/src/get-wallet-info.ts
@@ -504,15 +504,32 @@ export async function waitForDustFundsWithRetry(
   // Lazy import keeps node:fs out of the browser's static graph — this retry
   // flow is node-side (long-running dust sync with disk caching), while the
   // module as a whole is bundled for browsers via `./wallet-info`.
-  const { loadDustState, saveDustState, getDustStatePath } = await import("./dust-state.ts");
+  const { loadDustState, saveDustState, getDustStatePath, quarantineDustState } =
+    await import("./dust-state.ts");
 
   // Pre-load cached state from disk before building any wallet.
   // Uses seed-based path so we don't need the dust address yet.
-  const cachedState: string | null = loadDustState(dustStateDir, networkIdStr, seed);
+  // `loadDustState` already refuses anything malformed or from another network,
+  // so a non-null value here is at worst *stale*, never unparseable.
+  let cachedState: string | null = loadDustState(dustStateDir, networkIdStr, seed);
   if (cachedState) {
     log.info(`Loaded cached dust state from disk (${getDustStatePath(dustStateDir, networkIdStr, seed)})`);
   }
   let inMemoryState: string | null = null;
+
+  /**
+   * A snapshot proved unusable at restore time. Drop it from both places it
+   * could come back from, and move the file aside so a restart does not walk
+   * into the same failure — otherwise the cold sync we just paid for is
+   * repeated on every start.
+   */
+  function discardSnapshot(reason: string): void {
+    inMemoryState = null;
+    if (cachedState) {
+      cachedState = null;
+      quarantineDustState(dustStateDir, networkIdStr, seed, reason);
+    }
+  }
 
   // Helper to serialize and save dust state
   async function serializeAndSave(wr: WalletResult): Promise<string | null> {
@@ -564,7 +581,10 @@ export async function waitForDustFundsWithRetry(
           networkId,
           syncMode,
           stateToRestore,
-          { stopAuxWalletsImmediately: syncMode !== 'dust-only' },
+          {
+            stopAuxWalletsImmediately: syncMode !== 'dust-only',
+            onSnapshotRejected: discardSnapshot,
+          },
         );
       }
 
@@ -816,10 +836,56 @@ function resolveDustBatchUpdates(): {
   };
 }
 
+/**
+ * Restore a dust wallet from a snapshot, or cold-start it if the snapshot will
+ * not decode. Never throws on account of the snapshot.
+ *
+ * `DustWallet.restore` decodes with `Either.getOrThrow`
+ * (`DustWallet.ts:295-300`), so a truncated file — or any snapshot written
+ * before a `@midnight-ntwrk/ledger-v8` bump, since the format carries no
+ * version envelope (master-plan Q4) — throws synchronously out of wallet
+ * construction. Phase 1 §2 measured the consequence: the throw escapes
+ * `buildWalletFacade`, `waitForDustFundsWithRetry` treats it as a non-stall
+ * error and rethrows without ever rebuilding from scratch, and wallet init
+ * stays broken until an operator deletes the file. A cold sync is expensive;
+ * a bricked batcher is worse.
+ *
+ * Kept as a standalone decision so the fallback fires for a *decode* failure
+ * and nothing else — wrapping the whole facade build would also swallow
+ * indexer and proof-server errors and throw away a good snapshot (and ~66 min
+ * of preprod resync) on a transient outage.
+ *
+ * `onSnapshotRejected` is how the caller learns the snapshot must not be
+ * reused: it stops the retry loop from restoring the same bytes again and
+ * moves the file aside.
+ */
+export function restoreDustWalletWithColdSyncFallback<W>(
+  serializedState: string | null | undefined,
+  restore: (serializedState: string) => W,
+  coldStart: () => W,
+  onSnapshotRejected?: (reason: string) => void,
+): W {
+  if (serializedState) {
+    try {
+      log.info("Restoring dust wallet from cached state");
+      return restore(serializedState);
+    } catch (e) {
+      const reason = e instanceof Error ? e.message : String(e);
+      log.error(
+        `Dust snapshot could not be restored (${reason}). Falling back to a full sync ` +
+          `from genesis — this can take a long time on a real network.`,
+      );
+      onSnapshotRejected?.(reason);
+    }
+  }
+  return coldStart();
+}
+
 function buildDustWallet(
   config: DefaultConfiguration,
   seed: Uint8Array,
   serializedState?: string | null,
+  onSnapshotRejected?: (reason: string) => void,
 ) {
   const dustConfig = {
     ...config,
@@ -830,12 +896,16 @@ function buildDustWallet(
       feeBlocksMargin: CONSTANTS.DUST_FEE_BLOCKS_MARGIN,
     },
   };
-  if (serializedState) {
-    log.info("Restoring dust wallet from cached state");
-    return DustWallet(dustConfig as any).restore(serializedState);
-  }
-  const dustParameters = LedgerParameters.initialParameters().dust;
-  return DustWallet(dustConfig as any).startWithSeed(seed, dustParameters);
+  return restoreDustWalletWithColdSyncFallback(
+    serializedState,
+    (state) => DustWallet(dustConfig as any).restore(state),
+    () =>
+      DustWallet(dustConfig as any).startWithSeed(
+        seed,
+        LedgerParameters.initialParameters().dust,
+      ),
+    onSnapshotRejected,
+  );
 }
 
 function buildUnshieldedWallet(
@@ -864,7 +934,15 @@ export async function buildWalletFacade(
   networkId: NetworkId.NetworkId,
   syncMode: WalletSyncMode = 'all',
   dustSerializedState?: string | null,
-  options?: { stopAuxWalletsImmediately?: boolean },
+  options?: {
+    stopAuxWalletsImmediately?: boolean;
+    /**
+     * Called when `dustSerializedState` could not be decoded and the dust
+     * wallet cold-started instead. The caller owns what happens next — at
+     * minimum it must stop reusing those bytes.
+     */
+    onSnapshotRejected?: (reason: string) => void;
+  },
 ): Promise<WalletResult> {
   const shieldedSeed = deriveSeedForRole(seed, Roles.Zswap);
   const dustSeed = deriveSeedForRole(seed, Roles.Dust);
@@ -875,7 +953,12 @@ export async function buildWalletFacade(
   const unshieldedKeystore = createKeystore(unshieldedSeed, networkId);
 
   const shieldedWallet = buildShieldedWallet(config, shieldedSeed);
-  const dustWallet = buildDustWallet(config, dustSeed, dustSerializedState);
+  const dustWallet = buildDustWallet(
+    config,
+    dustSeed,
+    dustSerializedState,
+    options?.onSnapshotRejected,
+  );
   const unshieldedWallet = buildUnshieldedWallet(config, unshieldedKeystore);
 
   const zswapSecretKeys = ZswapSecretKeys.fromSeed(shieldedSeed);

--- a/packages/chains/midnight-contracts/src/get-wallet-info.ts
+++ b/packages/chains/midnight-contracts/src/get-wallet-info.ts
@@ -474,6 +474,46 @@ export function dustSyncAttemptMadeProgress(
   return lastAppliedIndex > attemptStartIndex;
 }
 
+/**
+ * Is this a well-formed snapshot whose `offset` sits past the end of the
+ * indexer's event log? Then it is not a stall to retry — it is a snapshot to
+ * throw away.
+ *
+ * `Sync.ts:271-303` opens the subscription at the inclusive cursor
+ * `appliedIndex - 1`, which re-delivers the boundary event and is what flips
+ * `isConnected` (`SyncProgress.ts:48` defaults it false and it is not
+ * serialized). If the cursor is past the end — a named-network reset, an
+ * indexer rollback or re-index — no event ever arrives, so the wallet sits at
+ * `appliedIndex === offset`, `highestRelevantWalletIndex === 0`, never
+ * connected, forever. Phase 1 §2 reproduced exactly that by tampering an
+ * offset to 999999 and watching a 45 s window pass with one emission.
+ *
+ * Retrying cannot help, because retrying restores the same bytes: `gwi:640`'s
+ * "nothing to sync" escape and `gwi:712`'s state-discard both require
+ * `appliedIndex === 0n`, which a restored wallet never satisfies.
+ *
+ * Every clause is a guard against discarding a snapshot that is merely slow —
+ * on preprod that mistake costs ~66 min of resync:
+ * - `restoredFromOffset > 0` — there is a snapshot to blame at all;
+ * - no progress — one applied event proves the cursor is inside the log;
+ * - `highestRelevantWalletIndex === 0` — a target index only appears once the
+ *   indexer delivered something;
+ * - not connected — a connected wallet is syncing, however slowly.
+ */
+export function isSnapshotOffsetPastLog(progress: {
+  restoredFromOffset: bigint;
+  appliedIndex: bigint;
+  highestRelevantWalletIndex: bigint;
+  isConnected: boolean;
+}): boolean {
+  return (
+    progress.restoredFromOffset > 0n &&
+    progress.appliedIndex <= progress.restoredFromOffset &&
+    progress.highestRelevantWalletIndex === 0n &&
+    !progress.isConnected
+  );
+}
+
 export interface DustSyncWithRetryOptions {
   networkUrls: Required<NetworkUrls>;
   seed: string;
@@ -602,10 +642,13 @@ export async function waitForDustFundsWithRetry(
   let dustSyncedState: any = null;
   let lastAppliedIndex = 0n;
   let attemptStartIndex = 0n;
+  /** Progress as of the last stall on this attempt; null if never read. */
+  let lastProgress: ReturnType<typeof dustProgressFromState> = null;
 
   for (let attempt = 1; attempt <= maxRetries; attempt++) {
     lastAppliedIndex = 0n;
     attemptStartIndex = 0n;
+    lastProgress = null;
     try {
       if (!walletResult) {
         const stateToRestore = inMemoryState ?? cachedState;
@@ -708,6 +751,7 @@ export async function waitForDustFundsWithRetry(
         // Update lastAppliedIndex so the stall handler knows progress was made
         // and preserves the in-memory state for the next retry.
         lastAppliedIndex = applied;
+        lastProgress = dustProgressFromState(currentState);
 
         log.info(
           `Dust sync attempt ${attempt}/${maxRetries} (${elapsedSec}s): ${applied}/${target} connected=${progress?.isConnected ?? "?"}`,
@@ -786,6 +830,30 @@ export async function waitForDustFundsWithRetry(
           `Dust sync attempt ${attempt}/${maxRetries} applied no new events ` +
             `(stuck at ${lastAppliedIndex}); refusing to persist that state.`,
         );
+      }
+
+      // A snapshot whose offset is past the indexer's log is not a stall to
+      // retry — retrying restores the same bytes and fails identically, five
+      // times, and (before this) re-persisted them each time. Throw it away and
+      // let the next attempt sync from genesis.
+      if (
+        isStall && lastProgress &&
+        isSnapshotOffsetPastLog({
+          restoredFromOffset: attemptStartIndex,
+          appliedIndex: lastProgress.appliedIndex,
+          highestRelevantWalletIndex: lastProgress.highestRelevantWalletIndex,
+          isConnected: lastProgress.isConnected,
+        })
+      ) {
+        log.error(
+          `Dust snapshot offset ${attemptStartIndex} is past the end of the indexer's ` +
+            `event log (no events delivered, never connected). The chain was reset, ` +
+            `rolled back or re-indexed. Discarding the snapshot and syncing from genesis.`,
+        );
+        discardSnapshot(`offset ${attemptStartIndex} past the indexer's event log`);
+        await stopWallet(walletResult);
+        walletResult = null;
+        if (attempt < maxRetries) continue;
       }
 
       if (isStall && attempt < maxRetries) {

--- a/packages/chains/midnight-contracts/src/get-wallet-info.ts
+++ b/packages/chains/midnight-contracts/src/get-wallet-info.ts
@@ -1,9 +1,42 @@
-// graphql-ws has a dangling promise in its subscribe flow: when a subscription ends,
-// the socket closes normally (code 1000) but the internal throwOnClose promise rejects
-// with no handler. In Bun, unhandled rejections crash the process (exit 1).
+// graphql-ws has a dangling promise in its subscribe flow: when a subscription
+// ends, the socket's `throwOnClose` promise rejects with no handler.
+// `dist/client.js:309-318` (6.2.1) does
+//   const [socket, release, waitForReleaseOrThrowOnClose] = await connect();
+//   if (done) return release();
+// and never awaits the `Promise.race([released, throwOnClose])` it was just
+// handed. In Bun, unhandled rejections crash the process (exit 1).
+//
+// The rejection reason is whatever the websocket last emitted: a `close` event
+// when the subscription ended gracefully, an `error` event when the socket died
+// first. Both are the SAME dangling promise, and neither is a reason to kill a
+// batcher — the wallet SDK's sync stream retries the subscription itself
+// (`RunningV1Variant.js`, `Stream.retry` with exponential backoff), and
+// `waitForDustFundsWithRetry` rebuilds the wallet from its last checkpoint when
+// the wallet goes quiet.
+//
+// Exempting only `close` is what Phase 3 §2.1 run 1 measured against live
+// preprod: a TLS handshake failure on the indexer socket exited the process
+// three minutes into a 58-minute cold sync — after the silence detector had
+// correctly fired and the checkpoint had correctly been written, and before
+// retry 2/5 could run. Every recovery path this project built was unreachable
+// behind it.
+//
+// A socket `error` is therefore reported to whoever is syncing (see
+// `onWalletSocketFailure`) instead of ending the process. Everything that is
+// NOT a socket lifecycle event keeps the old behaviour and still exits:
+// an unhandled rejection is a bug, and swallowing all of them to fix this one
+// would hide every other.
 if (globalThis.process?.versions?.bun) {
   process.on('unhandledRejection', (reason: unknown) => {
-    if (reason && typeof reason === 'object' && 'type' in reason && (reason as any).type === 'close') {
+    const socketEvent = classifyWalletSocketRejection(reason);
+    if (socketEvent === 'close') return;
+    if (socketEvent === 'error') {
+      console.warn(
+        `Indexer websocket failed (${describeWalletSocketRejection(reason)}). ` +
+          `The wallet SDK reconnects on its own; a dust sync in progress retries ` +
+          `from its last checkpoint.`,
+      );
+      reportWalletSocketFailure('error', reason);
       return;
     }
     console.error('Unhandled rejection:', reason);
@@ -744,6 +777,15 @@ export async function waitForDustFunds(
 const DUST_STALL_TIMEOUT_MS = 60_000;
 const DUST_MAX_RETRIES = 5;
 const DUST_COMPLETION_GAP = 50n;
+/**
+ * How long a dust sync attempt waits for a state emission after its indexer
+ * socket reported an error, before it counts as stalled.
+ *
+ * Long enough for the SDK's own reconnect (`Stream.retry`, exponential from
+ * 1 s) to land one, short enough that a dead socket does not cost the full
+ * 60 s silence budget.
+ */
+const DUST_SOCKET_FAILURE_GRACE_MS = 5_000;
 
 /**
  * Did this sync attempt move the wallet forward at all?
@@ -789,31 +831,140 @@ export function dustSyncAttemptMadeProgress(
  * `dispose()` must be called by whoever wins the race — otherwise a timer stays
  * armed on a wallet that already finished and its rejection surfaces as an
  * unhandled one.
+ *
+ * `nudge(ms)` is how a *known* failure (an indexer socket error) gets a say
+ * without a second detector: it re-arms the deadline shorter, so a socket we
+ * already know is dead does not get to burn the whole silence budget. It can
+ * only ever shorten, and the next emission restores the full budget — because
+ * the SDK's sync stream retries on its own, and a blip that recovers must cost
+ * nothing. Five blips that each cost an attempt would exhaust the retry budget
+ * across a 58-minute cold sync and fail init, which is the failure this project
+ * spent Phase 2 removing.
  */
+/** A websocket lifecycle event escaping graphql-ws's dangling promise. */
+export type WalletSocketEventKind = "close" | "error";
+
+export interface WalletSocketFailure {
+  kind: WalletSocketEventKind;
+  reason: unknown;
+}
+
+/**
+ * Is this rejection the indexer websocket's own lifecycle event, or a real bug?
+ *
+ * Classified by **shape**, deliberately, never by message text: graphql-ws
+ * rejects with whatever the socket emitted, and which `WebSocket`
+ * implementation is in play decides what that object looks like. What is
+ * constant is that it is a DOM-style event — `{ type: "close", code, reason }`
+ * or `{ type: "error", message, error }` — and that a real `Error` is never
+ * one, so an application error that happens to carry a `type` field stays
+ * fatal. See the top-of-file handler for why the exemption exists at all.
+ */
+export function classifyWalletSocketRejection(reason: unknown): WalletSocketEventKind | null {
+  if (reason === null || typeof reason !== "object") return null;
+  if (reason instanceof Error) return null;
+  const type = (reason as { type?: unknown }).type;
+  return type === "close" || type === "error" ? type : null;
+}
+
+/** A one-line description of a socket event, for logs. */
+export function describeWalletSocketRejection(reason: unknown): string {
+  const r = reason as
+    | { message?: unknown; code?: unknown; reason?: unknown; type?: unknown }
+    | null
+    | undefined;
+  if (typeof r?.message === "string" && r.message !== "") return r.message;
+  if (r?.code !== undefined) {
+    const detail = typeof r.reason === "string" && r.reason !== "" ? ` ${r.reason}` : "";
+    return `code ${String(r.code)}${detail}`;
+  }
+  return String(r?.type ?? reason);
+}
+
+const walletSocketFailureListeners = new Set<(failure: WalletSocketFailure) => void>();
+
+/**
+ * Listen for indexer socket failures for as long as you are the one syncing;
+ * the returned function unsubscribes.
+ *
+ * This is the seam that replaces killing the process. The rejection arrives
+ * with no call stack leading back to the wallet whose socket died — it is a
+ * promise nobody awaited — so the wallet cannot be found from the failure and
+ * has to announce itself instead.
+ *
+ * With nobody listening a socket error is logged and dropped, which is the
+ * right steady-state behaviour: after init the SDK's own sync stream reconnects
+ * and there is no attempt to fail.
+ *
+ * Delivery is to **every** listener, and that is a limitation worth knowing
+ * rather than a design goal. The batcher initialises its fee wallets
+ * concurrently (`Promise.all` over the seeds in the balancing adapter), so
+ * several attempts listen at once, and one wallet's socket error nudges all of
+ * their deadlines. It cannot be narrowed here: the rejection has no wallet
+ * identity to route on. It is safe in practice — a syncing dust wallet emits
+ * constantly at the shipped batch knobs, so a healthy wallet's next emission
+ * restores its full budget within milliseconds; a wallet quiet enough for the
+ * nudge to bite would have stalled anyway, and its retry resumes from the
+ * checkpoint; and every one of these sockets points at the same indexer, so a
+ * failure there is rarely one wallet's alone.
+ */
+export function onWalletSocketFailure(listener: (failure: WalletSocketFailure) => void): () => void {
+  walletSocketFailureListeners.add(listener);
+  return () => {
+    walletSocketFailureListeners.delete(listener);
+  };
+}
+
+/** Deliver a socket failure to every listener; returns how many took it. */
+export function reportWalletSocketFailure(kind: WalletSocketEventKind, reason: unknown): number {
+  let delivered = 0;
+  for (const listener of [...walletSocketFailureListeners]) {
+    try {
+      listener({ kind, reason });
+      delivered++;
+    } catch (e) {
+      // This runs inside an unhandled-rejection handler. A throw escaping here
+      // is the exact failure mode the whole path exists to remove.
+      log.warn(
+        `Wallet socket failure listener threw: ${e instanceof Error ? e.message : String(e)}`,
+      );
+    }
+  }
+  return delivered;
+}
+
 export function rejectOnDustSyncSilence(
   state$: Rx.Observable<unknown>,
   silenceMs: number,
-): { promise: Promise<never>; dispose: () => void } {
+): { promise: Promise<never>; dispose: () => void; nudge: (ms: number) => void } {
   let timer: ReturnType<typeof setTimeout> | undefined;
   let subscription: Rx.Subscription | undefined;
+  let done = false;
   const dispose = (): void => {
+    done = true;
     if (timer !== undefined) clearTimeout(timer);
     timer = undefined;
     subscription?.unsubscribe();
     subscription = undefined;
   };
+  let arm: (ms: number) => void = () => {};
   const promise = new Promise<never>((_resolve, reject) => {
-    const rearm = (): void => {
+    arm = (ms: number): void => {
+      if (done) return;
       if (timer !== undefined) clearTimeout(timer);
       timer = setTimeout(() => {
         dispose();
         reject(new Error("stall"));
-      }, silenceMs);
+      }, ms);
     };
-    rearm();
-    subscription = state$.subscribe({ next: rearm });
+    arm(silenceMs);
+    subscription = state$.subscribe({ next: () => arm(silenceMs) });
   });
-  return { promise, dispose };
+  return {
+    promise,
+    dispose,
+    nudge: (ms: number) => arm(Math.min(Math.max(0, ms), silenceMs)),
+  };
 }
 
 /**
@@ -862,6 +1013,21 @@ export interface DustSyncWithRetryOptions {
   networkId: NetworkId.NetworkId;
   /** Per-emission stall timeout in ms. Default: 60_000 (1 minute). */
   stallTimeoutMs?: number;
+  /**
+   * Grace period after an indexer socket error before the attempt counts as
+   * stalled. Default: {@link DUST_SOCKET_FAILURE_GRACE_MS} (5 s). Only ever
+   * shortens the stall deadline, and a state emission restores it in full.
+   */
+  socketFailureGraceMs?: number;
+  /**
+   * Override for {@link buildWalletFacade}.
+   *
+   * Exists so the retry loop can be driven without a chain: the property that
+   * matters after a socket failure is that the *next attempt is built*, and
+   * every other seam in this function ends at a real wallet facade. Production
+   * callers should leave it alone.
+   */
+  buildWallet?: typeof buildWalletFacade;
   /**
    * How long to wait for a non-zero façade dust balance after dust sync.
    * Default: {@link resolveWalletFundingTimeoutMs} (not `stallTimeoutMs`, and
@@ -933,6 +1099,8 @@ export async function waitForDustFundsWithRetry(
     seed,
     networkId,
     stallTimeoutMs = DUST_STALL_TIMEOUT_MS,
+    socketFailureGraceMs = DUST_SOCKET_FAILURE_GRACE_MS,
+    buildWallet = buildWalletFacade,
     balanceWaitTimeoutMs = resolveWalletFundingTimeoutMs(),
     maxRetries = DUST_MAX_RETRIES,
     throttleMs = CONSTANTS.WALLET_SYNC_THROTTLE_MS,
@@ -1040,6 +1208,23 @@ export async function waitForDustFundsWithRetry(
     attemptStartIndex = 0n;
     lastProgress = null;
     let progressSub: Rx.Subscription | undefined;
+    /** The silence detector guarding this attempt's wait, while it is waiting. */
+    let activeSilence: { nudge: (ms: number) => void } | null = null;
+    // A dead indexer socket used to end the process before this loop could
+    // retry (Phase 3 §2.1 run 1). It is now delivered here instead: the attempt
+    // stops waiting out the full silence budget for a socket that already
+    // failed, and if the SDK reconnects, the next emission restores the budget
+    // and the nudge costs nothing.
+    const offSocketFailure = onWalletSocketFailure((failure) => {
+      if (failure.kind !== "error") return;
+      log.warn(
+        `Dust sync attempt ${attempt}/${maxRetries}: indexer websocket failed ` +
+          `(${describeWalletSocketRejection(failure.reason)}). Allowing ` +
+          `${socketFailureGraceMs}ms for another state emission before treating ` +
+          `this attempt as stalled.`,
+      );
+      activeSilence?.nudge(socketFailureGraceMs);
+    });
     try {
       if (!walletResult) {
         const stateToRestore = inMemoryState ?? cachedState;
@@ -1058,7 +1243,7 @@ export async function waitForDustFundsWithRetry(
         } else if (stateToRestore) {
           log.info("Building wallet from cached dust state...");
         }
-        walletResult = await buildWalletFacade(
+        walletResult = await buildWallet(
           networkUrls,
           seed,
           networkId,
@@ -1119,12 +1304,14 @@ export async function waitForDustFundsWithRetry(
             dustWallet.state as Rx.Observable<unknown>,
             stallTimeoutMs,
           );
+          activeSilence = silence;
           try {
             dustSyncedState = await Promise.race([
               dustWallet.waitForSyncedState(DUST_COMPLETION_GAP),
               silence.promise,
             ]);
           } finally {
+            activeSilence = null;
             silence.dispose();
           }
         } else {
@@ -1323,7 +1510,10 @@ export async function waitForDustFundsWithRetry(
     } finally {
       // Per attempt: the next one rebuilds the wallet, and a subscription left
       // on a stopped facade both leaks and reports progress that stopped being
-      // this wallet's.
+      // this wallet's. The socket listener goes the same way — a stale one
+      // would nudge a later attempt's detector on behalf of a wallet that no
+      // longer exists.
+      offSocketFailure();
       progressSub?.unsubscribe();
     }
   }

--- a/packages/chains/midnight-contracts/src/get-wallet-info.ts
+++ b/packages/chains/midnight-contracts/src/get-wallet-info.ts
@@ -475,6 +475,54 @@ export function dustSyncAttemptMadeProgress(
 }
 
 /**
+ * Reject with `stall` once the wallet has gone `silenceMs` without emitting a
+ * state — the deadline is rearmed by every emission.
+ *
+ * This replaces a flat `setTimeout(stallTimeoutMs)` raced against
+ * `waitForSyncedState`, which was an absolute deadline on reaching *synced*,
+ * not on the wallet going quiet. With the 60 s default and 5 retries that
+ * capped total sync at ~5 minutes, against a measured 66-minute preprod cold
+ * sync — so a perfectly healthy sync was declared stalled, five times, and
+ * wallet init threw. Restarting did not converge either: each attempt only
+ * advanced the snapshot by ~60 s of sync.
+ *
+ * Silence is the signal that actually means "stuck": with
+ * `MIDNIGHT_DUST_SYNC_BATCH_SIZE` at 100 and a 1 ms batch timeout, a syncing
+ * dust wallet emits constantly, and a wallet whose subscription died emits
+ * nothing at all (Phase 1 §2's offset-past-log probe: one emission, then
+ * 45 s of nothing).
+ *
+ * `dispose()` must be called by whoever wins the race — otherwise a timer stays
+ * armed on a wallet that already finished and its rejection surfaces as an
+ * unhandled one.
+ */
+export function rejectOnDustSyncSilence(
+  state$: Rx.Observable<unknown>,
+  silenceMs: number,
+): { promise: Promise<never>; dispose: () => void } {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let subscription: Rx.Subscription | undefined;
+  const dispose = (): void => {
+    if (timer !== undefined) clearTimeout(timer);
+    timer = undefined;
+    subscription?.unsubscribe();
+    subscription = undefined;
+  };
+  const promise = new Promise<never>((_resolve, reject) => {
+    const rearm = (): void => {
+      if (timer !== undefined) clearTimeout(timer);
+      timer = setTimeout(() => {
+        dispose();
+        reject(new Error("stall"));
+      }, silenceMs);
+    };
+    rearm();
+    subscription = state$.subscribe({ next: rearm });
+  });
+  return { promise, dispose };
+}
+
+/**
  * Is this a well-formed snapshot whose `offset` sits past the end of the
  * indexer's event log? Then it is not a stall to retry — it is a snapshot to
  * throw away.
@@ -702,12 +750,20 @@ export async function waitForDustFundsWithRetry(
       const syncStartedAt = Date.now();
       try {
         if (typeof dustWallet.waitForSyncedState === "function") {
-          dustSyncedState = await Promise.race([
-            dustWallet.waitForSyncedState(DUST_COMPLETION_GAP),
-            new Promise<never>((_, reject) =>
-              setTimeout(() => reject(new Error("stall")), stallTimeoutMs)
-            ),
-          ]);
+          // Silence, not elapsed time: a long cold sync emits constantly and
+          // must be allowed to finish, however many hours it takes.
+          const silence = rejectOnDustSyncSilence(
+            dustWallet.state as Rx.Observable<unknown>,
+            stallTimeoutMs,
+          );
+          try {
+            dustSyncedState = await Promise.race([
+              dustWallet.waitForSyncedState(DUST_COMPLETION_GAP),
+              silence.promise,
+            ]);
+          } finally {
+            silence.dispose();
+          }
         } else {
           // Fallback: RxJS pipeline for SDK versions without waitForSyncedState
     

--- a/packages/chains/midnight-contracts/src/get-wallet-info.ts
+++ b/packages/chains/midnight-contracts/src/get-wallet-info.ts
@@ -86,18 +86,52 @@ function deriveSeedForRole(seed: string, role: DerivationRole): Uint8Array {
 // Wallet Configuration
 // ============================================================================
 
-/**
- * Resolve sync timeout from env or default.
- */
-export function resolveWalletSyncTimeoutMs(): number {
-  const envValue = getEnv("MIDNIGHT_WALLET_SYNC_TIMEOUT_MS");
-  if (!envValue) return CONSTANTS.WALLET_SYNC_TIMEOUT_MS;
+function resolveTimeoutMsEnv(name: string, fallbackMs: number): number {
+  const envValue = getEnv(name);
+  if (!envValue) return fallbackMs;
   const parsed = Number(envValue);
   if (Number.isFinite(parsed) && parsed > 0) return parsed;
-  log.warn(
-    `Invalid MIDNIGHT_WALLET_SYNC_TIMEOUT_MS="${envValue}", using default ${CONSTANTS.WALLET_SYNC_TIMEOUT_MS}ms`
+  log.warn(`Invalid ${name}="${envValue}", using default ${fallbackMs}ms`);
+  return fallbackMs;
+}
+
+/**
+ * How long a wallet may spend replaying the chain.
+ * `MIDNIGHT_WALLET_SYNC_TIMEOUT_MS`, default
+ * {@link CONSTANTS.WALLET_SYNC_TIMEOUT_MS} (4 h — a preprod dust cold sync
+ * measures ~66 min).
+ */
+export function resolveWalletSyncTimeoutMs(): number {
+  return resolveTimeoutMsEnv(
+    "MIDNIGHT_WALLET_SYNC_TIMEOUT_MS",
+    CONSTANTS.WALLET_SYNC_TIMEOUT_MS,
   );
-  return CONSTANTS.WALLET_SYNC_TIMEOUT_MS;
+}
+
+/**
+ * How long to wait for funds to arrive once the wallet is synced.
+ * `MIDNIGHT_WALLET_FUNDING_TIMEOUT_MS`, default
+ * {@link CONSTANTS.WALLET_FUNDING_TIMEOUT_MS} (10 min). Kept off the sync
+ * budget so an unfunded wallet fails in minutes instead of inheriting hours.
+ */
+export function resolveWalletFundingTimeoutMs(): number {
+  return resolveTimeoutMsEnv(
+    "MIDNIGHT_WALLET_FUNDING_TIMEOUT_MS",
+    CONSTANTS.WALLET_FUNDING_TIMEOUT_MS,
+  );
+}
+
+/**
+ * Deadline for {@link registerNightForDust}'s sync precheck.
+ * `MIDNIGHT_DUST_REGISTRATION_PRECHECK_TIMEOUT_MS`, default
+ * {@link CONSTANTS.DUST_REGISTRATION_PRECHECK_TIMEOUT_MS} (10 min). In
+ * dust-only mode the wait can never succeed, so it must stay small.
+ */
+export function resolveDustRegistrationPrecheckTimeoutMs(): number {
+  return resolveTimeoutMsEnv(
+    "MIDNIGHT_DUST_REGISTRATION_PRECHECK_TIMEOUT_MS",
+    CONSTANTS.DUST_REGISTRATION_PRECHECK_TIMEOUT_MS,
+  );
 }
 
 /**
@@ -570,7 +604,8 @@ export interface DustSyncWithRetryOptions {
   stallTimeoutMs?: number;
   /**
    * How long to wait for a non-zero façade dust balance after dust sync.
-   * Default: {@link resolveWalletSyncTimeoutMs} (not `stallTimeoutMs`).
+   * Default: {@link resolveWalletFundingTimeoutMs} (not `stallTimeoutMs`, and
+   * deliberately not the sync timeout — see the constant's docstring).
    */
   balanceWaitTimeoutMs?: number;
   /** Maximum retry attempts on stall. Default: 5. */
@@ -603,7 +638,7 @@ export async function waitForDustFundsWithRetry(
     seed,
     networkId,
     stallTimeoutMs = DUST_STALL_TIMEOUT_MS,
-    balanceWaitTimeoutMs = resolveWalletSyncTimeoutMs(),
+    balanceWaitTimeoutMs = resolveWalletFundingTimeoutMs(),
     maxRetries = DUST_MAX_RETRIES,
     throttleMs = CONSTANTS.WALLET_SYNC_THROTTLE_MS,
     syncMode = 'dust-only',
@@ -1215,10 +1250,10 @@ export function getInitialUnshieldedState(
 export interface RegisterNightForDustOptions {
   /**
    * Override for the wait-for-sync precheck timeout. The default
-   * (`resolveWalletSyncTimeoutMs()`, 10 min) is correct when the wallet has
-   * an active unshielded subscription. Callers that built the wallet with
-   * `syncMode: 'dust-only'` should pass a small value (e.g. 30s) — the
-   * unshielded sync is stopped, so this wait can never succeed and the
+   * ({@link resolveDustRegistrationPrecheckTimeoutMs}, 10 min) is correct when
+   * the wallet has an active unshielded subscription. Callers that built the
+   * wallet with `syncMode: 'dust-only'` should pass a small value (e.g. 30s) —
+   * the unshielded sync is stopped, so this wait can never succeed and the
    * full timeout is wasted.
    */
   precheckSyncTimeoutMs?: number;
@@ -1227,6 +1262,13 @@ export interface RegisterNightForDustOptions {
 /**
  * Register unshielded Night UTXOs for dust generation
  * This is required before the wallet can pay transaction fees
+ *
+ * Returns false on every failure, including a precheck timeout. That last one
+ * used to escape as an exception because the precheck sat outside the
+ * function's own try/catch — one failure mode out of several behaving
+ * differently from the boolean the signature promises, so callers that trusted
+ * the return value skipped their handling for exactly the case a stopped
+ * unshielded sub-wallet produces.
  */
 export async function registerNightForDust(
   walletResult: WalletResult,
@@ -1234,32 +1276,32 @@ export async function registerNightForDust(
 ): Promise<boolean> {
   log.info("Checking for unshielded Night UTXOs to register for dust generation...");
 
-  const state = await Rx.firstValueFrom(
-    walletResult.wallet.state().pipe(
-      Rx.filter((s: any) => {
-        const dustSynced = s.dust?.state?.progress?.isStrictlyComplete() ?? false;
-        const unshieldedSynced = s.unshielded?.progress?.isStrictlyComplete() ?? false;
-        return dustSynced && unshieldedSynced;
-      }),
-      Rx.timeout({
-        each: options?.precheckSyncTimeoutMs ?? resolveWalletSyncTimeoutMs(),
-        with: () => Rx.throwError(() => new Error("Timeout waiting for unshielded+dust sync for dust registration")),
-      })
-    )
-  );
-
-  const unregisteredNightUtxos =
-    (state as any).unshielded?.availableCoins?.filter((coin: any) => coin.meta.registeredForDustGeneration === false) ?? [];
-
-  if (unregisteredNightUtxos.length === 0) {
-    log.info("No unregistered unshielded Night UTXOs available.");
-    const dustBalance = await waitForDustFunds(walletResult.wallet, { timeoutMs: 5000 });
-    return dustBalance > 0n;
-  }
-
-  log.info(`Found ${unregisteredNightUtxos.length} unregistered Night UTXOs. Registering for dust...`);
-
   try {
+    const state = await Rx.firstValueFrom(
+      walletResult.wallet.state().pipe(
+        Rx.filter((s: any) => {
+          const dustSynced = s.dust?.state?.progress?.isStrictlyComplete() ?? false;
+          const unshieldedSynced = s.unshielded?.progress?.isStrictlyComplete() ?? false;
+          return dustSynced && unshieldedSynced;
+        }),
+        Rx.timeout({
+          each: options?.precheckSyncTimeoutMs ?? resolveDustRegistrationPrecheckTimeoutMs(),
+          with: () => Rx.throwError(() => new Error("Timeout waiting for unshielded+dust sync for dust registration")),
+        })
+      )
+    );
+
+    const unregisteredNightUtxos =
+      (state as any).unshielded?.availableCoins?.filter((coin: any) => coin.meta.registeredForDustGeneration === false) ?? [];
+
+    if (unregisteredNightUtxos.length === 0) {
+      log.info("No unregistered unshielded Night UTXOs available.");
+      const dustBalance = await waitForDustFunds(walletResult.wallet, { timeoutMs: 5000 });
+      return dustBalance > 0n;
+    }
+
+    log.info(`Found ${unregisteredNightUtxos.length} unregistered Night UTXOs. Registering for dust...`);
+
     const recipe = await (walletResult.wallet as any).registerNightUtxosForDustGeneration(
       unregisteredNightUtxos,
       walletResult.unshieldedKeystore.getPublicKey(),
@@ -1275,7 +1317,7 @@ export async function registerNightForDust(
     log.info("Waiting for dust to be generated...");
     await waitForDustFunds(walletResult.wallet, {
       waitNonZero: true,
-      timeoutMs: resolveWalletSyncTimeoutMs(),
+      timeoutMs: resolveWalletFundingTimeoutMs(),
     });
 
     log.info("Dust registration complete!");

--- a/packages/chains/midnight-contracts/src/get-wallet-info.ts
+++ b/packages/chains/midnight-contracts/src/get-wallet-info.ts
@@ -324,6 +324,71 @@ export function resolveFacadeDustBalance(
   return w > b ? w : b;
 }
 
+export interface DustCoinValues {
+  /** Generated value of each available dust coin, in Specks. */
+  values: bigint[];
+  /** False when the values are the state's own stale reading rather than a projection at `at`. */
+  liveClock: boolean;
+}
+
+/**
+ * Read each available dust coin's generated value **projected at `at`**, not at
+ * the wallet's `syncTime`.
+ *
+ * `DustWalletState.availableCoins` takes no time argument, so `resolveTime`
+ * (`CoinsAndBalances.ts:105`) falls back to `state.state.syncTime` — which only
+ * advances when a dust event is applied. Phase 1 §2 measured a fully synced
+ * wallet reporting a syncTime 377 days behind wall clock on a quiet chain.
+ * Since dust generation is a projection from `ctime`, reading it at that clock
+ * under-reports it, and the batcher's spendability gate can then mark a wallet
+ * exhausted while spendable dust exists.
+ *
+ * The SDK treats this as a known hazard rather than an edge case:
+ * `waitForGeneratedDust` (`DustWallet.ts:443-458`) re-reads a clock every
+ * second precisely so the projection advances. The capability underneath takes
+ * the time as a parameter, so this asks it for the value now.
+ *
+ * Falls back to the stale getter — and says so — when the capability is absent
+ * or throws. A projection failure must never read as "this wallet has no
+ * dust": that flips the capacity gate off for the whole batcher.
+ */
+export function resolveDustCoinValuesAt(dustState: unknown, at: Date): DustCoinValues {
+  const toValues = (coins: unknown): bigint[] =>
+    Array.isArray(coins)
+      ? coins.map((c) => {
+        try {
+          return BigInt((c as { generatedNow?: bigint | string })?.generatedNow ?? 0);
+        } catch {
+          return 0n;
+        }
+      })
+      : [];
+
+  const s = dustState as {
+    state?: unknown;
+    availableCoins?: unknown;
+    capabilities?: {
+      coinsAndBalances?: {
+        getAvailableCoins?: (state: unknown, time?: Date) => unknown;
+      };
+    };
+  } | null | undefined;
+
+  const getAvailableCoins = s?.capabilities?.coinsAndBalances?.getAvailableCoins;
+  if (typeof getAvailableCoins === "function" && s?.state !== undefined) {
+    try {
+      return { values: toValues(getAvailableCoins(s.state, at)), liveClock: true };
+    } catch (e) {
+      log.warn(
+        `Dust generation could not be projected at wall clock (${
+          e instanceof Error ? e.message : String(e)
+        }); falling back to the wallet's last sync time.`,
+      );
+    }
+  }
+  return { values: toValues(s?.availableCoins), liveClock: false };
+}
+
 function resolveDustHeartbeatPollMs(waitNonZero: boolean, override?: number): number {
   if (override !== undefined) return Math.max(0, Math.floor(override));
   if (!waitNonZero) return 0;

--- a/packages/chains/midnight-contracts/src/get-wallet-info.ts
+++ b/packages/chains/midnight-contracts/src/get-wallet-info.ts
@@ -54,7 +54,26 @@ import { getEnv, args as getArgs, exit, isNotFoundError } from "@effectstream/ut
 // static re-export would pull node:fs right back into the browser graph.
 // ============================================================================
 
-const DEFAULT_DUST_STATE_DIR = "dust-state";
+/** Where dust snapshots live, relative to CWD, unless a caller says otherwise. */
+export const DEFAULT_DUST_STATE_DIR = "dust-state";
+
+/**
+ * How often a running wallet checkpoints its dust state.
+ * `MIDNIGHT_DUST_STATE_SAVE_INTERVAL_MS`, default 5 minutes; 0 disables
+ * periodic saving (shutdown saves still happen).
+ *
+ * Before this existed, dust state was written at exactly three places, all
+ * inside `waitForDustFundsWithRetry`, all during init (Phase 1 §1) — so the
+ * snapshot never advanced after startup and a week of uptime meant a week of
+ * replay on restart. The interval bounds how much replay a crash costs; the
+ * cost of shortening it is one serialize + fsync of a snapshot that is
+ * megabytes on a real network, on the same event loop the wallet syncs on.
+ */
+export function resolveDustStateSaveIntervalMs(): number {
+  const raw = getEnv("MIDNIGHT_DUST_STATE_SAVE_INTERVAL_MS");
+  if (raw === "0") return 0;
+  return resolveTimeoutMsEnv("MIDNIGHT_DUST_STATE_SAVE_INTERVAL_MS", 300_000);
+}
 
 // ============================================================================
 // Key Derivation
@@ -80,6 +99,132 @@ function deriveSeedForRole(seed: string, role: DerivationRole): Uint8Array {
   }
 
   return Buffer.from(derivationResult.key);
+}
+
+/**
+ * The dust public key a seed's wallet will have — the same value the wallet
+ * writes into `publicKey.publicKey` when it serializes.
+ *
+ * Verified against the SDK 2026-08-17: a dust wallet started from
+ * `deriveSeedForRole(seed, Roles.Dust)` serializes exactly this key. It lets
+ * the persistence layer check that a seed-keyed snapshot file really belongs to
+ * that seed's wallet, which the file name (a hash of the seed) cannot: the
+ * balancing adapter's injected-wallet path pairs a wallet built by someone else
+ * with the seed the adapter was constructed with, and nothing enforced that
+ * they match.
+ */
+export function deriveDustPublicKey(seed: string): bigint {
+  return DustSecretKey.fromSeed(deriveSeedForRole(seed, Roles.Dust)).publicKey;
+}
+
+/** Anything that can hand us a serialized dust snapshot — i.e. `wallet.dust`. */
+export interface SerializableDustWallet {
+  serializeState: () => Promise<string>;
+}
+
+export interface DustStateAutosaveOptions {
+  networkId: string;
+  /** Seed this wallet was derived from; keys the snapshot file. */
+  seed: string;
+  /** Default: {@link DEFAULT_DUST_STATE_DIR}. */
+  dustStateDir?: string;
+  /** Default: {@link resolveDustStateSaveIntervalMs}. 0 disables the timer. */
+  intervalMs?: number;
+  /** Prefix for log lines, e.g. `"Wallet 2/5"`. */
+  label?: string;
+}
+
+export interface DustStateAutosaveHandle {
+  /** Checkpoint now. Concurrent calls share the in-flight save. */
+  saveNow(): Promise<string | null>;
+  /** Stop the timer and take one final checkpoint. Idempotent. */
+  stop(): Promise<string | null>;
+}
+
+/**
+ * Keep a running wallet's dust snapshot advancing, and take a final one at
+ * shutdown.
+ *
+ * Phase 1 §1 found dust state was written at exactly three places, all inside
+ * `waitForDustFundsWithRetry`, all during init: nothing periodic, nothing on
+ * shutdown (`close()` stopped wallets without saving), and nothing at all on
+ * the adapter's injected-wallet path. A week of uptime therefore left a
+ * week-old snapshot and a restart replayed a week of chain — the incident this
+ * project exists for.
+ *
+ * Takes the dust sub-wallet rather than a `WalletResult` so it can be driven by
+ * anything that serializes, which is what makes the cadence testable at all.
+ */
+export function startDustStateAutosave(
+  dustWallet: SerializableDustWallet,
+  options: DustStateAutosaveOptions,
+): DustStateAutosaveHandle {
+  const intervalMs = options.intervalMs ?? resolveDustStateSaveIntervalMs();
+  const dustStateDir = options.dustStateDir ?? DEFAULT_DUST_STATE_DIR;
+  const label = options.label ? `${options.label}: ` : "";
+  const expectedPublicKey = (() => {
+    try {
+      return deriveDustPublicKey(options.seed).toString();
+    } catch {
+      // A seed we cannot derive from is a caller error, not a reason to stop
+      // checkpointing — the network-id and offset guards still apply.
+      return undefined;
+    }
+  })();
+
+  let timer: ReturnType<typeof setInterval> | undefined;
+  let inFlight: Promise<string | null> | null = null;
+  let stopped = false;
+
+  async function persist(): Promise<string | null> {
+    try {
+      const serialized = await dustWallet.serializeState();
+      const { saveDustState } = await import("./dust-state.ts");
+      return saveDustState(dustStateDir, options.networkId, options.seed, serialized, {
+        expectedPublicKey,
+      });
+    } catch (e) {
+      // One bad checkpoint must not stop the next one: the wallet is mid-sync
+      // and transient serialization failures are expected.
+      log.warn(
+        `${label}dust state checkpoint failed: ${e instanceof Error ? e.message : String(e)}`,
+      );
+      return null;
+    }
+  }
+
+  function saveNow(): Promise<string | null> {
+    // Never stack saves. A preprod snapshot is large enough that a serialize
+    // can outlast the interval, and queueing one per tick would pile work onto
+    // the same event loop the wallet syncs on.
+    if (inFlight) return inFlight;
+    const run = persist().finally(() => {
+      inFlight = null;
+    });
+    inFlight = run;
+    return run;
+  }
+
+  if (intervalMs > 0) {
+    timer = setInterval(() => {
+      if (!stopped) void saveNow();
+    }, intervalMs);
+    // A checkpoint timer must never be the reason a process stays alive.
+    (timer as unknown as { unref?: () => void }).unref?.();
+  }
+
+  return {
+    saveNow,
+    async stop(): Promise<string | null> {
+      if (stopped) return null;
+      stopped = true;
+      if (timer !== undefined) clearInterval(timer);
+      // Let an in-flight save finish, then take a fresh one: the last state is
+      // the whole reason to save at shutdown.
+      if (inFlight) await inFlight.catch(() => null);
+      return persist();
+    },
+  };
 }
 
 // ============================================================================
@@ -660,9 +805,16 @@ export async function waitForDustFundsWithRetry(
 
   // Pre-load cached state from disk before building any wallet.
   // Uses seed-based path so we don't need the dust address yet.
-  // `loadDustState` already refuses anything malformed or from another network,
-  // so a non-null value here is at worst *stale*, never unparseable.
-  let cachedState: string | null = loadDustState(dustStateDir, networkIdStr, seed);
+  // `loadDustState` already refuses anything malformed, from another network,
+  // or belonging to another wallet, so a non-null value here is at worst
+  // *stale*, never unparseable.
+  const persistOptions = { expectedPublicKey: deriveDustPublicKey(seed).toString() };
+  let cachedState: string | null = loadDustState(
+    dustStateDir,
+    networkIdStr,
+    seed,
+    persistOptions,
+  );
   if (cachedState) {
     log.info(`Loaded cached dust state from disk (${getDustStatePath(dustStateDir, networkIdStr, seed)})`);
   }
@@ -688,7 +840,7 @@ export async function waitForDustFundsWithRetry(
 
       const serialized: string = await (wr.wallet as any).dust.serializeState();
       inMemoryState = serialized;
-      saveDustState(dustStateDir, networkIdStr, seed, serialized);
+      saveDustState(dustStateDir, networkIdStr, seed, serialized, persistOptions);
       return serialized;
     } catch (e) {
       log.warn(`Failed to serialize dust state: ${e instanceof Error ? e.message : String(e)}`);

--- a/packages/chains/midnight-contracts/src/get-wallet-info.ts
+++ b/packages/chains/midnight-contracts/src/get-wallet-info.ts
@@ -422,7 +422,8 @@ function dustWalletStateWithHeartbeat(
   ]).pipe(Rx.map(([s]) => s));
 }
 
-function dustProgressFromState(ds: unknown): {
+/** Pull sync progress out of a dust state emission, whatever shape it arrives in. */
+export function dustProgressFromState(ds: unknown): {
   appliedIndex: bigint;
   highestRelevantWalletIndex: bigint;
   isConnected: boolean;
@@ -825,6 +826,27 @@ export interface DustSyncWithRetryOptions {
   syncMode?: WalletSyncMode;
   /** Base directory for dust state files (relative to CWD). Default: "dust-state". */
   dustStateDir?: string;
+  /**
+   * Called (throttled) with each sync-progress sample while the wallet catches
+   * up. Init is the window where the difference between "syncing" and "stuck"
+   * matters most and is least visible — a preprod cold sync takes ~66 minutes,
+   * during which the caller otherwise knows only that the wallet is not ready
+   * yet.
+   */
+  onSyncProgress?: (sample: DustSyncProgressSample) => void;
+}
+
+/** One throttled observation of a dust wallet catching up. */
+export interface DustSyncProgressSample {
+  /** 1-based retry attempt this sample came from. */
+  attempt: number;
+  /** Offset this attempt resumed from; 0 for a cold sync. */
+  restoredFromOffset: bigint;
+  appliedIndex: bigint;
+  highestRelevantWalletIndex: bigint;
+  isConnected: boolean;
+  /** True once a snapshot has been rejected and this wallet is cold-syncing. */
+  snapshotRejected: boolean;
 }
 
 /**
@@ -853,6 +875,7 @@ export async function waitForDustFundsWithRetry(
     throttleMs = CONSTANTS.WALLET_SYNC_THROTTLE_MS,
     syncMode = 'dust-only',
     dustStateDir = DEFAULT_DUST_STATE_DIR,
+    onSyncProgress,
   } = options;
 
   const networkIdStr = String(networkId);
@@ -891,8 +914,10 @@ export async function waitForDustFundsWithRetry(
    * into the same failure — otherwise the cold sync we just paid for is
    * repeated on every start.
    */
+  let snapshotRejected = false;
   function discardSnapshot(reason: string): void {
     inMemoryState = null;
+    snapshotRejected = true;
     if (cachedState) {
       cachedState = null;
       quarantineDustState(dustStateDir, networkIdStr, seed, reason);
@@ -949,6 +974,7 @@ export async function waitForDustFundsWithRetry(
     lastAppliedIndex = 0n;
     attemptStartIndex = 0n;
     lastProgress = null;
+    let progressSub: Rx.Subscription | undefined;
     try {
       if (!walletResult) {
         const stateToRestore = inMemoryState ?? cachedState;
@@ -992,6 +1018,26 @@ export async function waitForDustFundsWithRetry(
       if (!dustWallet || !dustWallet.state) {
         log.warn("Dust wallet state not available; skipping dust sync.");
         return { walletResult, dustBalance: 0n };
+      }
+
+      // Report progress while the wallet catches up. Init is the window where
+      // "syncing" and "stuck" look identical from outside and where the
+      // difference is measured in hours.
+      if (onSyncProgress) {
+        progressSub = (dustWallet.state as Rx.Observable<unknown>)
+          .pipe(Rx.throttleTime(1_000, undefined, { leading: true, trailing: true }))
+          .subscribe((ds) => {
+            const p = dustProgressFromState(ds);
+            if (!p) return;
+            onSyncProgress({
+              attempt,
+              restoredFromOffset: attemptStartIndex,
+              appliedIndex: p.appliedIndex,
+              highestRelevantWalletIndex: p.highestRelevantWalletIndex,
+              isConnected: p.isConnected,
+              snapshotRejected,
+            });
+          });
       }
 
       // First, try the SDK's built-in waitForSyncedState with DUST_COMPLETION_GAP.
@@ -1192,6 +1238,11 @@ export async function waitForDustFundsWithRetry(
         );
       }
       throw e;
+    } finally {
+      // Per attempt: the next one rebuilds the wallet, and a subscription left
+      // on a stopped facade both leaks and reports progress that stopped being
+      // this wallet's.
+      progressSub?.unsubscribe();
     }
   }
 

--- a/packages/chains/midnight-contracts/src/mod.ts
+++ b/packages/chains/midnight-contracts/src/mod.ts
@@ -9,6 +9,7 @@ export type {
 export {
     DEFAULT_DUST_STATE_DIR,
     deriveDustPublicKey,
+    dustProgressFromState,
     resolveDustCoinValuesAt,
     resolveDustRegistrationPrecheckTimeoutMs,
     resolveDustStateSaveIntervalMs,

--- a/packages/chains/midnight-contracts/src/mod.ts
+++ b/packages/chains/midnight-contracts/src/mod.ts
@@ -9,6 +9,7 @@ export type {
 export {
     DEFAULT_DUST_STATE_DIR,
     deriveDustPublicKey,
+    resolveDustCoinValuesAt,
     resolveDustRegistrationPrecheckTimeoutMs,
     resolveDustStateSaveIntervalMs,
     resolveWalletFundingTimeoutMs,

--- a/packages/chains/midnight-contracts/src/mod.ts
+++ b/packages/chains/midnight-contracts/src/mod.ts
@@ -7,7 +7,13 @@ export type {
     InitialOwner,
 } from "./types.ts";
 export {
+    DEFAULT_DUST_STATE_DIR,
+    deriveDustPublicKey,
+    resolveDustRegistrationPrecheckTimeoutMs,
+    resolveDustStateSaveIntervalMs,
+    resolveWalletFundingTimeoutMs,
     resolveWalletSyncTimeoutMs,
+    startDustStateAutosave,
     suspendAuxWalletSyncForFees,
     resolveFacadeDustBalance,
     safeStringifyProgress,
@@ -27,6 +33,9 @@ export { saveDustState, loadDustState } from "./dust-state.ts";
 export type {
     WalletSyncMode,
     DustSyncWithRetryOptions,
+    DustStateAutosaveHandle,
+    DustStateAutosaveOptions,
+    SerializableDustWallet,
 } from "./get-wallet-info.ts";
 export { CONSTANTS } from "./constants.ts";
 export { 

--- a/packages/chains/midnight-contracts/src/mod.ts
+++ b/packages/chains/midnight-contracts/src/mod.ts
@@ -26,6 +26,7 @@ export {
     getInitialDustState,
     waitForDustFunds,
     waitForDustFundsWithRetry,
+    waitForShieldedSyncComplete,
 } from "./get-wallet-info.ts";
 // Disk-backed dust persistence lives in its own node-only module so the
 // browser-reachable ./wallet-info subpath carries no node:fs. This barrel is

--- a/packages/chains/midnight-contracts/test/README-dust-restore-harness.md
+++ b/packages/chains/midnight-contracts/test/README-dust-restore-harness.md
@@ -1,0 +1,70 @@
+# dust-restore-harness
+
+Measures what a batcher restart actually costs: how far a restored dust wallet
+resumes, how many indexer events it must replay, and how stale its dust
+projection is. Written for project 00009 Phase 1; kept because Phase 3 needs
+the same numbers against preprod, where they are finally meaningful.
+
+## Why it bypasses `waitForDustFundsWithRetry`
+
+That function takes **one** `networkId` and hands it to both the wallet facade
+and the persistence layer. Those two want different values on a local stack:
+
+- the wallet must be `undeployed`, because the node bakes that id into every
+  transaction — an indexer configured for any other id refuses to ingest
+  blocks at all and exits (`invalid network ID - expect 'testnet' found
+  'undeployed'`, verified 2026-08-17);
+- the persistence layer must **not** be `undeployed`, because
+  `saveDustState`/`loadDustState` no-op on it by design (`dust-state.ts:55`,
+  `:83`) so chain resets cannot resurrect stale state.
+
+So the batcher's real restore path is unreachable on any local stack. The
+harness splits the two ids instead. That is sound because dust sync is
+network-id-independent: `wallet-sdk-dust-wallet@4.2.0` `src/v1/Sync.ts:271-303`
+subscribes to `dustLedgerEvents` with an id cursor and no address or network
+argument, and the wallet filters events locally by secret key. Network id
+affects only address encoding and the value stored in `CoreWallet.networkId`.
+
+**What it therefore measures is the SDK's restore semantics, not the batcher
+wrapper's.** Wrapper behaviour is covered by the call-site inventory in
+`plans/00009-phase1-brief.md` §1 and by `test/dust-state.test.ts`.
+
+## Running
+
+Needs a node + indexer. Docker only, random host ports above 10000 — this is a
+shared machine and a **native** `midnight-node` owned by another project holds
+9944/30333. Check with `ss -ltn | grep -E ':9944|:30333'` before starting
+anything, and never run the orchestrator's `launchMidnight`: its
+`stopProcessAtPort: [9944, 8088, 6300, 30333]` would kill that node.
+
+```bash
+bun test/dust-restore-harness.ts cold      # ignore any snapshot, sync from 0, save
+bun test/dust-restore-harness.ts restore   # restore the snapshot, measure the resume
+bun test/dust-restore-harness.ts inspect   # dump snapshot shape without the state blob
+```
+
+| Env var | Default | Notes |
+| --- | --- | --- |
+| `HARNESS_INDEXER` / `HARNESS_INDEXER_WS` | `127.0.0.1:38223` | point at preprod for real numbers |
+| `HARNESS_NODE` / `HARNESS_PROOF` | `127.0.0.1:42521` / `47925` | |
+| `HARNESS_WALLET_NETWORK_ID` | `undeployed` | must match the chain |
+| `HARNESS_PERSIST_NETWORK_ID` | `harness-named` | must **not** be `undeployed` |
+| `HARNESS_SEED` | dev seed `…0001` | |
+| `HARNESS_STATE_DIR` | `/tmp/es00009-dust-state` | |
+| `HARNESS_SETTLE_MS` | `20000` | raise a lot for a real network |
+| `HARNESS_COMPLETION_GAP` | `50` | matches `DUST_COMPLETION_GAP` |
+
+## Reading the output
+
+`eventsReplayed` is the headline: `finalAppliedIndex - resumedAppliedIndex`.
+A working restore makes it ~0; a full replay makes it the whole log.
+`syncTime` vs `wallClockNow` exposes the `generatedNow` projection gap — the
+dust values the batcher's spendability gate sees are computed at `syncTime`,
+which advances only when a dust event is applied.
+
+Wall-clock (`syncMs`) is only meaningful on a chain with a long dust-event
+log. A local dev chain has **128** dust events total and does not grow with
+blocks (they come from the genesis `DistributeNight` transactions; dust
+generation is a projection, not a per-block event), so local timings are
+dominated by socket and Effect-runtime startup. Timing and the sync-knob sweep
+belong on preprod.

--- a/packages/chains/midnight-contracts/test/dust-autosave.test.ts
+++ b/packages/chains/midnight-contracts/test/dust-autosave.test.ts
@@ -1,0 +1,165 @@
+// The snapshot has to keep advancing while the batcher runs.
+//
+// Phase 1 §1 mapped every write of dust state: three call sites, all inside
+// `waitForDustFundsWithRetry`, all during init. Nothing periodic, nothing on
+// shutdown — `close()` stops the wallets without saving — and the injected-
+// wallet path (adapter:1136-1148) never persisted at all. So a week of uptime
+// left a week-old snapshot, and the restart replayed a week of chain. That is
+// the incident this project started from.
+//
+// Phase 1 deliberately shipped no test for it: there was no seam to inject
+// into, and a test written against an imagined API would have pinned a design
+// rather than a defect. These ride with the commit that creates the seam.
+//
+// Intervals here are milliseconds; the production default is minutes.
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { loadDustState } from "../src/dust-state.ts";
+import { startDustStateAutosave } from "../src/get-wallet-info.ts";
+
+const SEED = "0000000000000000000000000000000000000000000000000000000000000001";
+const PUBLIC_KEY =
+  "11886380015789543296729785856017363359697744265386149017101029008360306658047";
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+/** A dust wallet that advances one event per serialization. */
+function fakeDustWallet(): { serializeState: () => Promise<string>; calls: () => number } {
+  let offset = 0;
+  let calls = 0;
+  return {
+    serializeState: async () => {
+      calls++;
+      offset += 1;
+      return JSON.stringify({
+        publicKey: { publicKey: PUBLIC_KEY },
+        state: "ab".repeat(64),
+        protocolVersion: "0",
+        networkId: "preprod",
+        offset: String(offset),
+      });
+    },
+    calls: () => calls,
+  };
+}
+
+const offsetOnDisk = (dir: string): string | null => {
+  const raw = loadDustState(dir, "preprod", SEED, { expectedPublicKey: PUBLIC_KEY });
+  return raw ? String(JSON.parse(raw).offset) : null;
+};
+
+let dir: string;
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), "es00009-dust-autosave-"));
+});
+afterEach(() => {
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe("dust state autosave", () => {
+  test("the snapshot keeps advancing while the wallet runs", async () => {
+    const wallet = fakeDustWallet();
+    const autosave = startDustStateAutosave(wallet, {
+      networkId: "preprod",
+      seed: SEED,
+      dustStateDir: dir,
+      intervalMs: 25,
+    });
+    await sleep(130);
+    await autosave.stop();
+
+    expect(wallet.calls()).toBeGreaterThan(2);
+    expect(Number(offsetOnDisk(dir))).toBeGreaterThan(2);
+  });
+
+  test("stopping saves once more — shutdown must not drop the last minutes", async () => {
+    const wallet = fakeDustWallet();
+    const autosave = startDustStateAutosave(wallet, {
+      networkId: "preprod",
+      seed: SEED,
+      dustStateDir: dir,
+      // No periodic saving at all: the final save is the only one, which is
+      // exactly the close()-without-a-timer case.
+      intervalMs: 0,
+    });
+    expect(offsetOnDisk(dir)).toBeNull();
+
+    await autosave.stop();
+    expect(offsetOnDisk(dir)).toEqual("1");
+  });
+
+  test("a stopped autosave never writes again", async () => {
+    const wallet = fakeDustWallet();
+    const autosave = startDustStateAutosave(wallet, {
+      networkId: "preprod",
+      seed: SEED,
+      dustStateDir: dir,
+      intervalMs: 20,
+    });
+    await autosave.stop();
+    const after = wallet.calls();
+    await sleep(100);
+    // A timer left armed on a stopped wallet serializes state from a facade
+    // that is being torn down, and keeps the process alive.
+    expect(wallet.calls()).toEqual(after);
+  });
+
+  test("a save that throws does not kill the loop", async () => {
+    let calls = 0;
+    const flaky = {
+      serializeState: async () => {
+        calls++;
+        if (calls < 3) throw new Error("wallet busy");
+        return JSON.stringify({
+          publicKey: { publicKey: PUBLIC_KEY },
+          state: "ab".repeat(64),
+          protocolVersion: "0",
+          networkId: "preprod",
+          offset: "77",
+        });
+      },
+    };
+    const autosave = startDustStateAutosave(flaky, {
+      networkId: "preprod",
+      seed: SEED,
+      dustStateDir: dir,
+      intervalMs: 20,
+    });
+    await sleep(130);
+    await autosave.stop();
+    expect(offsetOnDisk(dir)).toEqual("77");
+  });
+
+  test("saves do not stack up behind a slow one", async () => {
+    let started = 0;
+    const slow = {
+      serializeState: async () => {
+        started++;
+        await sleep(120);
+        return JSON.stringify({
+          publicKey: { publicKey: PUBLIC_KEY },
+          state: "ab".repeat(64),
+          protocolVersion: "0",
+          networkId: "preprod",
+          offset: String(started),
+        });
+      },
+    };
+    const autosave = startDustStateAutosave(slow, {
+      networkId: "preprod",
+      seed: SEED,
+      dustStateDir: dir,
+      intervalMs: 10,
+    });
+    await sleep(100);
+    // Ten ticks fired while the first serialization was still running. A
+    // multi-megabyte preprod snapshot takes real time; queueing one save per
+    // tick behind it would pile up work on the same event loop the wallet
+    // syncs on.
+    expect(started).toEqual(1);
+    await autosave.stop();
+  });
+});

--- a/packages/chains/midnight-contracts/test/dust-live-clock.test.ts
+++ b/packages/chains/midnight-contracts/test/dust-live-clock.test.ts
@@ -1,0 +1,93 @@
+// Dust generation is a projection from a timestamp, so reading it at the wrong
+// clock reads the wrong number.
+//
+// `DustWalletState.availableCoins` takes no time argument: `resolveTime`
+// (CoinsAndBalances.ts:105) falls back to `state.state.syncTime`, which only
+// advances when a dust EVENT is applied. Phase 1 §2 measured a fully synced
+// wallet whose syncTime was 377 days behind wall clock on a quiet chain. The
+// batcher's spendability gate read `generatedNow` straight off that getter, so
+// on a quiet chain or during a dust-event lull it under-reports generated dust
+// and can mark a wallet exhausted while spendable dust exists.
+//
+// The SDK does not have this problem by accident: `waitForGeneratedDust`
+// (DustWallet.ts:443-458) documents that "the projection only advances because
+// the time is re-read each tick" and drives it from a 1 s clock. The capability
+// underneath takes the time as a parameter —
+// `CoinsAndBalancesCapability.getAvailableCoins(state, time?)` — which is what
+// this reads instead.
+
+import { describe, expect, test } from "bun:test";
+import { resolveDustCoinValuesAt } from "../src/get-wallet-info.ts";
+
+/** A dust state shaped like the SDK's: stale getter, time-aware capability. */
+function dustStateAt(syncTimeValue: bigint) {
+  return {
+    state: { marker: "core-wallet" },
+    // What the no-argument getter would return: the value at syncTime.
+    availableCoins: [{ generatedNow: syncTimeValue }, { generatedNow: syncTimeValue }],
+    capabilities: {
+      coinsAndBalances: {
+        getAvailableCoins: (state: unknown, time?: Date) => {
+          expect(state).toEqual({ marker: "core-wallet" });
+          const value = time === undefined ? syncTimeValue : BigInt(time.getTime());
+          return [{ generatedNow: value }, { generatedNow: value * 2n }];
+        },
+      },
+    },
+  };
+}
+
+describe("dust coin values are read at a live clock", () => {
+  test("values are projected at the requested time, not at syncTime", () => {
+    const at = new Date(1_700_000_000_000);
+    const read = resolveDustCoinValuesAt(dustStateAt(0n), at);
+    expect(read.values).toEqual([1_700_000_000_000n, 3_400_000_000_000n]);
+    expect(read.liveClock).toBe(true);
+  });
+
+  test("a state with no time-aware capability falls back and says so", () => {
+    // Reporting the fallback matters: the gate is then reading a possibly
+    // stale number, and an operator should be able to see that in health info
+    // rather than infer it from a wallet that looks starved.
+    const read = resolveDustCoinValuesAt(
+      { availableCoins: [{ generatedNow: 7n }] },
+      new Date(1_700_000_000_000),
+    );
+    expect(read.values).toEqual([7n]);
+    expect(read.liveClock).toBe(false);
+  });
+
+  test("coin values survive the SDK's bigint-as-string serialization", () => {
+    const read = resolveDustCoinValuesAt(
+      { availableCoins: [{ generatedNow: "12345" }, {}] },
+      new Date(),
+    );
+    expect(read.values).toEqual([12345n, 0n]);
+  });
+
+  test("a wallet with no coins reads as empty, not as an error", () => {
+    expect(resolveDustCoinValuesAt({}, new Date()).values).toEqual([]);
+    expect(resolveDustCoinValuesAt(null, new Date()).values).toEqual([]);
+  });
+
+  test("a capability that throws degrades to the stale getter", () => {
+    // Never let a projection failure look like "this wallet has no dust" —
+    // that would flip the capacity gate off for the whole batcher.
+    const read = resolveDustCoinValuesAt(
+      {
+        state: {},
+        availableCoins: [{ generatedNow: 99n }],
+        capabilities: {
+          coinsAndBalances: {
+            getAvailableCoins: () => {
+              throw new Error("wasm boom");
+            },
+          },
+        },
+      },
+      new Date(),
+    );
+    expect(read.values).toEqual([99n]);
+    expect(read.liveClock).toBe(false);
+  });
+});

--- a/packages/chains/midnight-contracts/test/dust-persist-progress.test.ts
+++ b/packages/chains/midnight-contracts/test/dust-persist-progress.test.ts
@@ -1,0 +1,36 @@
+// What a failed dust-sync attempt is allowed to write back, and when a
+// well-formed snapshot has to be thrown away.
+//
+// Phase 1 §2 measured the failure these pin down. A snapshot whose `offset` is
+// past the end of the indexer's event log leaves the wallet emitting exactly
+// once, `isConnected` false, `appliedIndex` frozen at the offset — hung past a
+// 45 s window. The batcher then re-saved that state on the stall path
+// (gwi:707) and again on final failure (gwi:721), and both `gwi:640` and
+// `gwi:712` require `appliedIndex === 0n` to escape, which a restored wallet
+// never satisfies. So all five retries re-restored the same unusable snapshot,
+// init failed after ~5 minutes, and the poisoned file outlived the process:
+// every restart repeated the outage until an operator deleted it by hand.
+
+import { describe, expect, test } from "bun:test";
+import { dustSyncAttemptMadeProgress } from "../src/get-wallet-info.ts";
+
+describe("a failed attempt may only persist state that moved forward", () => {
+  test("a wallet frozen at its restored offset is not worth persisting", () => {
+    // The measured poisoned case: restored at 999999, still at 999999.
+    expect(dustSyncAttemptMadeProgress(999_999n, 999_999n)).toBe(false);
+  });
+
+  test("a stalled but advancing sync IS worth persisting", () => {
+    // The checkpoint that makes stall-retry worth having: 128 -> 5000 means
+    // the next attempt resumes 4872 events further along.
+    expect(dustSyncAttemptMadeProgress(128n, 5_000n)).toBe(true);
+  });
+
+  test("a cold sync that never applied an event is not worth persisting", () => {
+    expect(dustSyncAttemptMadeProgress(0n, 0n)).toBe(false);
+  });
+
+  test("a backwards jump is never progress", () => {
+    expect(dustSyncAttemptMadeProgress(128n, 0n)).toBe(false);
+  });
+});

--- a/packages/chains/midnight-contracts/test/dust-restore-fallback.test.ts
+++ b/packages/chains/midnight-contracts/test/dust-restore-fallback.test.ts
@@ -1,0 +1,73 @@
+// A dust snapshot that the SDK cannot decode must cost a cold sync, never the
+// whole wallet.
+//
+// Phase 1 §2 measured both halves of this: truncating a snapshot made
+// `DustWallet.restore` throw `getOrThrow called on a Left` straight out of
+// buildWalletFacade, and `waitForDustFundsWithRetry` rethrew it without ever
+// rebuilding from scratch (gwi:701-730) — one bad file bricks wallet init
+// until an operator deletes it by hand. The same path catches a post-sdk-
+// upgrade decode failure (master-plan Q4), since the snapshot carries no
+// format version.
+//
+// The decision under test is deliberately separated from the SDK wiring: the
+// fallback must fire for a *decode* failure and nothing else. Wrapping the
+// whole facade build instead would also swallow indexer/network errors and
+// would throw away a perfectly good snapshot on a transient outage — a 66-min
+// preprod resync (master plan, first preprod measurements) for no reason.
+
+import { describe, expect, test } from "bun:test";
+import { restoreDustWalletWithColdSyncFallback } from "../src/get-wallet-info.ts";
+
+describe("dust restore — an unusable snapshot must cold-sync, not brick init", () => {
+  test("a snapshot that will not decode falls back to a cold start", () => {
+    const rejected: string[] = [];
+    const wallet = restoreDustWalletWithColdSyncFallback(
+      "corrupt-snapshot",
+      () => {
+        throw new Error("getOrThrow called on a Left");
+      },
+      () => "cold-start" as const,
+      (reason) => rejected.push(reason),
+    );
+
+    expect(wallet).toEqual("cold-start");
+    // The caller has to learn the snapshot was rejected — it is what moves the
+    // poisoned file aside so the next restart does not repeat the failure.
+    expect(rejected).toEqual(["getOrThrow called on a Left"]);
+  });
+
+  test("a usable snapshot is restored and never cold-starts", () => {
+    let coldStarts = 0;
+    const rejected: string[] = [];
+    const wallet = restoreDustWalletWithColdSyncFallback(
+      "good-snapshot",
+      (state) => `restored:${state}`,
+      () => {
+        coldStarts++;
+        return "cold-start";
+      },
+      (reason) => rejected.push(reason),
+    );
+
+    expect(wallet).toEqual("restored:good-snapshot");
+    expect(coldStarts).toEqual(0);
+    expect(rejected).toEqual([]);
+  });
+
+  test("no snapshot cold-starts without reporting a rejection", () => {
+    const rejected: string[] = [];
+    for (const empty of [null, undefined, ""]) {
+      expect(
+        restoreDustWalletWithColdSyncFallback(
+          empty,
+          () => "restored",
+          () => "cold-start",
+          (reason) => rejected.push(reason),
+        ),
+      ).toEqual("cold-start");
+    }
+    // Nothing was rejected here — there was nothing to reject. Reporting one
+    // would quarantine a file that is not at fault.
+    expect(rejected).toEqual([]);
+  });
+});

--- a/packages/chains/midnight-contracts/test/dust-restore-harness.ts
+++ b/packages/chains/midnight-contracts/test/dust-restore-harness.ts
@@ -1,0 +1,204 @@
+// 00009 Phase 1 — dust store/restore measurement harness.
+//
+// WHY THIS DOES NOT CALL `waitForDustFundsWithRetry`
+// --------------------------------------------------
+// That function takes ONE `networkId` and feeds it to both the wallet facade
+// and the persistence layer. On a local stack the wallet must be `undeployed`
+// (the node bakes that id into every transaction — an indexer configured for
+// any other id refuses to ingest blocks at all, verified 2026-08-17), and on
+// `undeployed` `saveDustState`/`loadDustState` deliberately no-op
+// (dust-state.ts:55,83). So the batcher's real restore path is unreachable
+// locally, full stop.
+//
+// The harness splits the two: the wallet gets `undeployed`, the persistence
+// layer gets a named string. That is sound because dust sync is
+// network-id-independent — `dust-wallet@4.2.0` `src/v1/Sync.ts:271-303`
+// subscribes to `dustLedgerEvents` with an id cursor and no address or
+// network argument, and the wallet filters events locally by secret key.
+// What it measures is therefore the SDK's restore semantics, not the
+// batcher wrapper's.
+//
+// Usage (see test/README-dust-restore-harness.md):
+//   bun test/dust-restore-harness.ts cold
+//   bun test/dust-restore-harness.ts restore
+import * as Rx from "rxjs";
+import type { NetworkId } from "@midnightntwrk/wallet-sdk-abstractions";
+import { buildWalletFacade } from "../src/get-wallet-info.ts";
+import { getDustStatePath, loadDustState, saveDustState } from "../src/dust-state.ts";
+
+const INDEXER = process.env.HARNESS_INDEXER ?? "http://127.0.0.1:38223/api/v4/graphql";
+const INDEXER_WS = process.env.HARNESS_INDEXER_WS ?? "ws://127.0.0.1:38223/api/v4/graphql/ws";
+const NODE = process.env.HARNESS_NODE ?? "http://127.0.0.1:42521";
+const PROOF = process.env.HARNESS_PROOF ?? "http://127.0.0.1:47925";
+// The wallet's network id must match the chain; the persistence key must not
+// be "undeployed" or every save/load silently no-ops. See header.
+const WALLET_NETWORK_ID = (process.env.HARNESS_WALLET_NETWORK_ID ?? "undeployed") as NetworkId.NetworkId;
+const PERSIST_NETWORK_ID = process.env.HARNESS_PERSIST_NETWORK_ID ?? "harness-named";
+const SEED = process.env.HARNESS_SEED ??
+  "0000000000000000000000000000000000000000000000000000000000000001";
+const STATE_DIR = process.env.HARNESS_STATE_DIR ?? "/tmp/es00009-dust-state";
+// Long enough to reach the tip of a 128-event local log many times over;
+// override upward when pointing at a real network.
+const SETTLE_MS = Number(process.env.HARNESS_SETTLE_MS ?? 20_000);
+// Stop early once the wallet reports complete — otherwise every run pays
+// SETTLE_MS in full.
+const COMPLETION_GAP = BigInt(process.env.HARNESS_COMPLETION_GAP ?? "50");
+
+type ProgressSample = {
+  atMs: number;
+  appliedIndex: string;
+  highestRelevantWalletIndex: string;
+  isConnected: boolean;
+  complete: boolean;
+};
+
+const bigintReplacer = (_k: string, v: unknown) => typeof v === "bigint" ? v.toString() : v;
+
+async function run(mode: "cold" | "restore" | "inspect"): Promise<void> {
+  const statePath = getDustStatePath(STATE_DIR, PERSIST_NETWORK_ID, SEED);
+
+  if (mode === "inspect") {
+    const raw = loadDustState(STATE_DIR, PERSIST_NETWORK_ID, SEED);
+    if (!raw) {
+      console.log(JSON.stringify({ mode, statePath, present: false }));
+      return;
+    }
+    // Report the snapshot's shape WITHOUT the state blob — it is megabytes of
+    // hex and the interesting part is which fields exist at all.
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    console.log(JSON.stringify({
+      mode,
+      statePath,
+      present: true,
+      bytes: raw.length,
+      fields: Object.keys(parsed).sort(),
+      offset: parsed.offset ?? null,
+      networkId: parsed.networkId ?? null,
+      protocolVersion: parsed.protocolVersion ?? null,
+      stateHexLen: typeof parsed.state === "string" ? parsed.state.length : null,
+    }, bigintReplacer));
+    return;
+  }
+
+  // `cold` deliberately ignores any snapshot on disk; `restore` requires one.
+  const cached = mode === "restore"
+    ? loadDustState(STATE_DIR, PERSIST_NETWORK_ID, SEED)
+    : null;
+  if (mode === "restore" && !cached) {
+    throw new Error(`restore mode needs a snapshot at ${statePath} — run \`cold\` first`);
+  }
+
+  const buildStartedAt = Date.now();
+  const walletResult = await buildWalletFacade(
+    { id: WALLET_NETWORK_ID, indexer: INDEXER, indexerWS: INDEXER_WS, node: NODE, proofServer: PROOF },
+    SEED,
+    WALLET_NETWORK_ID,
+    "dust-only",
+    cached,
+    // Keep the aux wallets alive exactly as waitForDustFundsWithRetry does
+    // for dust-only (gwi:567), so the harness does not accidentally measure a
+    // configuration the batcher never runs.
+    { stopAuxWalletsImmediately: false },
+  );
+  const builtAtMs = Date.now() - buildStartedAt;
+
+  const dust = (walletResult.wallet as { dust: { state: Rx.Observable<any> } }).dust;
+
+  // The FIRST emission after a restore is the resumed position before any new
+  // event is applied — that is the number that proves resume-vs-genesis.
+  const first = await Rx.firstValueFrom(dust.state);
+  const firstProgress = first?.state?.progress;
+  const resumedAppliedIndex = String(firstProgress?.appliedIndex ?? "?");
+
+  const samples: ProgressSample[] = [];
+  const syncStartedAt = Date.now();
+  let last: any = null;
+
+  await Rx.firstValueFrom(
+    (dust.state as Rx.Observable<any>).pipe(
+      Rx.tap((ds: any) => {
+        last = ds;
+        const p = ds?.state?.progress;
+        if (!p) return;
+        samples.push({
+          atMs: Date.now() - syncStartedAt,
+          appliedIndex: String(p.appliedIndex),
+          highestRelevantWalletIndex: String(p.highestRelevantWalletIndex),
+          isConnected: !!p.isConnected,
+          complete: typeof p.isCompleteWithin === "function"
+            ? p.isCompleteWithin(COMPLETION_GAP)
+            : false,
+        });
+      }),
+      Rx.filter((ds: any) =>
+        typeof ds?.state?.progress?.isCompleteWithin === "function" &&
+        ds.state.progress.isCompleteWithin(COMPLETION_GAP)
+      ),
+      // A wallet already at the tip of a quiet chain may never emit again, so
+      // the timeout is a normal outcome, not a failure.
+      Rx.timeout({ each: SETTLE_MS, with: () => Rx.of(null) }),
+    ),
+  );
+
+  const syncMs = Date.now() - syncStartedAt;
+  const finalProgress = last?.state?.progress;
+
+  // `availableCoins` takes NO time argument, so generatedNow is evaluated at
+  // DustLocalState.syncTime — the projection staleness this project is
+  // chasing. `balance(t)` DOES take a time, so evaluating it at syncTime and
+  // again at wall-clock now isolates the gap: same coins, two clocks.
+  const coins = (last?.availableCoins ?? []) as Array<{ generatedNow?: bigint }>;
+  const syncTime: Date | undefined = last?.state?.state?.syncTime;
+  const balanceAt = (t: Date): string => {
+    try {
+      const b = last?.balance?.(t);
+      // Balance is a token->amount map in the SDK; sum whatever it yields.
+      if (b == null) return "n/a";
+      const vals = b instanceof Map ? [...b.values()] : Object.values(b as Record<string, unknown>);
+      return String(vals.reduce((a: bigint, v) => a + (typeof v === "bigint" ? v : 0n), 0n));
+    } catch (e) {
+      return `err:${e instanceof Error ? e.message : String(e)}`;
+    }
+  };
+
+  const serialized: string = await (walletResult.wallet as any).dust.serializeState();
+  const savedTo = saveDustState(STATE_DIR, PERSIST_NETWORK_ID, SEED, serialized);
+
+  console.log(JSON.stringify({
+    mode,
+    statePath,
+    savedTo,
+    buildMs: builtAtMs,
+    syncMs,
+    resumedAppliedIndex,
+    finalAppliedIndex: String(finalProgress?.appliedIndex ?? "?"),
+    highestRelevantWalletIndex: String(finalProgress?.highestRelevantWalletIndex ?? "?"),
+    isConnected: !!finalProgress?.isConnected,
+    // The whole point: how many events this process had to apply.
+    eventsReplayed: String(
+      (finalProgress?.appliedIndex ?? 0n) - BigInt(resumedAppliedIndex === "?" ? 0 : resumedAppliedIndex),
+    ),
+    emissions: samples.length,
+    firstEmissions: samples.slice(0, 5),
+    dustCoins: coins.length,
+    // What the batcher's spendability gate actually sees (adapter:1462-1463).
+    dustGeneratedNowTotal: String(coins.reduce((a, c) => a + (c.generatedNow ?? 0n), 0n)),
+    // The projection gap, made explicit.
+    syncTime: syncTime instanceof Date ? syncTime.toISOString() : String(syncTime),
+    wallClockNow: new Date(Date.now()).toISOString(),
+    balanceAtSyncTime: syncTime instanceof Date ? balanceAt(syncTime) : "n/a",
+    balanceAtWallClock: balanceAt(new Date(Date.now())),
+    snapshotBytes: serialized.length,
+  }, bigintReplacer));
+
+  await walletResult.wallet.stop();
+}
+
+const mode = (process.argv[2] ?? "cold") as "cold" | "restore" | "inspect";
+if (!["cold", "restore", "inspect"].includes(mode)) {
+  throw new Error(`unknown mode ${mode} — use cold | restore | inspect`);
+}
+await run(mode);
+// The SDK keeps indexer sockets and Effect fibers alive past wallet.stop();
+// without this the harness hangs after printing its result.
+process.exit(0);

--- a/packages/chains/midnight-contracts/test/dust-restore-harness.ts
+++ b/packages/chains/midnight-contracts/test/dust-restore-harness.ts
@@ -18,10 +18,18 @@
 // What it measures is therefore the SDK's restore semantics, not the
 // batcher wrapper's.
 //
+// Phase 2 note: `saveDustState`/`loadDustState` now check that the snapshot's
+// own `networkId` matches the id they are keyed under, so the split above has
+// to be declared explicitly via `snapshotNetworkId` — the harness is the one
+// caller that legitimately wants them to differ. `HARNESS_BYPASS_VALIDATION=1`
+// reads the file with no checks at all, which is how you still hand a
+// deliberately-broken snapshot to `DustWallet.restore` and watch what it does.
+//
 // Usage (see test/README-dust-restore-harness.md):
 //   bun test/dust-restore-harness.ts cold
 //   bun test/dust-restore-harness.ts restore
 import * as Rx from "rxjs";
+import { readFileSync } from "node:fs";
 import type { NetworkId } from "@midnightntwrk/wallet-sdk-abstractions";
 import { buildWalletFacade } from "../src/get-wallet-info.ts";
 import { getDustStatePath, loadDustState, saveDustState } from "../src/dust-state.ts";
@@ -34,6 +42,10 @@ const PROOF = process.env.HARNESS_PROOF ?? "http://127.0.0.1:47925";
 // be "undeployed" or every save/load silently no-ops. See header.
 const WALLET_NETWORK_ID = (process.env.HARNESS_WALLET_NETWORK_ID ?? "undeployed") as NetworkId.NetworkId;
 const PERSIST_NETWORK_ID = process.env.HARNESS_PERSIST_NETWORK_ID ?? "harness-named";
+/** The wallet id the snapshot body carries; see header for why they differ. */
+const PERSIST_OPTIONS = { snapshotNetworkId: String(WALLET_NETWORK_ID) };
+/** Skip every validity check, to measure what a bad snapshot does to restore. */
+const BYPASS_VALIDATION = process.env.HARNESS_BYPASS_VALIDATION === "1";
 const SEED = process.env.HARNESS_SEED ??
   "0000000000000000000000000000000000000000000000000000000000000001";
 const STATE_DIR = process.env.HARNESS_STATE_DIR ?? "/tmp/es00009-dust-state";
@@ -56,9 +68,19 @@ const bigintReplacer = (_k: string, v: unknown) => typeof v === "bigint" ? v.toS
 
 async function run(mode: "cold" | "restore" | "inspect"): Promise<void> {
   const statePath = getDustStatePath(STATE_DIR, PERSIST_NETWORK_ID, SEED);
+  const readSnapshot = (): string | null => {
+    if (!BYPASS_VALIDATION) {
+      return loadDustState(STATE_DIR, PERSIST_NETWORK_ID, SEED, PERSIST_OPTIONS);
+    }
+    try {
+      return readFileSync(statePath, "utf-8");
+    } catch {
+      return null;
+    }
+  };
 
   if (mode === "inspect") {
-    const raw = loadDustState(STATE_DIR, PERSIST_NETWORK_ID, SEED);
+    const raw = readSnapshot();
     if (!raw) {
       console.log(JSON.stringify({ mode, statePath, present: false }));
       return;
@@ -81,9 +103,7 @@ async function run(mode: "cold" | "restore" | "inspect"): Promise<void> {
   }
 
   // `cold` deliberately ignores any snapshot on disk; `restore` requires one.
-  const cached = mode === "restore"
-    ? loadDustState(STATE_DIR, PERSIST_NETWORK_ID, SEED)
-    : null;
+  const cached = mode === "restore" ? readSnapshot() : null;
   if (mode === "restore" && !cached) {
     throw new Error(`restore mode needs a snapshot at ${statePath} — run \`cold\` first`);
   }
@@ -162,7 +182,13 @@ async function run(mode: "cold" | "restore" | "inspect"): Promise<void> {
   };
 
   const serialized: string = await (walletResult.wallet as any).dust.serializeState();
-  const savedTo = saveDustState(STATE_DIR, PERSIST_NETWORK_ID, SEED, serialized);
+  const savedTo = saveDustState(
+    STATE_DIR,
+    PERSIST_NETWORK_ID,
+    SEED,
+    serialized,
+    PERSIST_OPTIONS,
+  );
 
   console.log(JSON.stringify({
     mode,

--- a/packages/chains/midnight-contracts/test/dust-snapshot-recovery.test.ts
+++ b/packages/chains/midnight-contracts/test/dust-snapshot-recovery.test.ts
@@ -1,0 +1,86 @@
+// What a failed dust-sync attempt is allowed to write back, and when a
+// well-formed snapshot has to be thrown away.
+//
+// Phase 1 §2 measured the failure these pin down. A snapshot whose `offset` is
+// past the end of the indexer's event log leaves the wallet emitting exactly
+// once, `isConnected` false, `appliedIndex` frozen at the offset — hung past a
+// 45 s window. The batcher then re-saved that state on the stall path
+// (gwi:707) and again on final failure (gwi:721), and both `gwi:640` and
+// `gwi:712` require `appliedIndex === 0n` to escape, which a restored wallet
+// never satisfies. So all five retries re-restored the same unusable snapshot,
+// init failed after ~5 minutes, and the poisoned file outlived the process:
+// every restart repeated the outage until an operator deleted it by hand.
+
+import { describe, expect, test } from "bun:test";
+import { isSnapshotOffsetPastLog } from "../src/get-wallet-info.ts";
+
+describe("a snapshot whose offset is past the indexer's log must be discarded", () => {
+  // The measured signature, from §2: restored (so appliedIndex > 0), no
+  // progress at all this attempt, the wallet never reached `isConnected`, and
+  // the target index it is being compared against is still 0 because no event
+  // ever arrived to set one. Every clause is load-bearing — see the negative
+  // cases below.
+  test("no progress + never connected + nothing restored-past is the signature", () => {
+    expect(
+      isSnapshotOffsetPastLog({
+        restoredFromOffset: 999_999n,
+        appliedIndex: 999_999n,
+        highestRelevantWalletIndex: 0n,
+        isConnected: false,
+      }),
+    ).toBe(true);
+  });
+
+  test("a connected wallet is syncing, however slowly", () => {
+    // Connected means the subscription delivered something; the cursor is
+    // inside the log. Discarding here would throw away a good snapshot and buy
+    // a multi-hour resync for nothing.
+    expect(
+      isSnapshotOffsetPastLog({
+        restoredFromOffset: 999_999n,
+        appliedIndex: 999_999n,
+        highestRelevantWalletIndex: 1_000_500n,
+        isConnected: true,
+      }),
+    ).toBe(false);
+  });
+
+  test("a wallet that learned a target index has heard from the log", () => {
+    // `highestRelevantWalletIndex` only moves when the indexer delivered
+    // something, so a non-zero one means the cursor is inside the log even if
+    // the subscription has since dropped. A restored wallet that has heard
+    // nothing keeps the 0 that `CoreWallet.restore` gives it.
+    expect(
+      isSnapshotOffsetPastLog({
+        restoredFromOffset: 999_999n,
+        appliedIndex: 999_999n,
+        highestRelevantWalletIndex: 1_000_500n,
+        isConnected: false,
+      }),
+    ).toBe(false);
+  });
+
+  test("a wallet that applied even one event is not past the log", () => {
+    expect(
+      isSnapshotOffsetPastLog({
+        restoredFromOffset: 999_999n,
+        appliedIndex: 1_000_000n,
+        highestRelevantWalletIndex: 0n,
+        isConnected: false,
+      }),
+    ).toBe(false);
+  });
+
+  test("a cold sync that stalls is a stall, not a bad snapshot", () => {
+    // Nothing was restored, so there is no snapshot to blame and nothing to
+    // discard — this must stay an ordinary retry.
+    expect(
+      isSnapshotOffsetPastLog({
+        restoredFromOffset: 0n,
+        appliedIndex: 0n,
+        highestRelevantWalletIndex: 0n,
+        isConnected: false,
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/chains/midnight-contracts/test/dust-socket-error.test.ts
+++ b/packages/chains/midnight-contracts/test/dust-socket-error.test.ts
@@ -1,0 +1,318 @@
+// A dropped indexer websocket must not kill the batcher.
+//
+// Phase 3 §2.1 run 1, against live preprod, 3 minutes into a 58-minute cold
+// sync. Four mechanisms behaved correctly and the process died anyway:
+//
+//   1. the indexer websocket dropped (`TLS handshake failed`);
+//   2. Phase 2's silence detector (`c195c67e`) fired at ~60 s of no emissions;
+//   3. Phase 2's progress-gated save (`1f17a578`) wrote the checkpoint;
+//   4. retry 2/5 began — "rebuilding wallet from in-memory state";
+//   5. the discarded socket's `ErrorEvent` surfaced as an unhandled promise
+//      rejection and exited the process before the retry could run.
+//
+// So every recovery path this project built was unreachable behind one
+// transient socket failure. The escape route is a known defect in graphql-ws
+// 6.2.1: `subscribe()` does `const [socket, release, waitForRelease] = await
+// connect(); if (done) return release();` (`dist/client.js:309-318`), throwing
+// away a `Promise.race([..., throwOnClose])` that nobody then awaits. When the
+// subscription ends after the socket errored, that race rejects with the ws
+// `ErrorEvent` and there is no handler anywhere.
+//
+// This module's top-of-file handler already knew about the defect — it exempts
+// a rejection whose `type` is `"close"`, which is the *graceful* end of the
+// same dangling promise. It just never covered the case where the socket died
+// first, so `type === "error"` fell through to `process.exit(1)`.
+//
+// What these pin down:
+//   - the process survives a socket ErrorEvent, and still dies on a genuine
+//     unhandled rejection (the fix must be narrow, not a blanket swallow);
+//   - the classification is by socket-event shape, not by message text;
+//   - the failure is *delivered* to whoever is syncing rather than dropped;
+//   - delivery shortens the in-flight attempt's stall deadline instead of
+//     leaving it to wait out the full silence budget — and a socket that
+//     recovers costs nothing, because a later emission restores the budget;
+//   - the retry loop actually reaches attempt 2.
+//
+// Timings here are milliseconds; production is minutes.
+
+import { describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import * as Rx from "rxjs";
+import type { NetworkId } from "@midnightntwrk/wallet-sdk-abstractions";
+import {
+  classifyWalletSocketRejection,
+  onWalletSocketFailure,
+  reportWalletSocketFailure,
+  rejectOnDustSyncSilence,
+  waitForDustFundsWithRetry,
+} from "../src/get-wallet-info.ts";
+
+const MODULE_UNDER_TEST = path.join(import.meta.dir, "../src/get-wallet-info.ts");
+const SEED = "0000000000000000000000000000000000000000000000000000000000000001";
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+/**
+ * Run `body` in a child `bun` process that has imported this module, and
+ * report how it died.
+ *
+ * "The process survives" is not observable from inside the process — the
+ * defect is `process.exit(1)` — so the only honest test is a real child that
+ * creates a real unhandled rejection and is asked whether it is still there.
+ */
+async function runChild(body: string): Promise<{ code: number; stdout: string; stderr: string }> {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "es00009-socket-"));
+  const file = path.join(dir, "fixture.ts");
+  fs.writeFileSync(file, `import ${JSON.stringify(MODULE_UNDER_TEST)};\n${body}\n`);
+  try {
+    const proc = Bun.spawn(["bun", file], { stdout: "pipe", stderr: "pipe" });
+    const [stdout, stderr, code] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+    return { code, stdout, stderr };
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+/** The exact reason recorded in run 1's stderr, minus the seed-free prose. */
+const WS_ERROR_EVENT_LITERAL =
+  `{ type: "error", ` +
+  `message: "WebSocket connection to 'wss://indexer.example/api/v4/graphql/ws' failed: TLS handshake failed", ` +
+  `error: new Error("TLS handshake failed") }`;
+
+describe("a dropped indexer websocket does not kill the process", () => {
+  test("a socket ErrorEvent surfacing as an unhandled rejection is survivable", async () => {
+    const child = await runChild(
+      `Promise.reject(${WS_ERROR_EVENT_LITERAL});\n` +
+        `setTimeout(() => { console.log("SURVIVED"); process.exit(0); }, 500);`,
+    );
+    expect(child.stdout).toContain("SURVIVED");
+    expect(child.code).toBe(0);
+  }, 30_000);
+
+  test("a graceful socket close stays survivable", async () => {
+    // The case the original handler already covered; it must not regress.
+    const child = await runChild(
+      `Promise.reject({ type: "close", code: 1000, reason: "Normal Closure", wasClean: true });\n` +
+        `setTimeout(() => { console.log("SURVIVED"); process.exit(0); }, 500);`,
+    );
+    expect(child.stdout).toContain("SURVIVED");
+    expect(child.code).toBe(0);
+  }, 30_000);
+
+  test("an ordinary unhandled rejection is still fatal", async () => {
+    // The guard rail on the fix: a blanket `unhandledRejection` swallow would
+    // pass the two tests above and hide every real bug in the batcher.
+    const child = await runChild(
+      `Promise.reject(new Error("a genuine bug"));\n` +
+        `setTimeout(() => { console.log("SURVIVED"); process.exit(0); }, 500);`,
+    );
+    expect(child.stdout).not.toContain("SURVIVED");
+    expect(child.code).toBe(1);
+  }, 30_000);
+});
+
+describe("classifying a rejection as a wallet socket event", () => {
+  test("an ErrorEvent-shaped rejection is a socket error", () => {
+    expect(
+      classifyWalletSocketRejection({ type: "error", message: "TLS handshake failed" }),
+    ).toEqual("error");
+  });
+
+  test("a CloseEvent-shaped rejection is a socket close", () => {
+    expect(
+      classifyWalletSocketRejection({ type: "close", code: 1000, reason: "Normal Closure" }),
+    ).toEqual("close");
+  });
+
+  test("a plain Error is not a socket event", () => {
+    expect(classifyWalletSocketRejection(new Error("boom"))).toBeNull();
+  });
+
+  test("an Error that happens to carry type='error' is not a socket event", () => {
+    // Classification is by shape, and an `Error` is never a DOM event. Without
+    // this, any application error with a `type` field would be swallowed.
+    const e = Object.assign(new Error("boom"), { type: "error" });
+    expect(classifyWalletSocketRejection(e)).toBeNull();
+  });
+
+  test("neither primitives nor other event types are socket events", () => {
+    for (const reason of [null, undefined, "error", 7, { type: "message" }, { type: 1 }, []]) {
+      expect(classifyWalletSocketRejection(reason)).toBeNull();
+    }
+  });
+});
+
+// The registry is process-global, and `bun test` runs every file in one
+// process — other suites in this package drive `waitForDustFundsWithRetry`
+// against an unreachable indexer and leave their attempt listeners registered.
+// So delivery counts are asserted as deltas against a baseline rather than
+// absolutely, or these pass and fail by file ordering.
+const deliveryCount = (): number => reportWalletSocketFailure("error", { type: "error" });
+
+describe("a socket failure is delivered to whoever is syncing", () => {
+  test("a registered listener receives the failure", () => {
+    const baseline = deliveryCount();
+    const seen: string[] = [];
+    const off = onWalletSocketFailure((f) => seen.push(f.kind));
+    try {
+      expect(deliveryCount()).toEqual(baseline + 1);
+    } finally {
+      off();
+    }
+    expect(seen).toEqual(["error"]);
+  });
+
+  test("unsubscribing stops delivery", () => {
+    const baseline = deliveryCount();
+    let calls = 0;
+    const off = onWalletSocketFailure(() => calls++);
+    off();
+    expect(deliveryCount()).toEqual(baseline);
+    expect(calls).toEqual(0);
+  });
+
+  test("a listener that throws does not stop the others", () => {
+    // These run from an unhandled-rejection handler. A throw there would be
+    // the very failure mode this whole fix exists to remove.
+    let reached = false;
+    const offBad = onWalletSocketFailure(() => {
+      throw new Error("listener bug");
+    });
+    const offGood = onWalletSocketFailure(() => {
+      reached = true;
+    });
+    try {
+      expect(() => deliveryCount()).not.toThrow();
+    } finally {
+      offBad();
+      offGood();
+    }
+    expect(reached).toBe(true);
+  });
+
+  test("reporting is a no-op, not a throw", () => {
+    expect(() => deliveryCount()).not.toThrow();
+  });
+});
+
+describe("a socket failure shortens the stall deadline it cannot escape", () => {
+  test("a nudged detector stalls on the short grace, not the full budget", async () => {
+    const { promise, nudge } = rejectOnDustSyncSilence(new Rx.Subject<unknown>(), 30_000);
+    const startedAt = Date.now();
+    nudge(40);
+    await expect(promise).rejects.toThrow("stall");
+    // The point of routing the error in at all: a socket we know is dead does
+    // not get to burn the full silence budget (60 s in production).
+    expect(Date.now() - startedAt).toBeLessThan(5_000);
+  });
+
+  test("an emission after a nudge restores the full budget", async () => {
+    // The SDK's own sync stream retries with exponential backoff, so a socket
+    // blip that recovers must cost nothing — otherwise five blips across a
+    // 58-minute cold sync would exhaust the retry budget and fail init.
+    const state$ = new Rx.Subject<unknown>();
+    const { promise, nudge, dispose } = rejectOnDustSyncSilence(state$, 400);
+    let stalled = false;
+    void promise.catch(() => {
+      stalled = true;
+    });
+    nudge(30);
+    await sleep(10);
+    state$.next({ appliedIndex: 1n });
+    await sleep(120);
+    expect(stalled).toBe(false);
+    dispose();
+  });
+
+  test("a nudge cannot lengthen the deadline", async () => {
+    const { promise, nudge } = rejectOnDustSyncSilence(new Rx.Subject<unknown>(), 50);
+    nudge(60_000);
+    await expect(promise).rejects.toThrow("stall");
+  });
+
+  test("a nudge after dispose does nothing", async () => {
+    const { promise, nudge, dispose } = rejectOnDustSyncSilence(new Rx.Subject<unknown>(), 30_000);
+    let stalled = false;
+    void promise.catch(() => {
+      stalled = true;
+    });
+    dispose();
+    nudge(20);
+    await sleep(100);
+    expect(stalled).toBe(false);
+  });
+});
+
+describe("the retry machinery gets to run after a socket failure", () => {
+  test("attempt 2 is built after a socket failure kills attempt 1", async () => {
+    // Run 1's exact shape, without a chain: each attempt's wallet goes quiet
+    // and its socket reports an error. Before the fix the first report exited
+    // the process; the assertion that matters is that attempt 2 was built.
+    const syncedState = {
+      state: {
+        progress: {
+          appliedIndex: 5n,
+          highestRelevantWalletIndex: 100n,
+          isConnected: true,
+        },
+      },
+    };
+
+    const builds: number[] = [];
+    const buildWallet = async (): Promise<any> => {
+      builds.push(Date.now());
+      const state$ = new Rx.BehaviorSubject<unknown>(syncedState);
+      // A socket error arrives shortly after this attempt starts waiting —
+      // the same ordering as a live indexer dropping mid-sync.
+      setTimeout(() => {
+        reportWalletSocketFailure("error", {
+          type: "error",
+          message: "WebSocket connection failed: TLS handshake failed",
+        });
+      }, 60);
+      return {
+        wallet: {
+          dust: {
+            state: state$,
+            // Never settles — a dust sync that will not complete.
+            waitForSyncedState: () => new Promise(() => {}),
+            serializeState: async () => "{}",
+          },
+          stop: async () => {},
+        },
+      };
+    };
+
+    const startedAt = Date.now();
+    await expect(
+      waitForDustFundsWithRetry({
+        networkUrls: {
+          id: "undeployed" as NetworkId.NetworkId,
+          indexer: "http://127.0.0.1:1/api/v4/graphql",
+          indexerWS: "ws://127.0.0.1:1/api/v4/graphql/ws",
+          node: "http://127.0.0.1:1",
+          proofServer: "http://127.0.0.1:1",
+        },
+        seed: SEED,
+        // `undeployed` keeps persistence a no-op, so this touches no disk.
+        networkId: "undeployed" as NetworkId.NetworkId,
+        // Deliberately far longer than the test can take: if the socket
+        // failure were dropped, the attempts could only end by waiting this
+        // out, and the elapsed assertion below would fail.
+        stallTimeoutMs: 30_000,
+        socketFailureGraceMs: 40,
+        maxRetries: 2,
+        buildWallet,
+      }),
+    ).rejects.toThrow(/stalled after 2 attempts/);
+
+    expect(builds.length).toEqual(2);
+    expect(Date.now() - startedAt).toBeLessThan(10_000);
+  }, 30_000);
+});

--- a/packages/chains/midnight-contracts/test/dust-stall-detection.test.ts
+++ b/packages/chains/midnight-contracts/test/dust-stall-detection.test.ts
@@ -1,0 +1,75 @@
+// A dust sync that is working must never be called stalled.
+//
+// `waitForDustFundsWithRetry` raced `waitForSyncedState` against a plain
+// `setTimeout(stallTimeoutMs)` — an absolute deadline on reaching synced state,
+// not the "no new state emission within stallTimeoutMs" its own docstring
+// promises, and not what the RxJS fallback branch beside it does
+// (`Rx.timeout({ each: stallTimeoutMs })`).
+//
+// With DUST_STALL_TIMEOUT_MS = 60_000 and DUST_MAX_RETRIES = 5 that gave the
+// batcher a total sync budget of ~5 minutes. Preprod's dust cold sync was
+// measured at ~66 minutes (1.44 M indices, ~365 idx/s — master plan, first
+// preprod measurements), so every attempt "stalled" while syncing perfectly
+// normally and init threw. Persistence does not rescue it either: each attempt
+// only advances the snapshot by ~60 s of sync, so no number of restarts
+// converges.
+//
+// Timings here are milliseconds rather than minutes; the property is the same.
+
+import { describe, expect, test } from "bun:test";
+import * as Rx from "rxjs";
+import { rejectOnDustSyncSilence } from "../src/get-wallet-info.ts";
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+describe("stall detection watches for silence, not for elapsed time", () => {
+  test("a stream that never emits stalls", async () => {
+    const { promise } = rejectOnDustSyncSilence(new Rx.Subject<unknown>(), 60);
+    expect(promise).rejects.toThrow("stall");
+    await promise.catch(() => {});
+  });
+
+  test("a stream that keeps emitting does NOT stall past the timeout", async () => {
+    // The regression that matters: 300 ms of healthy progress under a 60 ms
+    // silence budget. The old flat deadline rejected at 60 ms regardless.
+    const state$ = new Rx.Subject<unknown>();
+    const { promise, dispose } = rejectOnDustSyncSilence(state$, 60);
+    let stalled = false;
+    void promise.catch(() => {
+      stalled = true;
+    });
+
+    for (let i = 0; i < 15; i++) {
+      await sleep(20);
+      state$.next({ appliedIndex: BigInt(i) });
+    }
+
+    expect(stalled).toBe(false);
+    dispose();
+  });
+
+  test("a stream that goes quiet after progress still stalls", async () => {
+    // The detector must not become a no-op: a subscription that dies mid-sync
+    // is exactly what retry-from-checkpoint exists for.
+    const state$ = new Rx.Subject<unknown>();
+    const { promise } = rejectOnDustSyncSilence(state$, 60);
+    state$.next({ appliedIndex: 1n });
+    await sleep(20);
+    state$.next({ appliedIndex: 2n });
+    expect(promise).rejects.toThrow("stall");
+    await promise.catch(() => {});
+  });
+
+  test("dispose stops the detector for good", async () => {
+    const { promise, dispose } = rejectOnDustSyncSilence(new Rx.Subject<unknown>(), 40);
+    let stalled = false;
+    void promise.catch(() => {
+      stalled = true;
+    });
+    dispose();
+    await sleep(100);
+    // Without this the winner of the race leaves a timer armed on a wallet it
+    // already finished with, and its rejection surfaces as an unhandled one.
+    expect(stalled).toBe(false);
+  });
+});

--- a/packages/chains/midnight-contracts/test/dust-state-identity.test.ts
+++ b/packages/chains/midnight-contracts/test/dust-state-identity.test.ts
@@ -1,0 +1,95 @@
+// A seed-keyed snapshot file must actually belong to that seed's dust wallet.
+//
+// The file name is `sha256(seed)`, but nothing checked that the snapshot inside
+// it came from that seed. Two ways that bites:
+//
+// - the balancing adapter's injected-wallet path takes a `walletResult` built
+//   by someone else and pairs it with the seed the adapter was constructed
+//   with. The convention is that they match (e2e builds both from the same
+//   seed), but nothing enforced it, and persisting under a mismatched key would
+//   hand a different wallet's dust state to a later restore;
+// - `DustWallet.restore` rebuilds the wallet from the snapshot's own key, while
+//   `wallet.start()` is then called with the seed's dust secret key. A mismatch
+//   there is not a clean failure.
+//
+// The snapshot records `publicKey.publicKey`, and that value is derivable from
+// the seed alone, so both sides can be checked. Verified against the SDK
+// 2026-08-17: a dust wallet started from seed 0x00…01 serializes exactly the
+// publicKey that DustSecretKey.fromSeed(deriveSeedForRole(seed, Roles.Dust))
+// produces — the constant below is that measured value, so this test also
+// pins the derivation itself. If an SDK upgrade changes it, this fails loudly
+// instead of silently disabling persistence.
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { getDustStatePath, loadDustState, saveDustState } from "../src/dust-state.ts";
+import { deriveDustPublicKey } from "../src/get-wallet-info.ts";
+
+const SEED_A = "0000000000000000000000000000000000000000000000000000000000000001";
+const SEED_B = "0000000000000000000000000000000000000000000000000000000000000002";
+/** Measured from the SDK for SEED_A — see header. */
+const SEED_A_DUST_PUBLIC_KEY =
+  "11886380015789543296729785856017363359697744265386149017101029008360306658047";
+
+const snapshot = (publicKey: string, offset = "128"): string =>
+  JSON.stringify({
+    publicKey: { publicKey },
+    state: "ab".repeat(64),
+    protocolVersion: "0",
+    networkId: "preprod",
+    offset,
+  });
+
+let dir: string;
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), "es00009-dust-identity-"));
+});
+afterEach(() => {
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe("dust snapshot identity", () => {
+  test("the dust public key is derivable from the seed alone", () => {
+    expect(deriveDustPublicKey(SEED_A).toString()).toEqual(SEED_A_DUST_PUBLIC_KEY);
+    expect(deriveDustPublicKey(SEED_B).toString()).not.toEqual(SEED_A_DUST_PUBLIC_KEY);
+  });
+
+  test("a snapshot from another wallet is not loaded for this seed", () => {
+    fs.writeFileSync(
+      getDustStatePath(dir, "preprod", SEED_A),
+      snapshot(deriveDustPublicKey(SEED_B).toString()),
+      "utf-8",
+    );
+    expect(
+      loadDustState(dir, "preprod", SEED_A, {
+        expectedPublicKey: deriveDustPublicKey(SEED_A).toString(),
+      }),
+    ).toBeNull();
+  });
+
+  test("a snapshot from another wallet is not saved under this seed", () => {
+    expect(
+      saveDustState(dir, "preprod", SEED_A, snapshot(deriveDustPublicKey(SEED_B).toString()), {
+        expectedPublicKey: deriveDustPublicKey(SEED_A).toString(),
+      }),
+    ).toBeNull();
+    expect(fs.readdirSync(dir)).toEqual([]);
+  });
+
+  test("the wallet's own snapshot still round-trips", () => {
+    const options = { expectedPublicKey: SEED_A_DUST_PUBLIC_KEY };
+    expect(
+      saveDustState(dir, "preprod", SEED_A, snapshot(SEED_A_DUST_PUBLIC_KEY), options),
+    ).not.toBeNull();
+    expect(loadDustState(dir, "preprod", SEED_A, options)).not.toBeNull();
+  });
+
+  test("callers that pass no expectation are not gated on identity", () => {
+    // The check costs a key derivation, so it stays opt-in at the persistence
+    // layer; every caller inside this package opts in.
+    saveDustState(dir, "preprod", SEED_A, snapshot(deriveDustPublicKey(SEED_B).toString()));
+    expect(loadDustState(dir, "preprod", SEED_A)).not.toBeNull();
+  });
+});

--- a/packages/chains/midnight-contracts/test/dust-state.test.ts
+++ b/packages/chains/midnight-contracts/test/dust-state.test.ts
@@ -1,0 +1,133 @@
+// Dust-state persistence: what must hold, and what Phase 1 proved does not.
+//
+// The suite is split deliberately. The CHARACTERIZATION block pins behaviour
+// that exists today and must survive Phase 2 — the `undeployed` no-op in
+// particular is load-bearing (chain resets invalidate cached state) and easy
+// to delete by accident while adding a validity guard. The RED block pins
+// behaviour Phase 1 measured to be missing; those tests fail on this branch
+// on purpose and are the Phase 2 acceptance criteria.
+//
+// Evidence for every RED case is in plans/00009-phase1-brief.md §2 —
+// each was reproduced against a live local stack, not inferred.
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { getDustStatePath, loadDustState, saveDustState } from "../src/dust-state.ts";
+
+const SEED_A = "0000000000000000000000000000000000000000000000000000000000000001";
+const SEED_B = "0000000000000000000000000000000000000000000000000000000000000002";
+
+/** A snapshot in the exact shape wallet-sdk-dust-wallet@4.2.0 writes. */
+const snapshot = (over: Partial<Record<string, unknown>> = {}): string =>
+  JSON.stringify({
+    publicKey: { publicKey: "123" },
+    state: "ab".repeat(64),
+    protocolVersion: "0",
+    networkId: "preprod",
+    offset: "128",
+    ...over,
+  });
+
+let dir: string;
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), "es00009-dust-state-"));
+});
+afterEach(() => {
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+describe("dust-state — characterization (must keep holding after Phase 2)", () => {
+  test("undeployed is a no-op in both directions", () => {
+    // Load must not resurrect state from a previous chain incarnation, and
+    // save must not create a file that a later named-network run could pick
+    // up. Both halves matter; testing only one has let this regress before.
+    expect(saveDustState(dir, "undeployed", SEED_A, snapshot())).toBeNull();
+    expect(fs.readdirSync(dir)).toEqual([]);
+
+    fs.writeFileSync(getDustStatePath(dir, "undeployed", SEED_A), snapshot(), "utf-8");
+    expect(loadDustState(dir, "undeployed", SEED_A)).toBeNull();
+  });
+
+  test("the path is keyed by the FULL seed, not a prefix", () => {
+    // Conventional dev seeds differ only in their last characters, so a
+    // prefix key collides and one wallet restores another's dust.
+    expect(getDustStatePath(dir, "preprod", SEED_A))
+      .not.toEqual(getDustStatePath(dir, "preprod", SEED_B));
+  });
+
+  test("networkId cannot escape baseDir via path traversal", () => {
+    const p = getDustStatePath(dir, "../../etc/preprod", SEED_A);
+    expect(path.dirname(p)).toEqual(dir);
+    expect(p.includes("..")).toBe(false);
+  });
+
+  test("a save is atomic and leaves no temp file behind", () => {
+    saveDustState(dir, "preprod", SEED_A, snapshot());
+    expect(fs.readdirSync(dir).filter((f) => f.endsWith(".tmp"))).toEqual([]);
+    expect(JSON.parse(loadDustState(dir, "preprod", SEED_A)!).offset).toEqual("128");
+  });
+
+  test("a missing snapshot loads as null rather than throwing", () => {
+    expect(loadDustState(dir, "preprod", SEED_A)).toBeNull();
+  });
+});
+
+describe("dust-state — RED: guards Phase 1 proved are missing", () => {
+  // Phase 1 §2: the harness wrote a file keyed `harness-named-*` whose
+  // snapshot body said `"networkId":"undeployed"`, and restore consumed it
+  // without complaint. `DustWallet.restore` (DustWallet.ts:295-300) never
+  // compares the snapshot's networkId against the configured one — only
+  // startWithSeed/startWithSecretKey read the configured id. So the single
+  // identity field the snapshot DOES record is never checked by anyone.
+  test("a snapshot recorded on another network is refused", () => {
+    fs.writeFileSync(
+      getDustStatePath(dir, "preprod", SEED_A),
+      snapshot({ networkId: "testnet" }),
+      "utf-8",
+    );
+    expect(loadDustState(dir, "preprod", SEED_A)).toBeNull();
+  });
+
+  // Phase 1 §2: truncating a real snapshot to half its bytes made
+  // DustWallet.restore throw `getOrThrow called on a Left` straight out of
+  // buildWalletFacade (get-wallet-info.ts:878). waitForDustFundsWithRetry
+  // treats that as a non-stall error and rethrows without ever rebuilding
+  // from scratch (gwi:701-730), so one bad file bricks wallet init until an
+  // operator deletes it. The load layer must reject it and let the caller
+  // cold-sync instead. This is also the post-sdk-upgrade path: the snapshot
+  // carries no format version, so a ledger bump fails here identically.
+  test("a truncated snapshot is refused rather than handed to restore", () => {
+    const raw = snapshot();
+    fs.writeFileSync(
+      getDustStatePath(dir, "preprod", SEED_A),
+      raw.slice(0, Math.floor(raw.length / 2)),
+      "utf-8",
+    );
+    expect(loadDustState(dir, "preprod", SEED_A)).toBeNull();
+  });
+
+  test("a snapshot missing required fields is refused", () => {
+    fs.writeFileSync(
+      getDustStatePath(dir, "preprod", SEED_A),
+      JSON.stringify({ publicKey: { publicKey: "123" } }),
+      "utf-8",
+    );
+    expect(loadDustState(dir, "preprod", SEED_A)).toBeNull();
+  });
+
+  // Phase 1 §2: with `offset` past the end of the indexer's event log the
+  // wallet emits exactly once, never sets isConnected, and hangs — measured
+  // over a 45 s window. The batcher then RE-SAVES that state on the stall
+  // path (gwi:707) and again on final failure (gwi:721), so the poisoned
+  // snapshot outlives the process and every restart repeats the ~5-minute
+  // failure. A save must never move a usable snapshot backwards into an
+  // unusable one; the simplest form of that rule is: do not persist a
+  // snapshot whose offset regresses below the one already on disk.
+  test("a save does not overwrite a good snapshot with a regressed offset", () => {
+    saveDustState(dir, "preprod", SEED_A, snapshot({ offset: "128" }));
+    saveDustState(dir, "preprod", SEED_A, snapshot({ offset: "0" }));
+    expect(JSON.parse(loadDustState(dir, "preprod", SEED_A)!).offset).toEqual("128");
+  });
+});

--- a/packages/chains/midnight-contracts/test/dust-tmp-sweep.test.ts
+++ b/packages/chains/midnight-contracts/test/dust-tmp-sweep.test.ts
@@ -1,0 +1,169 @@
+// Stale `.tmp` orphans left by killed processes must be swept.
+//
+// Measured, not imagined: the preprod kill matrix (sweep brief §2 step 4) ran
+// 14 `kill -9`s inside the save/rename cycle at a 5.1 MB payload and **8 of
+// them (57%) left a full-size `<snapshot>.<pid>.tmp` behind**. At 13.7 KB
+// (Phase 1's local scale) the write is over too fast to catch, which is why
+// this only became visible on preprod. A crash-looping batcher therefore leaks
+// 5.1 MB per restart, unbounded.
+//
+// Phase 2's `a4e67361` unlinks the tmp in `saveDustState`'s **catch block**,
+// which closes the failed-write/failed-rename path — a different bug. `SIGKILL`
+// runs no catch block, so it does not close this one. Hence a sweep.
+//
+// The liveness rule is the load-bearing part: a tmp owned by a *live* process
+// is that process's in-flight write, and deleting it would make its `rename`
+// fail. Sweeping is therefore gated on the owning pid being gone.
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+  getDustStatePath,
+  loadDustState,
+  saveDustState,
+  sweepStaleDustStateTmpFiles,
+} from "../src/dust-state.ts";
+
+const SEED_A = "0000000000000000000000000000000000000000000000000000000000000001";
+const SEED_B = "0000000000000000000000000000000000000000000000000000000000000002";
+
+const snapshot = (over: Partial<Record<string, unknown>> = {}): string =>
+  JSON.stringify({
+    publicKey: { publicKey: "123" },
+    state: "ab".repeat(64),
+    protocolVersion: "0",
+    networkId: "preprod",
+    offset: "128",
+    ...over,
+  });
+
+/**
+ * A pid that is definitely not running. Probed with the same `kill(pid, 0)`
+ * the implementation uses, rather than assumed from a magic number, so the
+ * test cannot go stale against a different `pid_max`.
+ */
+function deadPid(): number {
+  for (let pid = 4_194_303; pid > 1; pid--) {
+    try {
+      process.kill(pid, 0);
+    } catch (e) {
+      if ((e as { code?: string }).code === "ESRCH") return pid;
+    }
+  }
+  throw new Error("no dead pid found to test with");
+}
+
+let dir: string;
+let filePath: string;
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), "es00009-dust-tmp-sweep-"));
+  filePath = getDustStatePath(dir, "preprod", SEED_A);
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+});
+afterEach(() => {
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+/** Plant an orphan exactly as a SIGKILLed `saveDustState` would leave it. */
+function plantOrphan(pid: number, body = snapshot()): string {
+  const orphan = `${filePath}.${pid}.tmp`;
+  fs.writeFileSync(orphan, body, "utf-8");
+  return orphan;
+}
+
+describe("dust-state — stale .tmp sweep", () => {
+  test("a save sweeps orphans from dead processes and leaves the snapshot correct", () => {
+    const orphanA = plantOrphan(deadPid());
+    const orphanB = plantOrphan(deadPid() - 1);
+    fs.writeFileSync(filePath, snapshot({ offset: "100" }), "utf-8");
+
+    expect(saveDustState(dir, "preprod", SEED_A, snapshot({ offset: "200" })))
+      .toEqual(filePath);
+
+    expect(fs.existsSync(orphanA)).toBe(false);
+    expect(fs.existsSync(orphanB)).toBe(false);
+    // The snapshot itself is the thing the sweep must not disturb.
+    expect(JSON.parse(fs.readFileSync(filePath, "utf-8")).offset).toEqual("200");
+    expect(fs.readdirSync(dir)).toEqual([path.basename(filePath)]);
+  });
+
+  test("a load sweeps orphans and still returns the snapshot", () => {
+    const orphan = plantOrphan(deadPid());
+    fs.writeFileSync(filePath, snapshot(), "utf-8");
+
+    expect(loadDustState(dir, "preprod", SEED_A)).toEqual(snapshot());
+
+    expect(fs.existsSync(orphan)).toBe(false);
+    expect(fs.existsSync(filePath)).toBe(true);
+  });
+
+  test("a tmp owned by a LIVE process is never swept", () => {
+    // A real second process, not this one: `saveDustState`'s own tmp is
+    // `<snapshot>.<our pid>.tmp`, so an own-pid orphan is indistinguishable
+    // from the active write and gets consumed by the rename. A live *other*
+    // pid is the case that matters — that file is somebody's in-flight write,
+    // and deleting it turns their successful save into a failed one.
+    const child = Bun.spawn(["sleep", "30"], { stdout: "ignore", stderr: "ignore" });
+    try {
+      const live = plantOrphan(child.pid);
+      fs.writeFileSync(filePath, snapshot(), "utf-8");
+
+      loadDustState(dir, "preprod", SEED_A);
+      saveDustState(dir, "preprod", SEED_A, snapshot({ offset: "300" }));
+
+      expect(fs.existsSync(live)).toBe(true);
+    } finally {
+      child.kill();
+    }
+  });
+
+  test("another wallet's orphans are left alone", () => {
+    // The sweep is scoped to siblings of THIS snapshot. A second wallet in the
+    // same directory owns its own leaks and sweeps them on its own save/load.
+    const otherPath = getDustStatePath(dir, "preprod", SEED_B);
+    const otherOrphan = `${otherPath}.${deadPid()}.tmp`;
+    fs.writeFileSync(otherOrphan, snapshot(), "utf-8");
+
+    saveDustState(dir, "preprod", SEED_A, snapshot());
+
+    expect(fs.existsSync(otherOrphan)).toBe(true);
+  });
+
+  test("files that merely look like tmps are left alone", () => {
+    // Only the exact `<snapshot>.<pid>.tmp` shape the writer produces is
+    // swept — a `.rejected` quarantine file or an operator's manual copy is
+    // evidence, and deleting evidence is how a surprise 58-minute cold sync
+    // becomes unexplainable.
+    const decoys = [
+      `${filePath}.rejected`,
+      `${filePath}.tmp`,
+      `${filePath}.notapid.tmp`,
+      `${filePath}.123.tmp.bak`,
+    ];
+    for (const d of decoys) fs.writeFileSync(d, snapshot(), "utf-8");
+
+    sweepStaleDustStateTmpFiles(dir, "preprod", SEED_A);
+
+    for (const d of decoys) expect(fs.existsSync(d)).toBe(true);
+  });
+
+  test("the sweep reports what it removed, and is a no-op on undeployed", () => {
+    const orphan = plantOrphan(deadPid());
+    expect(sweepStaleDustStateTmpFiles(dir, "preprod", SEED_A)).toEqual([orphan]);
+    expect(sweepStaleDustStateTmpFiles(dir, "preprod", SEED_A)).toEqual([]);
+
+    // Persistence no-ops on undeployed, so nothing there is ours to delete.
+    const undeployedPath = getDustStatePath(dir, "undeployed", SEED_A);
+    const undeployedOrphan = `${undeployedPath}.${deadPid()}.tmp`;
+    fs.writeFileSync(undeployedOrphan, snapshot(), "utf-8");
+    expect(sweepStaleDustStateTmpFiles(dir, "undeployed", SEED_A)).toEqual([]);
+    expect(fs.existsSync(undeployedOrphan)).toBe(true);
+  });
+
+  test("a missing directory is not an error", () => {
+    expect(sweepStaleDustStateTmpFiles(path.join(dir, "nope"), "preprod", SEED_A))
+      .toEqual([]);
+  });
+});

--- a/packages/chains/midnight-contracts/test/shielded-sync-wait.test.ts
+++ b/packages/chains/midnight-contracts/test/shielded-sync-wait.test.ts
@@ -1,0 +1,65 @@
+// Shielded padding needs a shielded wallet that finished syncing. Today it gets
+// one that was cut off mid-replay.
+//
+// Master-plan Q2, answered in Phase 1 §1: fee wallets are built
+// `syncMode: 'dust-only'`, but dust-only passes `stopAuxWalletsImmediately:
+// false` (gwi:567) — so the shielded wallet syncs from genesis for the whole
+// dust-sync window and is then stopped the moment *dust* sync completes
+// (gwi:694), however far behind shielded still is. It has no persistence of any
+// kind, so every restart replays it from genesis and truncates it again.
+//
+// `applyShieldedPadding` then performs a real shielded spend against that
+// partial state, and the failure is swallowed with a warn per transaction
+// (adapter:1973, :1993) — so a padding-enabled deployment degrades silently on
+// any chain long enough for shielded sync to outlast dust sync.
+//
+// The fix is the smallest one that is honest: when padding is possible, wait
+// for shielded sync before suspending it. Persisting shielded state would mean
+// inventing a second snapshot format, and "documented as unsupported" would
+// leave a config that silently does nothing.
+
+import { describe, expect, test } from "bun:test";
+import * as Rx from "rxjs";
+import { waitForShieldedSyncComplete } from "../src/get-wallet-info.ts";
+
+type Facade = Parameters<typeof waitForShieldedSyncComplete>[0];
+
+const facadeEmitting = (states: Array<boolean | null>): Facade =>
+  ({
+    state: () =>
+      Rx.from(states).pipe(
+        Rx.concatMap((complete, i) =>
+          Rx.of(
+            complete === null
+              ? {}
+              : { shielded: { state: { progress: { isStrictlyComplete: () => complete } } } },
+          ).pipe(Rx.delay(i === 0 ? 0 : 10)),
+        ),
+      ),
+  }) as unknown as Facade;
+
+describe("waiting for shielded sync before suspending it", () => {
+  test("resolves true once shielded reports strictly complete", async () => {
+    expect(await waitForShieldedSyncComplete(facadeEmitting([false, false, true]), 5_000))
+      .toBe(true);
+  });
+
+  test("reports false on timeout instead of throwing", async () => {
+    // Padding may not be used by every input on this target, so a slow shielded
+    // sync must not take the whole batcher down — it must be visible and
+    // survivable.
+    expect(await waitForShieldedSyncComplete(facadeEmitting([false, false, false]), 60))
+      .toBe(false);
+  });
+
+  test("a facade with no shielded sub-wallet reports false, not a hang", async () => {
+    expect(await waitForShieldedSyncComplete(facadeEmitting([null, null]), 60)).toBe(false);
+  });
+
+  test("a stream that errors reports false", async () => {
+    const facade = {
+      state: () => Rx.throwError(() => new Error("wallet stopped")),
+    } as unknown as Facade;
+    expect(await waitForShieldedSyncComplete(facade, 60)).toBe(false);
+  });
+});

--- a/packages/chains/midnight-contracts/test/wallet-timeouts.test.ts
+++ b/packages/chains/midnight-contracts/test/wallet-timeouts.test.ts
@@ -1,0 +1,88 @@
+// Timeout defaults that have to survive a real network, and the funding waits
+// that must not be dragged along with them.
+//
+// Measured on preprod (master plan, "First real preprod sync measurements"):
+// the dust cold sync takes ~66 minutes (1,438,641 indices at ~365 idx/s) while
+// the unshielded sync takes ~1 second. `WALLET_SYNC_TIMEOUT_MS` was 10 minutes,
+// an order of magnitude short — every default-configured cold sync on preprod
+// fails, so this is a bug rather than a tunable.
+//
+// Raising it is not free: the same default was also the deadline for "wait for
+// funds to arrive" and for the dust-registration precheck, neither of which is
+// a sync question. An unfunded wallet would sit for hours, and the precheck —
+// which in dust-only mode waits on an unshielded sub-wallet that has been
+// stopped and can never complete (see the RegisterNightForDustOptions
+// docstring) — would burn the same hours before giving up.
+
+import { afterEach, describe, expect, test } from "bun:test";
+import * as Rx from "rxjs";
+import {
+  registerNightForDust,
+  resolveDustRegistrationPrecheckTimeoutMs,
+  resolveWalletFundingTimeoutMs,
+  resolveWalletSyncTimeoutMs,
+} from "../src/get-wallet-info.ts";
+
+/** Preprod's measured dust cold sync. A default below this cannot work. */
+const PREPROD_COLD_SYNC_MS = 66 * 60 * 1000;
+
+const ENV_KEYS = [
+  "MIDNIGHT_WALLET_SYNC_TIMEOUT_MS",
+  "MIDNIGHT_WALLET_FUNDING_TIMEOUT_MS",
+  "MIDNIGHT_DUST_REGISTRATION_PRECHECK_TIMEOUT_MS",
+];
+afterEach(() => {
+  for (const key of ENV_KEYS) delete process.env[key];
+});
+
+describe("sync timeout must outlast a real cold sync", () => {
+  test("the default survives a preprod dust cold sync with headroom", () => {
+    expect(resolveWalletSyncTimeoutMs()).toBeGreaterThan(PREPROD_COLD_SYNC_MS * 2);
+  });
+
+  test("the env override wins and a bad value falls back to the default", () => {
+    process.env.MIDNIGHT_WALLET_SYNC_TIMEOUT_MS = "1234";
+    expect(resolveWalletSyncTimeoutMs()).toEqual(1234);
+    process.env.MIDNIGHT_WALLET_SYNC_TIMEOUT_MS = "not-a-number";
+    expect(resolveWalletSyncTimeoutMs()).toBeGreaterThan(PREPROD_COLD_SYNC_MS * 2);
+  });
+});
+
+describe("waiting for funds is not waiting for a sync", () => {
+  test("the funding wait keeps its own, much shorter default", () => {
+    // A wallet that will never be funded must fail in minutes, not hours.
+    expect(resolveWalletFundingTimeoutMs()).toEqual(600_000);
+    expect(resolveWalletFundingTimeoutMs()).toBeLessThan(resolveWalletSyncTimeoutMs());
+  });
+
+  test("the registration precheck keeps its own default too", () => {
+    // In dust-only mode this wait can never succeed — the unshielded wallet it
+    // waits on has been stopped — so it must stay bounded by something small.
+    expect(resolveDustRegistrationPrecheckTimeoutMs()).toEqual(600_000);
+    expect(resolveDustRegistrationPrecheckTimeoutMs())
+      .toBeLessThan(resolveWalletSyncTimeoutMs());
+  });
+
+  test("both are independently configurable", () => {
+    process.env.MIDNIGHT_WALLET_FUNDING_TIMEOUT_MS = "5000";
+    process.env.MIDNIGHT_DUST_REGISTRATION_PRECHECK_TIMEOUT_MS = "7000";
+    expect(resolveWalletFundingTimeoutMs()).toEqual(5000);
+    expect(resolveDustRegistrationPrecheckTimeoutMs()).toEqual(7000);
+  });
+});
+
+describe("registerNightForDust reports failure rather than throwing it", () => {
+  test("a precheck timeout returns false like every other failure there", async () => {
+    // The precheck's Rx.timeout threw from OUTSIDE the function's own
+    // try/catch, so this one failure mode escaped as an exception while every
+    // other one returned false. Callers that treated the boolean as the whole
+    // contract skipped their own handling for it.
+    const walletResult = {
+      wallet: { state: () => Rx.NEVER },
+    } as unknown as Parameters<typeof registerNightForDust>[0];
+
+    await expect(
+      registerNightForDust(walletResult, { precheckSyncTimeoutMs: 50 }),
+    ).resolves.toBe(false);
+  });
+});


### PR DESCRIPTION
Stacked on #855 (`claude/multi-batcher-sdk-v2`), same pattern as #870. Review
the 16 commits here; the base branch's own changes are in #855.

## The problem

A batcher's Midnight fee wallets sync by replaying the chain, so **a restart is
an outage** unless store/restore works and sync is tuned for a real chain.
Neither had ever been verified against a long chain. It turns out restore
itself was fine — what was broken was everything around it, and the worst of it
was **unrecoverable**: several distinct states in which no number of restarts
would ever converge.

## What was measured (live preprod, not simulated)

| | |
| --- | --- |
| Cold dust sync | **54.4 min** (real batcher, funded wallet, 1 439 884 indices, 441 idx/s); 58.5 min in the read-only sweep |
| Restart with a snapshot | **43.4 s**, **0 indices replayed** — **75×** faster |
| Snapshot size | **5.20 MB** funded, vs 5.15 MB unfunded (+1.13%) |
| Preprod dust log growth | **46.6 indices/hour** |
| Fee paid from restored dust | tx `5614cf18…ead137`, **preprod block 2 157 709**, `HTTP 200` on `wait-receipt` |

**The measurement that changed this project's priorities.** Restored sync
scales with *time since snapshot*, and at 46.6 idx/h that term is tiny: a
**week-old snapshot is ~7 800 indices behind ≈ 19 s of replay**. So periodic
checkpointing — the thing the work started out chasing — is worth far less than
assumed, while each **unrecoverable-snapshot defect costs a full cold sync or a
permanent failure**. The fix list below is ordered by that finding, not by the
original hypothesis.

Spendability is proven by a **real sponsored transaction**, not a reported
balance: the batcher, restored from the 5.2 MB snapshot, balanced a delegated
circuit call with its dust, bound it and submitted it. `dustUtxos` went **1 → 0**
across the spend with `dustClock: "live"` — the coin picker consuming a
*restored* coin projected at wall clock, which a balance readout could not have
shown.

## The fixes

**Unrecoverable states — each of these was a permanent outage**

- **Snapshot validation + cold-sync fallback.** A corrupt, truncated or
  post-SDK-upgrade snapshot threw synchronously out of `DustWallet.restore` and
  wallet init stayed broken until an operator deleted the file by hand. Now
  validated on save and load (shape, network id, and the wallet's own dust
  public key), unusable ones are **quarantined to `<snapshot>.rejected`** rather
  than deleted, and the fallback wraps the *decode alone* — wrapping the whole
  facade build would discard a good snapshot on a transient indexer blip and
  cost an hour of resync.
- **No re-persisting a poisoned snapshot.** A failed attempt could only make
  things worse: it wrote its own broken state back on every retry, so the outage
  survived restarts. A save may now move the offset forward or leave it, never
  backwards, and a failed attempt may only persist state that actually advanced.
- **Recovery from an offset past the indexer's log.** A well-formed snapshot
  whose cursor is past the end (chain reset, rollback, re-index) hung forever:
  all five retries restored the same bytes. Detected from a four-clause
  signature, quarantined, cold-synced. **Verified end to end on preprod**:
  detected at ~101 s, file renamed, wallet cold-synced from genesis, init
  neither hung nor threw.
- **The dust stall timeout was a flat deadline, not a stall detector.** It raced
  sync against a 60 s timer, so a *healthy* 58-minute cold sync "stalled" every
  60 s and init threw after 5 attempts — a total sync budget of ~5 minutes, and
  no number of restarts converged. It is now rearmed by every state emission.
- **`WALLET_SYNC_TIMEOUT_MS` was 5.85× too small** for a real cold sync — a
  batcher without a valid snapshot could not finish initial sync at all. This
  was a blocker, not a tunable. See Config below.
- **A dropped indexer websocket killed the process outright**, which made every
  recovery path above unreachable. Observed on preprod three minutes into a cold
  sync: the stall detector fired correctly, the checkpoint was written
  correctly, retry 2/5 began — and the dead socket's `ErrorEvent` surfaced as an
  unhandled rejection and exited the process. Socket lifecycle events are now
  classified by shape and routed into the existing retry machinery instead;
  every other unhandled rejection is still fatal. One limitation is worth
  stating: the rejection carries **no wallet identity** — it is a promise
  nobody awaited — so with fee wallets initialising concurrently, one wallet's
  socket error nudges every in-flight attempt's deadline. It cannot be narrowed
  without an upstream fix, and it is safe in practice for the reasons given in
  `onWalletSocketFailure`'s docstring.

**Durability and staleness**

- **Periodic, shutdown and injected-wallet checkpointing**, with `fsync` and a
  directory `fsync` on the atomic write. Before this, state was written at
  exactly three places, all during init, so the snapshot never advanced after
  startup. Measured live: five checkpoints at **5.00 min ± 10 ms**, `close()`'s
  final save proven on a deliberately off-cadence run, **436 ms stall per
  checkpoint = 0.145% of wall-clock**.
- **Stale temp-file sweep.** `SIGKILL` runs no `catch` block, so a crash-looping
  batcher leaked a full 5 MB temp file per restart. Sibling `<snapshot>.<pid>.tmp`
  files whose owning pid is gone are now swept on save and load. **State this
  precisely: the orphan rate went UP, 57% → 83%, because `fsync` lengthens the
  write→rename window. What changed is that 0 of them survive a restart.** The
  claim is "no accumulation", not "no orphans".
- Kill matrix re-run with `fsync` in the path: **6/6 snapshots byte-identical
  and loadable**.

**Correctness and visibility**

- **Wall-clock spendability gate.** The gate read `generatedNow` at the wallet's
  `syncTime`, which only advances when a dust event is applied — measured 377
  days stale on a quiet chain. Dust generation is a projection, so reading it at
  that clock under-reports it and can mark a funded wallet exhausted. It now
  projects at wall clock, falling back to the stale getter (never to zero, which
  would flip the capacity gate off for the whole batcher) and reporting which
  clock it used.
- **Sync/restore state in `getHealthInfo()`** — per wallet: syncing/stalled/
  complete, restored-from offset, applied index, target, behind, last-advance
  age, and whether the snapshot was cold/restored/rejected. Init was the gap:
  for ~an hour health said `walletsReady: 0` and nothing else, identical to a
  wallet that would never start. Verified across **218 samples over 54.4 min** —
  `state` was `syncing` throughout and `behind` fell 1 436 221 → 404 without
  rising once.
- **Shielded sync is finished before it is suspended** when shielded padding is
  possible. Dust-only mode stopped the shielded wallet the moment *dust* sync
  completed, leaving a half-replayed state that padding silently failed against.
- **The HTTP port no longer opens before adapters are past blocking startup.**
  See Config below.
- The three dust sync knobs are now **measured** (13 cells on preprod, one
  factor at a time over an identical window, baseline reproduced to 0.95%) and
  documented. Result: **keep `100 / 1 / 1`** — every direction of change is
  worse for a process that serves HTTP while syncing.

## Config and behaviour changes — please read

- **`CONSTANTS.WALLET_SYNC_TIMEOUT_MS` default changes: 10 min → 4 h**
  (`MIDNIGHT_WALLET_SYNC_TIMEOUT_MS`). The old value was 5.85× smaller than a
  measured preprod cold sync. Two waits that were silently sharing it split off
  into their own constants and env knobs, both still 10 min:
  `MIDNIGHT_WALLET_FUNDING_TIMEOUT_MS` (waiting for funds to arrive) and
  `MIDNIGHT_DUST_REGISTRATION_PRECHECK_TIMEOUT_MS` (which in dust-only mode can
  never succeed, and whose throw was outside its own try/catch). 4 h is a
  **per-network** number — it is 4.4× a *preprod* cold sync, and a busier chain
  needs it re-derived rather than inherited.
- **New env var `MIDNIGHT_DUST_STATE_SAVE_INTERVAL_MS`** — checkpoint cadence,
  default 5 min, `0` disables periodic saving (shutdown saves still happen).
- **Documented (unchanged defaults): `MIDNIGHT_DUST_SYNC_BATCH_SIZE` (100),
  `MIDNIGHT_DUST_SYNC_BATCH_TIMEOUT_MS` (1), `MIDNIGHT_DUST_SYNC_BATCH_SPACING_MS`
  (1).** `spacing = 0` is measurably harmful — 2.4% more throughput for 5× the
  median event-loop stall — and is reachable from env today.
- **Behaviour: the HTTP listener no longer opens until every adapter is past its
  loop-blocking startup.** `BlockchainAdapter` gains an optional
  `whenServable()`; adapters that omit it are treated as immediately servable,
  so nothing else in the repo changes behaviour. Bounded by
  `httpServerReadinessTimeoutMs` (default 5 min) and never fatal. This exists
  because `DustWallet.restore` is one contiguous ~41 s synchronous block during
  which no handler of any kind can run, so a client connecting in that window
  hung for 41 s. It now gets an immediate connection refusal instead (measured:
  24 consecutive refusals, max curl time 5 ms).
  **The server still runs through the whole cold sync**, deliberately. Gating on
  sync *completion* would blind `/health` for an hour and destroy the value of
  the health work above. Measured: **624 external probes across the full
  55-minute cold sync, 622 × HTTP 200, p99 542 ms, none over 1 s.**
- **Not breaking:** no public API is removed or changed incompatibly;
  `whenServable()` and `DustSyncWithRetryOptions.buildWallet` are both optional
  additions.

## Tests

`bun test packages/chains/midnight-contracts packages/batcher`: **391 pass / 0
fail**. On the base branch those two packages were **299 pass / 0 fail**
(`packages/batcher`) and **5 pass / 4 fail** (`packages/chains/midnight-contracts`). Full repo `bun test ./packages`: **655 pass /
2 skip / 4 fail / 2 errors** — the failures are the pre-existing
`packages/node-sdk/db/src/pool-error-tracker.test.ts` pair plus the
`@effectstream/sm` module-resolution errors, checked by identity rather than by
count, and in a package nothing here touches.

Every fix landed red-first. Type-check of changed files: no new errors
(pre-existing ones confirmed by type-checking the same files at the base
commit).

Beyond unit tests: a local Docker node+indexer for the store/restore and
kill -9 work, and live preprod for everything the local chain provably cannot
reproduce — a local dev chain holds 128 dust events total and gains none as
blocks advance, and its only possible network id is `undeployed`, on which
persistence no-ops.

## Known follow-ups (deliberately not in scope here)

1. **Make restore incremental or off-thread.** `DustWallet.restore` is a single
   ~41 s synchronous block at 5.2 MB and grows with chain length. It is a
   restart-latency problem, not an availability one — the listener gating above
   already removed the user-facing half.
2. **Make stall detection advance-based rather than emission-based.** The silence
   detector rearms on every emission, so a wallet that emits constantly without
   advancing is invisible to it — while `getHealthInfo`'s classifier, which *is*
   advance-based, would correctly call it stalled. The health endpoint currently
   knows more than the recovery path. Closing that gap would also make the 4 h
   deadline genuinely vestigial.
3. `buildWalletFacade` returns when a restored snapshot is **decoded**, not when
   the wallet has caught up, so a direct caller that spends immediately can
   double-spend a coin the snapshot still shows as unspent. The batcher's own
   path is safe (`waitForDustFundsWithRetry` waits for sync); a direct caller
   wants a documented warning or a `waitForCatchUp` option.
