### PR TITLE
Handle duplicate marker offers in zswap-da frontend

### DIFF
--- a/plans/00015-zswap-da-frontend-api-sync.md
+++ b/plans/00015-zswap-da-frontend-api-sync.md
@@ -1,0 +1,51 @@
+# 00015-zswap-da-frontend-api-sync — COMPLETED
+
+| Working scope | Absolute path |
+|---|---|
+| Project root | `/Users/edwardalvarado/todo/Effectstream/experiments/00015-zswap-da` |
+| Spec | `/Users/edwardalvarado/todo/Effectstream/experiments/00015-zswap-da/spec/00015-zswap-da-frontend-api-sync.md` |
+| Plan | `/Users/edwardalvarado/todo/Effectstream/experiments/00015-zswap-da/plans/00015-zswap-da-frontend-api-sync.md` |
+| Frontend client | `/Users/edwardalvarado/todo/Effectstream/experiments/00015-zswap-da/templates/zswap-da/src/state/useZSwapApp.ts` |
+| API client | `/Users/edwardalvarado/todo/Effectstream/experiments/00015-zswap-da/templates/zswap-da/src/services/api.ts` |
+| Project summary | `/Users/edwardalvarado/todo/Effectstream/project-summary.md` |
+
+## EXECUTION FLOW
+
+| Phase | Order | State | Notes |
+|---|---|---|---|
+| API compatibility verification | 1 | COMPLETED | Compared backend `API.md` + `FRONTEND-API-HANDOFF.md` against frontend submit and type contracts. |
+| Frontend duplicate handling | 2 | COMPLETED | Added `DUPLICATE_MARKERS` branch in `createOffer` and mapped `activeOfferId`. |
+| Workspace documentation | 3 | COMPLETED | Added spec, updated plan/state, incremented `counter.md`, added summary row. |
+
+## Phase Goals
+
+1. Guarantee parity with backend submit error contract and prevent false-failure UX.
+2. Keep project process artifacts complete and current for handoff.
+
+## Work Items
+
+1. Handle both `DUPLICATE_OFFER` and `DUPLICATE_MARKERS` in `useZSwapApp` create flow.
+2. Resolve existing offer references from `activeOfferId` first, then `offerId`, during duplicate handling.
+3. Update submit contract comments in `src/services/api.ts` to document marker-duplicate payload semantics.
+4. Create `spec/00015-zswap-da-frontend-api-sync.md`.
+5. Update this plan file with current state, execution flow, and test plan.
+6. Update `counter.md` to `00016`.
+7. Append row `00015-zswap-da` in `project-summary.md`.
+
+## Testing
+
+1. Manual API contract smoke check:
+   - Reproduce a `POST /v1/offers` call that returns `409 DUPLICATE_OFFER`.
+   - Reproduce a call that returns `409 DUPLICATE_MARKERS` (if backend endpoint access exists).
+   - Confirm the create flow does not throw and resolves to an existing offer reference.
+2. Local state/UI check:
+   - Verify a duplicate marker path adds trade with resolved `offerId = activeOfferId`.
+   - Verify no retry loop or repeated submit attempts are triggered.
+3. Workspace metadata check:
+   - Confirm `counter.md = 00016`.
+   - Confirm `project-summary.md` row exists for `00015-zswap-da`.
+   - Confirm `spec/` and `plans/` artifacts exist in the project folder.
+
+## Questions
+
+No open questions currently; all needed decisions were made in code and docs.

--- a/spec/00015-zswap-da-frontend-api-sync.md
+++ b/spec/00015-zswap-da-frontend-api-sync.md
@@ -1,0 +1,85 @@
+# Feature Specification: 00015-zswap-da frontend API sync
+
+**Feature Branch**: `00015-zswap-da`
+
+**Created**: 2026-08-20
+
+**Status**: Draft
+
+**Input**: User request to verify/update `templates/zswap-da/*` against the updated
+`zswap-offerfiles-kernel` backend API contract.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Duplicate intent submission behavior (Priority: P1)
+
+As a swap maker, when I re-submit an equivalent intent with a different offer blob,
+the frontend should not fail or mislead me when the backend now returns
+`409 DUPLICATE_MARKERS`; instead it should route me to the already-active offer
+just like existing duplicate behavior.
+
+**Why this priority**: Prevents duplicate intent confusion and accidental
+submission retries after the backend contract changed.
+
+**Independent Test**: Submit an offer, then submit a re-proved equivalent offer
+and verify the app records the existing offer id and does not show it as a hard error.
+
+**Acceptance Scenarios**:
+
+1. **Given** the backend returns `DUPLICATE_MARKERS` for a submit call, **When**
+the user clicks submit, **Then** the app uses `activeOfferId` as the resulting
+`offerId`.
+2. **Given** duplicate status is present for the same payload (`DUPLICATE_OFFER`),
+**When** submit succeeds by duplicate path, **Then** status and UX remain unchanged.
+
+### User Story 2 - API contract visibility (Priority: P2)
+
+As a maintainer, I need the frontend interface docs/comments to mention the new
+duplicate marker contract so future changes do not regress compatibility.
+
+**Why this priority**: Keeps code-level contract assumptions explicit and discoverable.
+
+**Independent Test**: Confirm API submit docs in the frontend project describe
+both duplicate modes and their response payloads.
+
+**Acceptance Scenarios**:
+
+1. **Given** backend docs mark `DUPLICATE_MARKERS` as non-transactional duplicate,
+**When** frontend team reviews comments/notes, **Then** they match current API behavior.
+
+### Edge Cases
+
+- What if `DUPLICATE_MARKERS` arrives without a usable `activeOfferId`?  
+- What if the app receives only `offerId` and `status` from the backend for marker
+duplicate (future schema drift)?
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The frontend submit flow must treat `DUPLICATE_MARKERS` similarly
+to `DUPLICATE_OFFER` from the user perspective.
+- **FR-002**: On duplicate marker handling, `addTrade` and local status flow must
+reference `activeOfferId` for the existing live offer.
+- **FR-003**: Frontend API comments/types should document `DUPLICATE_MARKERS`
+response shape (`offerId`, `activeOfferId`) so the contract is explicit.
+- **FR-004**: The project must include required organizer records (`spec/`,
+`plans/`, `counter.md`, `project-summary.md`) for `00015-zswap-da`.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A scripted submit scenario that triggers `DUPLICATE_MARKERS`
+ends as duplicate handling without throwing or retrying.
+- **SC-002**: The local trade record points to the active offer id (not the
+submitted blob id) for marker duplicates.
+- **SC-003**: `templates/zswap-da` includes explicit notes for both duplicate
+submit codes.
+
+## Assumptions
+
+- Backend contract used is post-2026-08-18 `zswap-offerfiles-kernel`, where
+`DUPLICATE_MARKERS` is active at `POST /v1/offers`.
+- Existing template code paths for `DUPLICATE_OFFER` are stable and should remain unchanged
+except for parity with marker duplicates.

--- a/templates/zswap-da/src/services/api.ts
+++ b/templates/zswap-da/src/services/api.ts
@@ -16,7 +16,8 @@ const V1 = `${API_BASE}/v1`;
  *
  * Bodies are always `{error, reason, ...extras}` with a truthful status: 400
  * validation, 404 unknown, 409 duplicate, 429 rate-limited, 500 INTERNAL.
- * Extras (`offerId`, `status`, `hint`, `diagnostics`) survive on `.data`.
+ * Extras (`offerId`, `activeOfferId`, `status`, `hint`, `diagnostics`) survive
+ * on `.data`.
  */
 export class ApiError extends Error {
   readonly code: string;
@@ -169,7 +170,9 @@ export const api = {
    * (seconds to ~a minute), so poll status until it leaves `not_found`.
    *
    * Throws ApiError. Notable codes: `DUPLICATE_OFFER` (409, carries the existing
-   * `offerId` + `status` — not a failure), and everything in
+   * `offerId` + `status`) and `DUPLICATE_MARKERS` (409, carries `activeOfferId`
+   * of the live offer that owns the same declared markers, plus `offerId` for this
+   * attempt) — both are not failures from the user's point of view. Everything in
    * TERMINAL_SUBMIT_CODES, which must never be retried.
    */
   submitSwapOffer: async (

--- a/templates/zswap-da/src/state/useZSwapApp.ts
+++ b/templates/zswap-da/src/state/useZSwapApp.ts
@@ -457,9 +457,9 @@ export function useZSwapApp(): ZSwapApp {
       const blob = await w.buildOfferBlob(cfg.networkId, gives, wants);
       opts?.onStatus?.('Posting to Celestia…');
 
-      // 409 DUPLICATE_OFFER isn't a failure from the user's point of view — the
-      // offer exists — so adopt the existing offer's id and status. The node
-      // rejects it before paying a Celestia fee.
+      // 409 DUPLICATE_OFFER / DUPLICATE_MARKERS isn't a failure from the
+      // user's point of view — the offer already exists — so adopt the existing
+      // offer's id and status. The node rejects it before paying a Celestia fee.
       //
       // Everything in TERMINAL_SUBMIT_CODES is unretryable by construction, so
       // there is no retry loop here any more. ROOT_UNKNOWN in particular used to
@@ -472,10 +472,10 @@ export function useZSwapApp(): ZSwapApp {
         const submitted = await api.submitSwapOffer(blob);
         offerId = submitted?.offerId ?? null;
       } catch (e: any) {
-        if (e?.code === 'DUPLICATE_OFFER') {
-          offerId = e.data?.offerId ?? null;
+        if (e?.code === 'DUPLICATE_OFFER' || e?.code === 'DUPLICATE_MARKERS') {
+          offerId = e.data?.activeOfferId ?? e.data?.offerId ?? null;
           duplicateStatus = (e.data?.status as OfferStatus) ?? null;
-          dlog('createOffer: duplicate offer', { offerId, status: duplicateStatus });
+          dlog('createOffer: duplicate offer', { code: e.code, offerId, status: duplicateStatus });
         } else if (e?.code === 'ROOT_UNKNOWN' && e.data?.hint) {
           dlog('createOffer: root unknown', e.data?.diagnostics);
           throw new Error(e.data.hint);
@@ -501,7 +501,7 @@ export function useZSwapApp(): ZSwapApp {
       toast(
         duplicateStatus
           ? `This offer was already posted (${duplicateStatus})`
-          : 'Offer created',
+          : `This intent was already active (${offerId ?? 'existing offer'})`,
         duplicateStatus ? undefined : 'ok',
       );
       zapi.fetchOffers();


### PR DESCRIPTION
## Summary
- Handle the backend-introduced `409 DUPLICATE_MARKERS` response path in `templates/zswap-da/src/state/useZSwapApp.ts` submit flow.
- On duplicate-marker response, derive existing offer reference from `activeOfferId` (fallback to `offerId`) so the UI points to the already-active intent instead of treating submission as a failure.
- Keep existing `DUPLICATE_OFFER` behavior parity and add duplicate code context to duplicate logging.
- Update `templates/zswap-da/src/services/api.ts` submit comments to document `DUPLICATE_MARKERS` payload semantics (`offerId`, `activeOfferId`, `status`).
- Add required process docs: `spec/00015-zswap-da-frontend-api-sync.md` and `plans/00015-zswap-da-frontend-api-sync.md`.

## Testing
- Not run (requested no-test pass).

## Notes
- Organizer workspace was updated separately: `counter.md` is now `00016` and `project-summary.md` includes the `00015-zswap-da` work item.
