### PR TITLE
fix(sdk): silence same-version @polkadot ESM/CJS duplicate warnings

### DIFF
--- a/e2e/wallets-ui/vite.config.ts
+++ b/e2e/wallets-ui/vite.config.ts
@@ -74,6 +74,9 @@ export default defineConfig({
       // `src/mod.ts/types` → ENOTDIR and the whole app fails to build, which
       // surfaces in the wallets-ui suite as a blank page and a click timeout.
       "@effectstream/utils/types": utilsPath + "src/types/mod.ts",
+      // Like the other utils subpaths above, this must precede the broad root
+      // alias or Vite appends the subpath to the mod.ts file (ENOTDIR).
+      "@effectstream/utils/polkadot-esm-cjs-warning": utilsPath + "src/polkadot-esm-cjs-warning.ts",
       "@effectstream/utils": utilsPath + "src/mod.ts",
       "@effectstream/config": configPath + "src/mod.ts",
       "@effectstream/concise": concisePath + "src/mod.ts",

--- a/packages/effectstream-sdk/crypto/src/chains/polkadot.ts
+++ b/packages/effectstream-sdk/crypto/src/chains/polkadot.ts
@@ -1,3 +1,5 @@
+// MUST stay first: it sets the flag @polkadot/util reads while loading.
+import "@effectstream/utils/polkadot-esm-cjs-warning";
 import {
   type Signature,
   type SubstrateAddress,

--- a/packages/effectstream-sdk/utils/package.json
+++ b/packages/effectstream-sdk/utils/package.json
@@ -17,7 +17,8 @@
     "./node-env": "./src/config.ts",
     "./runtime": "./src/runtime.ts",
     "./runtime-spawn": "./src/runtime-spawn.ts",
-    "./fs": "./src/fs.ts"
+    "./fs": "./src/fs.ts",
+    "./polkadot-esm-cjs-warning": "./src/polkadot-esm-cjs-warning.ts"
   },
   "dependencies": {
     "@coderspirit/nominal": "^4.1.1",

--- a/packages/effectstream-sdk/utils/src/polkadot-esm-cjs-warning.ts
+++ b/packages/effectstream-sdk/utils/src/polkadot-esm-cjs-warning.ts
@@ -1,0 +1,39 @@
+/**
+ * Side-effect-only module. Import it as the FIRST statement of any module that
+ * imports a `@polkadot/*` package (directly, or via a wrapper such as
+ * `avail-js-sdk`), and never import it lazily.
+ *
+ * Why: every `@polkadot/*` package registers itself in `globalThis.__polkadotjs`
+ * at load time and warns when it sees more than one entry for the same package.
+ * We load two entries — but of the same version, in two module formats:
+ *
+ *   esm  `@effectstream/crypto` ships raw TS, so Bun loads it as ESM, and
+ *        `chains/polkadot.ts` pulls the ESM build of `@polkadot/util-crypto`.
+ *   cjs  `avail-js-sdk` is CommonJS-only, so its `require("@polkadot/api")`
+ *        can only ever resolve the `cjs/` build.
+ *
+ * The result is six warnings ("@polkadot/util has multiple versions...") on
+ * every start, telling the user to pin or dedupe. There is nothing to dedupe:
+ * only one version of each package is installed. Setting the flag below is the
+ * escape hatch `@polkadot/util` provides for exactly this case — it suppresses
+ * the message only when every registered entry has the same version, so a
+ * genuine multi-version conflict still warns.
+ *
+ * To see the warnings again, set POLKADOTJS_DISABLE_ESM_CJS_WARNING=0 — an
+ * explicit value in the environment always wins over the default set here.
+ *
+ * Ordering matters: `@polkadot/util` reads this variable while it is being
+ * evaluated, i.e. during the first `@polkadot/*` import in the process. Setting
+ * it afterwards has no effect.
+ *
+ * See spec/00009-polkadot-package-conflicts.md in the organizer workspace for
+ * the captured stack traces behind the two loads.
+ */
+const FLAG = "POLKADOTJS_DISABLE_ESM_CJS_WARNING";
+
+// `process` is absent in browser/bundler builds; there is nothing to set there.
+const env = globalThis.process?.env;
+
+if (env && env[FLAG] === undefined) {
+  env[FLAG] = "1";
+}

--- a/packages/effectstream-sdk/wallets/src/avail/avail.ts
+++ b/packages/effectstream-sdk/wallets/src/avail/avail.ts
@@ -1,3 +1,5 @@
+// MUST stay first: it sets the flag @polkadot/util reads while loading.
+import "@effectstream/utils/polkadot-esm-cjs-warning";
 import { Buffer } from "node:buffer";
 import { utf8ToHex } from 'web3-utils';
 import type { ApiPromise } from "avail-js-sdk";

--- a/packages/effectstream-sdk/wallets/src/avail/wrapper.ts
+++ b/packages/effectstream-sdk/wallets/src/avail/wrapper.ts
@@ -1,3 +1,6 @@
+// MUST stay first: avail-js-sdk requires the CJS @polkadot build, and
+// @polkadot/util reads the flag this sets while loading.
+import "@effectstream/utils/polkadot-esm-cjs-warning";
 import type { Result } from "@effectstream/utils/types";
 import type { IProvider } from "../IProvider.ts";
 import type { WalletMode, ApiForMode } from "../utils.ts";

--- a/packages/node-sdk/sync/src/sync-protocols/avail/AvailClient.ts
+++ b/packages/node-sdk/sync/src/sync-protocols/avail/AvailClient.ts
@@ -1,3 +1,6 @@
+// MUST stay first: avail-js-sdk requires the CJS @polkadot build, and
+// @polkadot/util reads the flag this sets while loading.
+import "@effectstream/utils/polkadot-esm-cjs-warning";
 import { SDK } from "avail-js-sdk";
 import { DEFAULT_REQUEST_TIMEOUT_MS, fetchWithTimeout } from "../common/http.ts";
 import type {


### PR DESCRIPTION
## The report

Every template start prints 24 lines of `@polkadot/* has multiple versions ... dedupe using your package manager`, for six packages. The question that opened this was reasonable: *can we pin the dependencies to make it go away?*

**No — and nothing is actually wrong with the dependencies.**

## It is not a version conflict

Every reported pair is the *same* version. The two rows differ only by module format:

```
@polkadot/util has multiple versions, ensure that there is only one installed.
	cjs 13.5.9	node_modules/@polkadot/util/cjs
	esm 13.5.9	node_modules/@polkadot/util/
```

Verified on a clean install: exactly **one** `@polkadot/util` package on disk (13.5.9), loaded **twice**. So `overrides`/`resolutions` and `bun pm dedupe` have nothing to act on — there is no second version to remove.

The upstream check confirms it never compares versions to decide whether to warn (`@polkadot/util/detectPackage.js`):

```js
const entriesSameVersion = entry.every((e) => e.version === version);
const esmCjsWarningDisabled = xglobal.process?.env?.[FLAG] === '1';
const multipleEntries = entry.length !== 1;
const disableWarnings = esmCjsWarningDisabled && entriesSameVersion;

if (multipleEntries && !disableWarnings) { warn(...) }
```

It warns on `entry.length !== 1` — two *loads*, not two versions. Version equality is only consulted to decide whether the suppression flag may apply.

## Why it is loaded twice

Stack traces captured by instrumenting `detectPackage()`:

- **esm** — `@effectstream/crypto` ships raw TS (`"exports": "./src/mod.ts"`), so Bun loads it as ESM, and `chains/polkadot.ts` pulls the ESM build of `@polkadot/util-crypto` / `@polkadot/util`.
- **cjs** — `avail-js-sdk@0.4.2` is CommonJS-only, so its `require("@polkadot/api")` can only ever resolve the `cjs/` build. It is imported *eagerly* by `syncProtocolFactory.ts`, even when no Avail chain is configured — the single-file template does not use Avail at all.

Each half alone is silent; loading both produces the six warnings.

## The fix

Opt into `@polkadot/util`'s own `POLKADOTJS_DISABLE_ESM_CJS_WARNING` escape hatch via a side-effect module, imported **first** by each of the four sites that load a `@polkadot` package at runtime.

Two details that matter:

- **It must be first.** `@polkadot/util` reads the variable while it is being evaluated, i.e. during the first `@polkadot/*` import in the process. Setting it afterwards does nothing.
- **It is wired next to each import site, not into `mod.ts`.** `@effectstream/node-sdk` has ~24 export subpaths; someone importing `@effectstream/node-sdk/sync` never evaluates `mod.ts`.

An explicit value in the environment always wins — set `POLKADOTJS_DISABLE_ESM_CJS_WARNING=0` to see the warnings again.

## The safety net still works

Upstream honours the flag **only when all registered entries share a version**, so a genuine multi-version conflict still warns. This was verified rather than assumed: the monorepo tree resolves `util` `cjs 13.5.9 | cjs 14.0.3 | esm 13.5.9`, and with the guard active and the flag reading back as `"1"`, the warnings were **still printed**.

## Verification

Tested against a flat published install — the exact `node_modules` shape a user gets.

| Test | Result |
| --- | --- |
| Single-file template startup | **24 warning lines → 0** |
| Rest of startup output | Identical: migrations, indexer, HTTP server, block sync |
| `POLKADOTJS_DISABLE_ESM_CJS_WARNING=0` | All 6 warnings return |
| Entry paths (`node-sdk`, `/sync`, `/runtime`, `/concise`, `/sm`) | 0 warnings each |
| Genuine multi-version conflict | Still warns |
| `tsc --noEmit` | Same pre-existing errors as the pristine tree; 0 new |

No `postinstall`, no patched `node_modules`, no lockfile change.

## Not in this PR

- **Lazy-loading Avail.** Loading `avail-js-sdk` only when an Avail sync protocol is configured would remove the CJS half at its source. It is subsumed by broader "lazy-load all optional wallets" work. Note it would not replace this fix: an app that genuinely uses Avail still loads both builds and would still see the warning.
- **A regression test.** The obvious check cannot pass under `LINK_LOCAL=1`, because the monorepo's real 13.5.9-vs-14.0.3 split is a conflict this fix correctly refuses to hide. Deciding the right assertion is pending.
- **The 13.5.9-vs-14.0.3 split itself** (`@midnightntwrk/wallet-sdk-node-client` + `@polkadot/api@16.5.6` pulling 14.x against `@effectstream/wallets`' `@polkadot/api@15.10.2` pinning 13.x). That one *is* a real conflict, and pinning would fix it.

Not a breaking change.