### PR TITLE
fix(batcher): align failed receipts and async events

### DIFF
--- a/packages/batcher/core/batch-processor-status.test.ts
+++ b/packages/batcher/core/batch-processor-status.test.ts
@@ -18,7 +18,7 @@
 
 import { describe, expect, test } from "bun:test";
 import { BatchProcessor } from "./batch-processor.ts";
-import { InputValidationError } from "./errors.ts";
+import { InputTerminalError, InputValidationError } from "./errors.ts";
 import { computeRequestId } from "./request-id.ts";
 import type {
   RequestState,
@@ -295,14 +295,19 @@ describe("recording a batch that reaches the chain", () => {
 
     await h.processor.processBatchForTarget(adapter, TARGET, [lonely]);
 
-    // The callback path reads one hash for one input as "multi-hash" and so
-    // RESOLVES this caller — pre-existing, and defensible there because it
-    // hands over the raw receipt, `status: 0` and all. A status record has
-    // nowhere to put that nuance, so it says what the chain said.
+    // One input is shared/single-transaction semantics. A failed receipt must
+    // reject the waiter with the same verdict already written for polling.
     expect(h.statesOf(lonely).at(-1)).toBe("failed");
     expect(h.detailOf(lonely, "failed")?.errorCode).toBe("ONCHAIN_FAILED");
-    const outcome = await settlesPromptly(waiting) as { ok?: { status: number } };
-    expect(outcome.ok?.status).toBe(0);
+    const outcome = await settlesPromptly(waiting) as { err?: unknown };
+    expect(outcome.err).toBeInstanceOf(InputTerminalError);
+    expect(outcome.err).toMatchObject({
+      statusCode: 422,
+      errorCode: "ONCHAIN_FAILED",
+      requestId: computeRequestId(lonely, TARGET),
+      transactionHash: "0xhash",
+      retryable: false,
+    });
   });
 });
 

--- a/packages/batcher/core/batch-processor.test.ts
+++ b/packages/batcher/core/batch-processor.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "bun:test";
 import { BatchProcessor, normalizeBatchOutcome } from "./batch-processor.ts";
-import { InputValidationError } from "./errors.ts";
+import { InputTerminalError, InputValidationError } from "./errors.ts";
+import { computeRequestId } from "./request-id.ts";
 import type { DefaultBatcherInput } from "./types.ts";
 import type {
   BatchSubmitResult,
@@ -103,8 +104,6 @@ function makeAdapter(
     getBlockNumber: async () => 1n,
   };
 }
-
-const redProofTest = process.env.BATCHER_RED_PROOF === "1" ? test : test.skip;
 
 // --- normalizeBatchOutcome --------------------------------------------
 
@@ -477,7 +476,7 @@ test("a bare-hash adapter still resolves every input from the receipt", async ()
 
 // --- Receipt settlement classification --------------------------------
 
-redProofTest("a failed one-input receipt rejects its waiting caller", async () => {
+test("a failed one-input receipt rejects its waiting caller", async () => {
   const h = makeHarness();
   const input = makeInput("single-failed");
   h.waitOn(input);
@@ -487,10 +486,40 @@ redProofTest("a failed one-input receipt rejects its waiting caller", async () =
     blockNumber: 2n,
     status: 0,
   });
+  const startedAt = performance.now();
+  await h.processor.processBatchForTarget(adapter, TARGET, [input]);
+
+  const settled = h.settled.get(input.address);
+  expect(settled?.status).toBe("rejected");
+  expect(settled?.value).toBeInstanceOf(InputTerminalError);
+  expect(settled?.value).toMatchObject({
+    statusCode: 422,
+    errorCode: "ONCHAIN_FAILED",
+    requestId: computeRequestId(input, TARGET),
+    transactionHash: "0xfailed",
+    retryable: false,
+  });
+  expect(performance.now() - startedAt).toBeLessThan(1_000);
+  expect(h.callbacks.has(input.address)).toBe(false);
+});
+
+test("a failed one-input receipt with a comma hash keeps shared semantics", async () => {
+  const h = makeHarness();
+  const input = makeInput("single-comma");
+  h.waitOn(input);
+
+  const adapter = makeAdapter([input], async () => "0xpart-a,0xpart-b", {
+    hash: "0xpart-a,0xpart-b",
+    blockNumber: 2n,
+    status: 0,
+  });
   await h.processor.processBatchForTarget(adapter, TARGET, [input]);
 
   expect(h.settled.get(input.address)?.status).toBe("rejected");
-  expect(h.callbacks.has(input.address)).toBe(false);
+  expect(h.settled.get(input.address)?.value).toMatchObject({
+    transactionHash: "0xpart-a,0xpart-b",
+    errorCode: "ONCHAIN_FAILED",
+  });
 });
 
 test("a successful one-input receipt still resolves its waiting caller", async () => {
@@ -545,6 +574,28 @@ test("per-input hashes retain their existing receipt settlement behavior", async
   expect((h.settled.get("multi-a")?.value as BlockchainTransactionReceipt).hash)
     .toBe("0xa");
   expect((h.settled.get("multi-b")?.value as BlockchainTransactionReceipt).hash)
+    .toBe("0xb");
+});
+
+test("successful per-input hashes still resolve each waiting caller", async () => {
+  const h = makeHarness();
+  const inputs = [makeInput("multi-success-a"), makeInput("multi-success-b")];
+  for (const input of inputs) h.waitOn(input);
+
+  const adapter = makeAdapter(inputs, async () => "0xa,0xb", {
+    hash: "0xa,0xb",
+    blockNumber: 6n,
+    status: 1,
+  });
+  await h.processor.processBatchForTarget(adapter, TARGET, inputs);
+
+  expect(inputs.map((input) => h.settled.get(input.address)?.status)).toEqual([
+    "resolved",
+    "resolved",
+  ]);
+  expect((h.settled.get("multi-success-a")?.value as BlockchainTransactionReceipt).hash)
+    .toBe("0xa");
+  expect((h.settled.get("multi-success-b")?.value as BlockchainTransactionReceipt).hash)
     .toBe("0xb");
 });
 

--- a/packages/batcher/core/batch-processor.test.ts
+++ b/packages/batcher/core/batch-processor.test.ts
@@ -86,12 +86,12 @@ function makeHarness(options: { removeError?: Error } = {}): Harness {
 function makeAdapter(
   inputs: DefaultBatcherInput[],
   submit: () => Promise<BatchSubmitResult<DefaultBatcherInput>>,
-): BlockchainAdapter<any> {
-  const receipt: BlockchainTransactionReceipt = {
+  receipt: BlockchainTransactionReceipt = {
     hash: "0xhash",
     blockNumber: 1n,
     status: 1,
-  };
+  },
+): BlockchainAdapter<any> {
   return {
     buildBatchData: () => ({ selectedInputs: inputs, data: { selectedInputs: [...inputs] } }),
     estimateBatchFee: () => "1",
@@ -103,6 +103,8 @@ function makeAdapter(
     getBlockNumber: async () => 1n,
   };
 }
+
+const redProofTest = process.env.BATCHER_RED_PROOF === "1" ? test : test.skip;
 
 // --- normalizeBatchOutcome --------------------------------------------
 
@@ -471,6 +473,79 @@ test("a bare-hash adapter still resolves every input from the receipt", async ()
   expect(h.retried).toEqual([]);
   expect(h.settled.get("a")?.status).toEqual("resolved");
   expect(h.settled.get("b")?.status).toEqual("resolved");
+});
+
+// --- Receipt settlement classification --------------------------------
+
+redProofTest("a failed one-input receipt rejects its waiting caller", async () => {
+  const h = makeHarness();
+  const input = makeInput("single-failed");
+  h.waitOn(input);
+
+  const adapter = makeAdapter([input], async () => "0xfailed", {
+    hash: "0xfailed",
+    blockNumber: 2n,
+    status: 0,
+  });
+  await h.processor.processBatchForTarget(adapter, TARGET, [input]);
+
+  expect(h.settled.get(input.address)?.status).toBe("rejected");
+  expect(h.callbacks.has(input.address)).toBe(false);
+});
+
+test("a successful one-input receipt still resolves its waiting caller", async () => {
+  const h = makeHarness();
+  const input = makeInput("single-success");
+  h.waitOn(input);
+
+  const adapter = makeAdapter([input], async () => "0xsuccess", {
+    hash: "0xsuccess",
+    blockNumber: 3n,
+    status: 1,
+  });
+  await h.processor.processBatchForTarget(adapter, TARGET, [input]);
+
+  expect(h.settled.get(input.address)?.status).toBe("resolved");
+});
+
+test("a failed shared receipt rejects every waiting caller in a multi-input batch", async () => {
+  const h = makeHarness();
+  const inputs = [makeInput("shared-a"), makeInput("shared-b")];
+  for (const input of inputs) h.waitOn(input);
+
+  const adapter = makeAdapter(inputs, async () => "0xshared", {
+    hash: "0xshared",
+    blockNumber: 4n,
+    status: 0,
+  });
+  await h.processor.processBatchForTarget(adapter, TARGET, inputs);
+
+  expect(inputs.map((input) => h.settled.get(input.address)?.status)).toEqual([
+    "rejected",
+    "rejected",
+  ]);
+});
+
+test("per-input hashes retain their existing receipt settlement behavior", async () => {
+  const h = makeHarness();
+  const inputs = [makeInput("multi-a"), makeInput("multi-b")];
+  for (const input of inputs) h.waitOn(input);
+
+  const adapter = makeAdapter(inputs, async () => "0xa,0xb", {
+    hash: "0xa,0xb",
+    blockNumber: 5n,
+    status: 0,
+  });
+  await h.processor.processBatchForTarget(adapter, TARGET, inputs);
+
+  expect(inputs.map((input) => h.settled.get(input.address)?.status)).toEqual([
+    "resolved",
+    "resolved",
+  ]);
+  expect((h.settled.get("multi-a")?.value as BlockchainTransactionReceipt).hash)
+    .toBe("0xa");
+  expect((h.settled.get("multi-b")?.value as BlockchainTransactionReceipt).hash)
+    .toBe("0xb");
 });
 
 test("a bare-hash adapter that splices inputs still charges them a retry", async () => {

--- a/packages/batcher/core/batch-processor.ts
+++ b/packages/batcher/core/batch-processor.ts
@@ -12,7 +12,7 @@ import type {
   TransitionOutcome,
 } from "./storage.ts";
 import { computeRequestId } from "./request-id.ts";
-import { InputValidationError } from "./errors.ts";
+import { InputTerminalError, InputValidationError } from "./errors.ts";
 import * as fs from "node:fs";
 
 /**
@@ -691,7 +691,7 @@ export class BatchProcessor<T extends DefaultBatcherInput> {
 
     // Resolve all callbacks with the receipt
     // Individual callers will decide if they want to continue waiting for EffectStream
-    this.resolveInputCallbacks(selectedInputs, receipt);
+    this.resolveInputCallbacks(selectedInputs, target, receipt);
 
     // Optional: Still trigger EffectStream processing check for event emission
     this.waitForEffectStreamProcessing(
@@ -758,16 +758,10 @@ export class BatchProcessor<T extends DefaultBatcherInput> {
    * Per-input hashes come from the same multi-hash split `resolveInputCallbacks`
    * uses, so a poller and a waiting caller are told about the same transaction.
    *
-   * The `status: 0` branch deliberately does NOT copy that method's extra
-   * `&& !isMultiHash` condition. `resolveInputCallbacks` hands the caller the
-   * raw receipt, so a caller who is resolved on a failed transaction can still
-   * read `status` and see it — nothing is claimed on their behalf. A status
-   * RECORD is a summarised verdict with nowhere to hide that nuance: writing
-   * `confirmed` for a transaction the chain marked failed would be a plain
-   * false statement, and this feature exists so that "complete" means it. (The
-   * `!isMultiHash` guard also makes the callback path treat a ONE-input batch
-   * as multi-hash — one hash, one input — so a single failed transaction
-   * resolves rather than rejects. Pre-existing; not changed here.)
+   * A failed chain receipt is terminal for a shared transaction and is
+   * recorded with the same hash/classification the waiting caller receives.
+   * Genuinely per-input hashes remain the adapter's existing protocol: one
+   * shared receipt cannot reveal an individual hash's status.
    */
   private async recordChainOutcome(
     selectedInputs: T[],
@@ -811,18 +805,25 @@ export class BatchProcessor<T extends DefaultBatcherInput> {
    * One transaction for the whole batch, or one per input?
    *
    * Adapters that submit per input report a comma-joined hash whose parts line
-   * up with `selectedInputs`. Any other count means the batch shares one hash.
+   * up with a multi-input `selectedInputs` list. Any other count means the
+   * batch shares one hash. A one-input batch is always shared/single-
+   * transaction semantics, even for a pathological hash containing a comma.
    */
   private splitReceiptHashes(
     selectedInputs: T[],
     receipt: BlockchainTransactionReceipt,
   ): { hashes: string[]; isMultiHash: boolean } {
     const hashes = receipt.hash.split(",");
-    return { hashes, isMultiHash: hashes.length === selectedInputs.length };
+    return {
+      hashes,
+      isMultiHash: selectedInputs.length > 1 &&
+        hashes.length === selectedInputs.length,
+    };
   }
 
   private resolveInputCallbacks(
     selectedInputs: T[],
+    target: string,
     receipt: BlockchainTransactionReceipt,
   ): void {
     const { hashes, isMultiHash } = this.splitReceiptHashes(
@@ -837,9 +838,19 @@ export class BatchProcessor<T extends DefaultBatcherInput> {
       if (callbacks) {
         const inputHash = isMultiHash ? hashes[i] : receipt.hash;
 
+        // Consume the waiter before invoking user-owned resolve/reject code so
+        // re-entrancy cannot settle it twice. Both terminal branches cancel
+        // the timeout and release the map entry identically.
+        clearTimeout(callbacks.timeoutId);
+        this.batcher.submissionCallbacks.delete(callbackKey);
+
         if (receipt.status === 0 && !isMultiHash) {
           callbacks.reject(
-            new Error(`Transaction failed on-chain: ${inputHash}`),
+            new InputTerminalError(
+              `Transaction failed on-chain: ${inputHash}`,
+              computeRequestId(input, target),
+              inputHash,
+            ),
           );
         } else {
           const inputReceipt = isMultiHash
@@ -847,9 +858,6 @@ export class BatchProcessor<T extends DefaultBatcherInput> {
             : receipt;
           callbacks.resolve(inputReceipt);
         }
-
-        clearTimeout(callbacks.timeoutId);
-        this.batcher.submissionCallbacks.delete(callbackKey);
       }
     }
   }

--- a/packages/batcher/core/batcher-events.test.ts
+++ b/packages/batcher/core/batcher-events.test.ts
@@ -1,12 +1,13 @@
 import { expect, test } from "bun:test";
 import { run, sleep } from "effection";
+import { readFileSync } from "node:fs";
 import type { BlockchainAdapter } from "../adapters/adapter.ts";
 import { Batcher } from "./batcher.ts";
+import { attachDefaultConsoleListeners } from "./batcher-events.ts";
 import type { BatcherStorage } from "./storage.ts";
 import type { DefaultBatcherInput } from "./types.ts";
 
 const TARGET = "events-test";
-const redProofTest = process.env.BATCHER_RED_PROOF === "1" ? test : test.skip;
 
 function makeInput(address = "event-wallet"): DefaultBatcherInput {
   return {
@@ -93,7 +94,7 @@ function listenForAsyncEvents(
   });
 }
 
-redProofTest("ordinary async lifecycle sites deliver all seven emissions", async () => {
+test("ordinary async lifecycle sites deliver all seven emissions", async () => {
   const seen: string[] = [];
   const storage = new MemoryStorage([makeInput()]);
   const port = Number(process.env.BATCHER_TEST_PORT ?? "18372");
@@ -171,4 +172,103 @@ test("the Effection generator emitter still invokes its listener", async () => {
   });
 
   expect(calls).toBe(1);
+});
+
+test("ordinary async code never awaits the Effection generator emitter", () => {
+  const source = readFileSync(new URL("./batcher.ts", import.meta.url), "utf8");
+  expect(source.match(/await this\.emitStateTransition\(/g) ?? []).toHaveLength(0);
+  expect(source.match(/yield\* (?:this|batcher)\.emitStateTransition\(/g) ?? [])
+    .toHaveLength(5);
+});
+
+test("disabling the event system suppresses async and Effection listeners", async () => {
+  const batcher = new Batcher({
+    adapters: { [TARGET]: makeAdapter() },
+    defaultTarget: TARGET,
+    enableHttpServer: false,
+    enableEventSystem: false,
+    pollingIntervalMs: 1_000_000,
+  }, new MemoryStorage());
+  let calls = 0;
+  batcher.addStateTransition("startup", () => {
+    calls += 1;
+  });
+  const payload = {
+    publicConfig: batcher.getPublicConfig(),
+    time: Date.now(),
+  };
+
+  await (batcher as any).emitStateTransitionAsync("startup", payload);
+  await run(function* () {
+    yield* batcher.emitStateTransition("startup", payload);
+    yield* sleep(10);
+  });
+
+  expect(calls).toBe(0);
+});
+
+test("the default startup listener prints its banner on async init", async () => {
+  const batcher = new Batcher({
+    adapters: { [TARGET]: makeAdapter() },
+    defaultTarget: TARGET,
+    enableHttpServer: false,
+    enableEventSystem: true,
+    pollingIntervalMs: 1_000_000,
+  }, new MemoryStorage());
+  attachDefaultConsoleListeners(batcher);
+  const logs: string[] = [];
+  const originalLog = console.log;
+  console.log = (...args: unknown[]) => logs.push(args.map(String).join(" "));
+  try {
+    await batcher.init({ startPolling: false });
+  } finally {
+    console.log = originalLog;
+  }
+
+  expect(logs.filter((line) => line.includes("Batcher started"))).toHaveLength(1);
+});
+
+test("throwing async listeners do not break init, poll, or batch work", async () => {
+  const storage = new MemoryStorage([makeInput("throwing-listener")]);
+  const batcher = new Batcher({
+    adapters: { [TARGET]: makeAdapter() },
+    defaultTarget: TARGET,
+    enableHttpServer: false,
+    enableEventSystem: true,
+    pollingIntervalMs: 1_000_000,
+  }, storage);
+  const reportedPhases: string[] = [];
+  batcher.addStateTransition("startup", () => {
+    throw new Error("startup-listener");
+  });
+  batcher.addStateTransition("poll:targets-ready", () => {
+    throw new Error("poll-listener");
+  });
+  batcher.addStateTransition("batch:process:start", () => {
+    throw new Error("batch-listener");
+  });
+  batcher.addStateTransition("error", ({ phase }) => {
+    reportedPhases.push(phase);
+  });
+
+  await batcher.init({ startPolling: false });
+  const internals = batcher as any;
+  const processTargets = internals.processBatchesForTargets.bind(batcher);
+  internals.isTargetReadyForBatching = async () => true;
+  internals.processBatchesForTargets = async () => {};
+  await batcher.pollBatcher();
+  internals.processBatchesForTargets = processTargets;
+
+  let batchesProcessed = 0;
+  internals.batchProcessor.processBatchForTarget = async () => {
+    batchesProcessed += 1;
+  };
+  await batcher.processBatchesForTargets([TARGET]);
+
+  expect(batchesProcessed).toBe(1);
+  expect(reportedPhases).toEqual([
+    "event-listener:startup",
+    "event-listener:poll:targets-ready",
+    "event-listener:batch:process:start",
+  ]);
 });

--- a/packages/batcher/core/batcher-events.test.ts
+++ b/packages/batcher/core/batcher-events.test.ts
@@ -1,0 +1,174 @@
+import { expect, test } from "bun:test";
+import { run, sleep } from "effection";
+import type { BlockchainAdapter } from "../adapters/adapter.ts";
+import { Batcher } from "./batcher.ts";
+import type { BatcherStorage } from "./storage.ts";
+import type { DefaultBatcherInput } from "./types.ts";
+
+const TARGET = "events-test";
+const redProofTest = process.env.BATCHER_RED_PROOF === "1" ? test : test.skip;
+
+function makeInput(address = "event-wallet"): DefaultBatcherInput {
+  return {
+    addressType: 0 as DefaultBatcherInput["addressType"],
+    address,
+    input: "event-payload",
+    signature: "event-signature",
+    timestamp: "2026-08-20T00:00:00.000Z",
+    target: TARGET,
+  };
+}
+
+class MemoryStorage implements BatcherStorage<DefaultBatcherInput> {
+  constructor(readonly inputs: DefaultBatcherInput[] = []) {}
+  async init(): Promise<void> {}
+  async addInput(input: DefaultBatcherInput): Promise<void> {
+    this.inputs.push(input);
+  }
+  async getAllInputs(): Promise<DefaultBatcherInput[]> {
+    return [...this.inputs];
+  }
+  async removeProcessedInputs(inputs: DefaultBatcherInput[]): Promise<void> {
+    for (const input of inputs) {
+      const index = this.inputs.indexOf(input);
+      if (index >= 0) this.inputs.splice(index, 1);
+    }
+  }
+  async getInputCountAndSize(): Promise<{ count: number; size: number }> {
+    return { count: this.inputs.length, size: 0 };
+  }
+  async getInputsByTarget(): Promise<DefaultBatcherInput[]> {
+    return [...this.inputs];
+  }
+  async incrementRetryCount(): Promise<void> {}
+  async clearAllInputs(): Promise<void> {
+    this.inputs.length = 0;
+  }
+}
+
+function makeAdapter(concurrent = false): BlockchainAdapter<any> {
+  return {
+    verifySignature: () => true,
+    getChainName: () => "events-test",
+    getAccountAddress: () => "batcher",
+    isReady: () => true,
+    getBlockNumber: async () => 1n,
+    buildBatchData: (inputs: DefaultBatcherInput[]) => ({
+      selectedInputs: inputs,
+      data: { selectedInputs: inputs },
+    }),
+    estimateBatchFee: () => 1n,
+    submitBatch: async () => "0xevents",
+    waitForTransactionReceipt: async () => ({
+      hash: "0xevents",
+      blockNumber: 1n,
+      status: 1,
+    }),
+    ...(concurrent
+      ? {
+        hasAvailableCapacity: () => true,
+        isFullyIdle: () => true,
+      }
+      : {}),
+  };
+}
+
+function listenForAsyncEvents(
+  batcher: Batcher<DefaultBatcherInput>,
+  seen: string[],
+): void {
+  batcher.addStateTransition("startup", () => seen.push("startup"));
+  batcher.addStateTransition("http:start", () => seen.push("http:start"));
+  batcher.addStateTransition("http:stop", () => seen.push("http:stop"));
+  batcher.addStateTransition(
+    "poll:targets-ready",
+    () => seen.push("poll:targets-ready"),
+  );
+  batcher.addStateTransition(
+    "batch:process:start",
+    () => seen.push("batch:process:start"),
+  );
+  batcher.addStateTransition("error", ({ error }) => {
+    seen.push(`error:${error instanceof Error ? error.message : String(error)}`);
+  });
+}
+
+redProofTest("ordinary async lifecycle sites deliver all seven emissions", async () => {
+  const seen: string[] = [];
+  const storage = new MemoryStorage([makeInput()]);
+  const port = Number(process.env.BATCHER_TEST_PORT ?? "18372");
+  const batcher = new Batcher({
+    adapters: { [TARGET]: makeAdapter() },
+    defaultTarget: TARGET,
+    enableHttpServer: true,
+    enableEventSystem: true,
+    pollingIntervalMs: 1_000_000,
+    port,
+  }, storage);
+  listenForAsyncEvents(batcher, seen);
+
+  await batcher.init({ startPolling: false });
+
+  const internals = batcher as any;
+  const processTargets = internals.processBatchesForTargets.bind(batcher);
+  internals.isTargetReadyForBatching = async () => true;
+  internals.processBatchesForTargets = async () => {};
+  await batcher.pollBatcher();
+  internals.processBatchesForTargets = processTargets;
+
+  internals.batchProcessor.processBatchForTarget = async () => {
+    throw new Error("sequential-site");
+  };
+  await batcher.processBatchesForTargets([TARGET]);
+  await batcher.stopHttpServer();
+
+  const concurrent = new Batcher({
+    adapters: { [TARGET]: makeAdapter(true) },
+    defaultTarget: TARGET,
+    enableHttpServer: false,
+    enableEventSystem: true,
+    pollingIntervalMs: 1_000_000,
+  }, new MemoryStorage([makeInput("concurrent-wallet")]));
+  concurrent.addStateTransition("error", ({ error }) => {
+    seen.push(`error:${error instanceof Error ? error.message : String(error)}`);
+  });
+  (concurrent as any).batchProcessor.processBatchForTarget = async () => {
+    throw new Error("concurrent-site");
+  };
+  await concurrent.processBatchesForTargets([TARGET]);
+  await new Promise((resolve) => setTimeout(resolve, 10));
+
+  expect(seen).toEqual([
+    "http:start",
+    "startup",
+    "poll:targets-ready",
+    "batch:process:start",
+    "error:sequential-site",
+    "http:stop",
+    "error:concurrent-site",
+  ]);
+});
+
+test("the Effection generator emitter still invokes its listener", async () => {
+  const batcher = new Batcher({
+    adapters: { [TARGET]: makeAdapter() },
+    defaultTarget: TARGET,
+    enableHttpServer: false,
+    enableEventSystem: true,
+    pollingIntervalMs: 1_000_000,
+  }, new MemoryStorage());
+  let calls = 0;
+  batcher.addStateTransition("startup", () => {
+    calls += 1;
+  });
+
+  await run(function* () {
+    yield* batcher.emitStateTransition("startup", {
+      publicConfig: batcher.getPublicConfig(),
+      time: Date.now(),
+    });
+    yield* sleep(10);
+  });
+
+  expect(calls).toBe(1);
+});

--- a/packages/batcher/core/batcher-events.test.ts
+++ b/packages/batcher/core/batcher-events.test.ts
@@ -41,7 +41,9 @@ class MemoryStorage implements BatcherStorage<DefaultBatcherInput> {
   async getInputsByTarget(): Promise<DefaultBatcherInput[]> {
     return [...this.inputs];
   }
-  async incrementRetryCount(): Promise<void> {}
+  async incrementRetryCount(): Promise<DefaultBatcherInput[]> {
+    return [];
+  }
   async clearAllInputs(): Promise<void> {
     this.inputs.length = 0;
   }
@@ -78,16 +80,26 @@ function listenForAsyncEvents(
   batcher: Batcher<DefaultBatcherInput>,
   seen: string[],
 ): void {
-  batcher.addStateTransition("startup", () => seen.push("startup"));
-  batcher.addStateTransition("http:start", () => seen.push("http:start"));
-  batcher.addStateTransition("http:stop", () => seen.push("http:stop"));
+  batcher.addStateTransition("startup", () => {
+    seen.push("startup");
+  });
+  batcher.addStateTransition("http:start", () => {
+    seen.push("http:start");
+  });
+  batcher.addStateTransition("http:stop", () => {
+    seen.push("http:stop");
+  });
   batcher.addStateTransition(
     "poll:targets-ready",
-    () => seen.push("poll:targets-ready"),
+    () => {
+      seen.push("poll:targets-ready");
+    },
   );
   batcher.addStateTransition(
     "batch:process:start",
-    () => seen.push("batch:process:start"),
+    () => {
+      seen.push("batch:process:start");
+    },
   );
   batcher.addStateTransition("error", ({ error }) => {
     seen.push(`error:${error instanceof Error ? error.message : String(error)}`);

--- a/packages/batcher/core/batcher.ts
+++ b/packages/batcher/core/batcher.ts
@@ -44,7 +44,7 @@ import { ENV } from "@effectstream/utils/node-env";
 // Defined in ./errors.ts so `batch-processor.ts` can throw the same class
 // without importing this module back. Re-exported here because it has always
 // been part of this module's public surface.
-export { InputValidationError } from "./errors.ts";
+export { InputTerminalError, InputValidationError } from "./errors.ts";
 
 export interface AuthenticatedInputContext {
   /** Adapter target resolved and verified by the batcher. */

--- a/packages/batcher/core/batcher.ts
+++ b/packages/batcher/core/batcher.ts
@@ -592,7 +592,7 @@ export class Batcher<T extends DefaultBatcherInput = DefaultBatcherInput> {
     }
 
     this.isInitialized = true;
-    await this.emitStateTransition("startup", {
+    await this.emitStateTransitionAsync("startup", {
       publicConfig: this.getPublicConfig(),
       time: Date.now(),
     });
@@ -1056,7 +1056,7 @@ export class Batcher<T extends DefaultBatcherInput = DefaultBatcherInput> {
     }
 
     if (targetsToProcess.length === 0) return;
-    await this.emitStateTransition("poll:targets-ready", {
+    await this.emitStateTransitionAsync("poll:targets-ready", {
       targets: targetsToProcess,
       time: Date.now(),
     });
@@ -1352,7 +1352,7 @@ export class Batcher<T extends DefaultBatcherInput = DefaultBatcherInput> {
 
     try {
       this.httpServer = await startBatcherHttpServer(this, this.port);
-      await this.emitStateTransition("http:start", {
+      await this.emitStateTransitionAsync("http:start", {
         port: this.port,
         time: Date.now(),
       });
@@ -1369,7 +1369,7 @@ export class Batcher<T extends DefaultBatcherInput = DefaultBatcherInput> {
     if (this.httpServer) {
       await this.httpServer.close();
       this.httpServer = undefined;
-      await this.emitStateTransition("http:stop", { time: Date.now() });
+      await this.emitStateTransitionAsync("http:stop", { time: Date.now() });
     }
   }
 
@@ -1843,7 +1843,7 @@ export class Batcher<T extends DefaultBatcherInput = DefaultBatcherInput> {
               `Error processing concurrent batch for target ${target}:`,
               error,
             );
-            await this.emitStateTransition("error", {
+            await this.emitStateTransitionAsync("error", {
               phase: "batch",
               target,
               error,
@@ -1862,7 +1862,7 @@ export class Batcher<T extends DefaultBatcherInput = DefaultBatcherInput> {
       } else {
         // Sequential path. processingAdapters was already added above.
         try {
-          await this.emitStateTransition("batch:process:start", {
+          await this.emitStateTransitionAsync("batch:process:start", {
             target,
             inputCount: targetInputs.length,
             time: Date.now(),
@@ -1877,7 +1877,7 @@ export class Batcher<T extends DefaultBatcherInput = DefaultBatcherInput> {
             `Error processing batch for target ${target}:`,
             error,
           );
-          await this.emitStateTransition("error", {
+          await this.emitStateTransitionAsync("error", {
             phase: "batch",
             target,
             error,

--- a/packages/batcher/core/errors.ts
+++ b/packages/batcher/core/errors.ts
@@ -30,3 +30,25 @@ export class InputValidationError extends Error {
     this.name = "InputValidationError";
   }
 }
+
+/**
+ * An accepted input reached a definitive unsuccessful terminal state.
+ *
+ * This is deliberately not an {@link InputValidationError}: intake succeeded,
+ * the request was queued and submitted, and the chain later mined a reverted
+ * transaction. SDK and HTTP callers receive the same stable terminal verdict.
+ */
+export class InputTerminalError extends Error {
+  public readonly statusCode = 422;
+  public readonly errorCode = "ONCHAIN_FAILED";
+  public readonly retryable = false;
+
+  constructor(
+    message: string,
+    public readonly requestId: string,
+    public readonly transactionHash: string,
+  ) {
+    super(message);
+    this.name = "InputTerminalError";
+  }
+}

--- a/packages/batcher/mod.ts
+++ b/packages/batcher/mod.ts
@@ -7,7 +7,12 @@
  */
 
 // Core batcher functionality
-export { Batcher, createNewBatcher } from "./core/batcher.ts";
+export {
+  Batcher,
+  createNewBatcher,
+  InputTerminalError,
+  InputValidationError,
+} from "./core/batcher.ts";
 
 // Configuration types and validation
 export type {

--- a/packages/batcher/server/batcher-server-onchain-failure.test.ts
+++ b/packages/batcher/server/batcher-server-onchain-failure.test.ts
@@ -1,0 +1,188 @@
+import { expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import {
+  createNewBatcher,
+  InputTerminalError,
+  type Batcher,
+} from "../core/batcher.ts";
+import { ONCHAIN_FAILED } from "../core/batch-processor.ts";
+import { computeRequestId } from "../core/request-id.ts";
+import { DatabaseStorage } from "../core/storage.ts";
+import type { DefaultBatcherInput } from "../core/types.ts";
+import { startBatcherHttpServer } from "./batcher-server.ts";
+
+const TARGET = "failed-chain-test";
+
+function input(nonce: string): DefaultBatcherInput {
+  return {
+    addressType: 5 as DefaultBatcherInput["addressType"],
+    address: `failed-wallet-${nonce}`,
+    input: JSON.stringify({ nonce }),
+    timestamp: String(Date.now()),
+    signature: `failed-signature-${nonce}`,
+    target: TARGET,
+  };
+}
+
+function failedAdapter() {
+  return {
+    verifySignature: () => true,
+    validateInput: async () => ({ valid: true }),
+    buildBatchData: (inputs: DefaultBatcherInput[]) => ({
+      selectedInputs: inputs,
+      data: { inputs },
+    }),
+    estimateBatchFee: () => 0n,
+    submitBatch: async () => "0xreverted",
+    waitForTransactionReceipt: async () => ({
+      hash: "0xreverted",
+      blockNumber: 9001n,
+      status: 0,
+    }),
+    getAccountAddress: () => "failed-chain-batcher",
+    getChainName: () => "failed-chain",
+    isReady: () => true,
+    getBlockNumber: async () => 9001n,
+  };
+}
+
+interface FailureContext {
+  batcher: Batcher<DefaultBatcherInput>;
+  storage: DatabaseStorage;
+  terminal: any[];
+}
+
+async function withFailureBatcher(
+  fn: (context: FailureContext) => Promise<void>,
+): Promise<void> {
+  const dir = mkdtempSync(path.join(tmpdir(), "batcher-onchain-failure-"));
+  const storage = new DatabaseStorage({ dataDirectory: dir });
+  const batcher = createNewBatcher({
+    pollingIntervalMs: 1_000_000,
+    enableHttpServer: false,
+    enableEventSystem: true,
+  }, storage as any) as Batcher<DefaultBatcherInput>;
+  batcher.addBlockchainAdapter(TARGET, failedAdapter() as any, {
+    criteriaType: "size",
+    maxBatchSize: 1,
+  });
+  const terminal: any[] = [];
+  batcher.addStateTransition(
+    "request:terminal" as never,
+    ((payload: unknown) => terminal.push(payload)) as never,
+  );
+  await batcher.init({ startPolling: false });
+  try {
+    await fn({ batcher, storage, terminal });
+  } finally {
+    await (batcher as any).gracefulShutdown().catch(() => {});
+    await storage.close().catch(() => {});
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+async function waitUntilQueued(storage: DatabaseStorage): Promise<void> {
+  for (let attempt = 0; attempt < 200; attempt++) {
+    if ((await storage.getAllInputs()).length > 0) return;
+    await Bun.sleep(5);
+  }
+  throw new Error("input was not queued before the test deadline");
+}
+
+test("SDK, terminal event, and polling agree on one failed transaction", async () => {
+  await withFailureBatcher(async ({ batcher, storage, terminal }) => {
+    const payload = input("sdk");
+    const requestId = computeRequestId(payload, TARGET);
+    const pending = batcher.batchInput(payload, "wait-receipt", 20_000);
+    await waitUntilQueued(storage);
+
+    const startedAt = performance.now();
+    await batcher.forceProcessBatches(TARGET);
+    const error = await pending.catch((caught) => caught);
+
+    expect(error).toBeInstanceOf(InputTerminalError);
+    expect(error).toMatchObject({
+      statusCode: 422,
+      errorCode: ONCHAIN_FAILED,
+      requestId,
+      transactionHash: "0xreverted",
+      retryable: false,
+    });
+    expect(performance.now() - startedAt).toBeLessThan(5_000);
+    expect((batcher as any).submissionCallbacks.size).toBe(0);
+
+    expect(terminal).toHaveLength(1);
+    expect(terminal[0]).toMatchObject({
+      requestId,
+      target: TARGET,
+      state: "failed",
+      transactionHash: "0xreverted",
+      errorCode: ONCHAIN_FAILED,
+    });
+    expect(await storage.getStatus(requestId)).toMatchObject({
+      requestId,
+      state: "failed",
+      transactionHash: "0xreverted",
+      errorCode: ONCHAIN_FAILED,
+    });
+  });
+}, { timeout: 30_000 });
+
+test("HTTP wait-receipt returns structured 422 and its id polls failed", async () => {
+  await withFailureBatcher(async ({ batcher, storage, terminal }) => {
+    const port = Number(process.env.BATCHER_TEST_PORT ?? "18379");
+    const server = await startBatcherHttpServer(batcher, port);
+    try {
+      const payload = input("http");
+      const requestId = computeRequestId(payload, TARGET);
+      const pending = server.inject({
+        method: "POST",
+        url: "/send-input",
+        payload: {
+          confirmationLevel: "wait-receipt",
+          timeoutMs: 20_000,
+          data: payload,
+        },
+      });
+      await waitUntilQueued(storage);
+      await batcher.forceProcessBatches(TARGET);
+
+      const response = await pending;
+      expect(response.statusCode).toBe(422);
+      expect(response.json()).toEqual({
+        success: false,
+        error: "On-chain transaction failed",
+        message: "Transaction failed on-chain: 0xreverted",
+        requestId,
+        transactionHash: "0xreverted",
+        errorCode: ONCHAIN_FAILED,
+        retryable: false,
+      });
+
+      const poll = await server.inject({
+        method: "GET",
+        url: `/input-status/${requestId}`,
+      });
+      expect(poll.statusCode).toBe(200);
+      expect(poll.json()).toMatchObject({
+        status: "failed",
+        subState: "failed",
+        transactionHash: "0xreverted",
+        errorCode: ONCHAIN_FAILED,
+      });
+      expect(terminal).toHaveLength(1);
+      expect(terminal[0]).toMatchObject({
+        requestId,
+        state: "failed",
+        transactionHash: "0xreverted",
+        errorCode: ONCHAIN_FAILED,
+      });
+      expect((batcher as any).submissionCallbacks.size).toBe(0);
+    } finally {
+      await server.close();
+    }
+  });
+}, { timeout: 30_000 });

--- a/packages/batcher/server/batcher-server-onchain-failure.test.ts
+++ b/packages/batcher/server/batcher-server-onchain-failure.test.ts
@@ -152,7 +152,7 @@ test("HTTP wait-receipt returns structured 422 and its id polls failed", async (
 
       const response = await pending;
       expect(response.statusCode).toBe(422);
-      expect(response.json()).toEqual({
+      expect(response.json() as Record<string, unknown>).toEqual({
         success: false,
         error: "On-chain transaction failed",
         message: "Transaction failed on-chain: 0xreverted",

--- a/packages/batcher/server/batcher-server.ts
+++ b/packages/batcher/server/batcher-server.ts
@@ -2,7 +2,10 @@ import fastify, { type FastifyInstance, type FastifyRequest } from "fastify";
 import cors from "@fastify/cors";
 import { type Static, Type } from "@sinclair/typebox";
 import type { Batcher, DefaultBatcherInput } from "../core/mod.ts";
-import { InputValidationError } from "../core/batcher.ts";
+import {
+  InputTerminalError,
+  InputValidationError,
+} from "../core/batcher.ts";
 import fastifySwagger, {
   type FastifyDynamicSwaggerOptions,
 } from "@fastify/swagger";
@@ -158,6 +161,18 @@ async function registerOpenApiDocumentation(
         error: "Validation failed",
         message: "Invalid request data",
         details: (error as any).validation
+      });
+    }
+
+    if (error instanceof InputTerminalError) {
+      return reply.status(error.statusCode).send({
+        success: false,
+        error: "On-chain transaction failed",
+        message: error.message,
+        requestId: error.requestId,
+        transactionHash: error.transactionHash,
+        errorCode: error.errorCode,
+        retryable: error.retryable,
       });
     }
 
@@ -461,6 +476,29 @@ export async function startBatcherHttpServer<T extends DefaultBatcherInput>(
           message: Type.String(),
           retryAfter: Type.Optional(Type.Number()),
         }),
+        // The input was accepted and submitted, but its shared transaction was
+        // mined unsuccessfully. This is terminal execution, not validation.
+        422: Type.Union([
+          Type.Object({
+            success: Type.Boolean(),
+            error: Type.String(),
+            message: Type.String(),
+            requestId: Type.String(),
+            transactionHash: Type.String(),
+            errorCode: Type.Literal("ONCHAIN_FAILED"),
+            retryable: Type.Literal(false),
+          }),
+          // Existing adapters may use 422 for a deterministic late validation
+          // verdict. Preserve that additive contract alongside terminal chain
+          // execution without requiring transaction fields it cannot have.
+          Type.Object({
+            success: Type.Boolean(),
+            error: Type.String(),
+            message: Type.String(),
+            errorCode: Type.Optional(Type.String()),
+            retryable: Type.Optional(Type.Boolean()),
+          }),
+        ]),
         // Validation could not be COMPLETED — a dependency of the check was
         // unavailable. Distinct from 400: the input was never judged, so the
         // caller should retry rather than change it.
@@ -643,6 +681,18 @@ export async function startBatcherHttpServer<T extends DefaultBatcherInput>(
       }
 
       console.error("Error adding input to batcher:", error);
+
+      if (error instanceof InputTerminalError) {
+        return reply.status(error.statusCode).send({
+          success: false,
+          error: "On-chain transaction failed",
+          message: error.message,
+          requestId: error.requestId,
+          transactionHash: error.transactionHash,
+          errorCode: error.errorCode,
+          retryable: error.retryable,
+        });
+      }
 
       if (error instanceof InputValidationError) {
         return reply.status(error.statusCode).send({


### PR DESCRIPTION
## Summary

Fixes two correctness bugs found while auditing #873:

- Ordinary async lifecycle sites awaited `emitStateTransition`, but that API is an Effection generator. Awaiting the generator only returns the inert iterator, so none of seven listeners ran. Those sites now call the Promise bridge `emitStateTransitionAsync`; the five genuine `yield*` sites remain unchanged.
- Receipt classification treated one input plus one hash as per-input multi-hash mode because hash count equaled input count. That bypassed the shared-transaction status-0 rejection and falsely resolved the SDK waiter. Per-input mode now requires more than one selected input, and a shared status-0 receipt rejects through one typed terminal error.

This PR extends #873; #873 remains unmerged. Its base is exactly `00011-batcher-request-tracking`.

## Red evidence on the #873 base

- Receipt proof: one input, one status-0 receipt expected rejection but received resolution; 21 pass / 1 fail / 78 assertions.
- Lifecycle proof: all seven ordinary async events expected in order but received `[]`; the Effection `yield*` control passed; 1 pass / 1 fail / 2 assertions.

## Behavior contract

| Inputs / hashes / receipt | Result |
|---|---|
| 1 / shared hash / status 0 | SDK rejects `InputTerminalError`; HTTP 422; poll and terminal event report `failed/ONCHAIN_FAILED` |
| 1 / shared hash / status 1 | resolves unchanged |
| N / shared hash / status 0 | all waiters reject unchanged, now with the typed error |
| N / N hashes / status 0 or 1 | existing genuine per-input-hash behavior remains unchanged |
| 1 / comma-containing hash / status 0 | shared semantics; rejects with the complete hash |

The stable HTTP 422 terminal body contains `requestId`, `transactionHash`, `errorCode: ONCHAIN_FAILED`, and `retryable: false`. The `/send-input` response schema declares this branch alongside the existing intake-validation 422 shape so Fastify serialization preserves both contracts.

## Verification

- Targeted receipt matrix: 26 pass / 0 fail / 101 assertions.
- Targeted typecheck-fixture behavior: 8 pass / 0 fail / 22 assertions.
- Final full Docker streak: 545 pass / 0 fail, three consecutive clean runs (192.20s, 195.18s, 189.94s).
- `bun.lock` is byte-identical to the base.
- Pinned TypeScript 5.9.2 narrowed diagnostics introduce no new error versus exact base `daf58876`; repository-wide typecheck gaps remain pre-existing.

## Compatibility

Non-breaking and additive: one previously false-success terminal path now correctly rejects, one typed error is exported, one explicit terminal HTTP 422 shape is added, and dormant documented lifecycle events now fire. No dependency, storage, retry, row-removal, or successful receipt behavior changes.