### PR TITLE
perf(batcher): recover PgLite submit latency under batching

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -574,6 +574,7 @@
         "@midnightntwrk/wallet-sdk-unshielded-wallet": "3.1.0",
         "@noble/hashes": "^2.2.0",
         "@noble/secp256k1": "^3.1.0",
+        "@pgtyped/runtime": "2.4.2",
         "@sinclair/typebox": "0.34.41",
         "@solana/web3.js": "^1.95.0",
         "bitcoinjs-lib": "^6.1.5",
@@ -586,6 +587,9 @@
         "tiny-secp256k1": "^2.2.1",
         "tweetnacl": "^1.0.3",
         "viem": "2.37.3",
+      },
+      "devDependencies": {
+        "@paima/pgtyped-cli": "^2.4.5",
       },
     },
     "packages/binaries/avail-light-client": {

--- a/packages/batcher/core/batch-processor-status.test.ts
+++ b/packages/batcher/core/batch-processor-status.test.ts
@@ -60,11 +60,16 @@ interface HarnessOptions {
   transitionError?: Error;
   /** Drop `recordTransition` entirely — a queue-only backend. */
   untracked?: boolean;
+  /** Advertise the additive bulk transition capability. */
+  bulk?: boolean;
+  /** Throw only from the bulk capability; individual fallback stays healthy. */
+  bulkError?: Error;
 }
 
 interface Harness {
   processor: BatchProcessor<DefaultBatcherInput>;
   recorded: Recorded[];
+  bulkCalls: Recorded[][];
   events: { prefix: string; payload: any }[];
   removed: DefaultBatcherInput[];
   /** Transitions already recorded at the moment removal was attempted. */
@@ -88,6 +93,7 @@ interface Harness {
 
 function makeHarness(options: HarnessOptions = {}): Harness {
   const recorded: Recorded[] = [];
+  const bulkCalls: Recorded[][] = [];
   const events: { prefix: string; payload: any }[] = [];
   const removed: DefaultBatcherInput[] = [];
   let recordedAtRemoval: Recorded[] = [];
@@ -124,6 +130,21 @@ function makeHarness(options: HarnessOptions = {}): Harness {
       options.dropOnRetry?.(inputs) ?? [],
   };
   if (!options.untracked) storage.recordTransition = recordTransition;
+  if (!options.untracked && options.bulk) {
+    storage.recordTransitions = async (transitions: Recorded[]) => {
+      if (options.bulkError) throw options.bulkError;
+      bulkCalls.push(transitions.map((transition) => ({ ...transition })));
+      return await Promise.all(
+        transitions.map((transition) =>
+          recordTransition(
+            transition.requestId,
+            transition.state,
+            transition.detail,
+          )
+        ),
+      );
+    };
+  }
 
   const processor = new BatchProcessor<DefaultBatcherInput>({
     emitStateTransition: async (prefix: string, payload: any) => {
@@ -140,6 +161,7 @@ function makeHarness(options: HarnessOptions = {}): Harness {
   return {
     processor,
     recorded,
+    bulkCalls,
     events,
     removed,
     get recordedAtRemoval() {
@@ -553,6 +575,84 @@ describe("a mixed batch", () => {
 // --- Recording must never be able to break a batch ---------------------
 
 describe("the status write is observation, never judgement", () => {
+  test("a bulk-capable backend receives one call per common stage", async () => {
+    const h = makeHarness({ bulk: true });
+    const inputs = [makeInput("bulk-a"), makeInput("bulk-b")];
+
+    await h.processor.processBatchForTarget(
+      makeAdapter(inputs, async () => "0xhash"),
+      TARGET,
+      inputs,
+    );
+
+    expect(h.bulkCalls.map((call) => call.map((entry) => entry.state)))
+      .toEqual([
+        ["batching", "batching"],
+        ["submitted", "submitted"],
+        ["confirmed", "confirmed"],
+      ]);
+    expect(h.statesOf(inputs[0])).toEqual(["batching", "submitted", "confirmed"]);
+    expect(h.statesOf(inputs[1])).toEqual(["batching", "submitted", "confirmed"]);
+  });
+
+  test("same-reason terminal groups use one bulk call with per-input detail", async () => {
+    const rejected = [makeInput("reject-a"), makeInput("reject-b")];
+    const exhausted = [makeInput("exhaust-a"), makeInput("exhaust-b")];
+    const inputs = [...rejected, ...exhausted];
+    const h = makeHarness({
+      bulk: true,
+      dropOnRetry: (charged) =>
+        charged.map((input) => ({ ...input, retryCount: 3 })),
+    });
+
+    await h.processor.processBatchForTarget(
+      makeAdapter(inputs, async () => ({
+        permanentRejected: rejected.map((input, index) => ({
+          input,
+          error: `bad input ${index}`,
+          errorCode: `BAD_${index}`,
+        })),
+        failed: exhausted.map((input, index) => ({
+          input,
+          error: `retry diagnostic ${index}`,
+        })),
+      })),
+      TARGET,
+      inputs,
+    );
+
+    expect(h.bulkCalls.map((call) => call.map((entry) => entry.state)))
+      .toEqual([
+        ["batching", "batching", "batching", "batching"],
+        ["failed", "failed"],
+        ["failed", "failed"],
+      ]);
+    expect(h.detailOf(rejected[0], "failed")).toMatchObject({
+      errorCode: "BAD_0",
+      message: "bad input 0",
+    });
+    expect(h.detailOf(exhausted[1], "failed")).toMatchObject({
+      errorCode: "RETRIES_EXHAUSTED",
+      message: expect.stringContaining("retry diagnostic 1"),
+      retryCount: 3,
+    });
+  });
+
+  test("an exceptional bulk throw falls back without blocking chain work", async () => {
+    const h = makeHarness({ bulk: true, bulkError: new Error("bulk unavailable") });
+    const inputs = [makeInput("fallback-a"), makeInput("fallback-b")];
+
+    await h.processor.processBatchForTarget(
+      makeAdapter(inputs, async () => "0xhash"),
+      TARGET,
+      inputs,
+    );
+
+    expect(h.removed).toEqual(inputs);
+    expect(h.statesOf(inputs[0])).toEqual(["batching", "submitted", "confirmed"]);
+    expect(h.statesOf(inputs[1])).toEqual(["batching", "submitted", "confirmed"]);
+  });
+
   test("a refused transition is normal operation, not a batch failure", async () => {
     const h = makeHarness({ refuseTransitions: true });
     const good = makeInput("good");

--- a/packages/batcher/core/batch-processor.ts
+++ b/packages/batcher/core/batch-processor.ts
@@ -8,6 +8,7 @@ import type {
 import type { DefaultBatcherInput } from "./types.ts";
 import type {
   RequestState,
+  RequestTransition,
   RequestTransitionDetail,
   TransitionOutcome,
 } from "./storage.ts";
@@ -85,6 +86,9 @@ export class BatchProcessor<T extends DefaultBatcherInput> {
           state: RequestState,
           detail?: RequestTransitionDetail,
         ) => Promise<TransitionOutcome>;
+        recordTransitions?: (
+          transitions: readonly RequestTransition[],
+        ) => Promise<TransitionOutcome[]>;
       };
       submissionCallbacks: Map<
         string,
@@ -152,7 +156,7 @@ export class BatchProcessor<T extends DefaultBatcherInput> {
     const requestId = computeRequestId(input, target);
     try {
       const outcome = await storage.recordTransition(requestId, state, detail);
-      if (!outcome.applied) {
+      if (outcome.applied === false) {
         debugLog(
           `[BatchProcessor] Status transition → ${state} refused for request ` +
             `${requestId.substring(0, 12)}… (${outcome.refused}); the record ` +
@@ -174,8 +178,48 @@ export class BatchProcessor<T extends DefaultBatcherInput> {
     state: RequestState,
     detail?: (input: T) => RequestTransitionDetail | undefined,
   ): Promise<void> {
-    for (const input of inputs) {
-      await this.transition(input, target, state, detail?.(input));
+    const storage = this.batcher.storage;
+    if (inputs.length === 0 || typeof storage.recordTransition !== "function") {
+      return;
+    }
+    const transitions = inputs.map((input): RequestTransition => ({
+      requestId: computeRequestId(input, target),
+      state,
+      detail: detail?.(input),
+    }));
+    if (typeof storage.recordTransitions === "function") {
+      try {
+        const outcomes = await storage.recordTransitions(transitions);
+        if (outcomes.length !== transitions.length) {
+          throw new Error(
+            `bulk backend returned ${outcomes.length} outcomes for ` +
+              `${transitions.length} transitions`,
+          );
+        }
+        outcomes.forEach((outcome, index) => {
+          if (outcome.applied === false) {
+            debugLog(
+              `[BatchProcessor] Status transition → ${state} refused for request ` +
+                `${transitions[index].requestId.substring(0, 12)}… ` +
+                `(${outcome.refused}); the record already knows better.`,
+            );
+          }
+        });
+        return;
+      } catch (error) {
+        console.warn(
+          `[BatchProcessor] Bulk status transition → ${state} failed for ` +
+            `${transitions.length} request(s); retrying individual status writes: ${error}`,
+        );
+      }
+    }
+    for (let index = 0; index < inputs.length; index++) {
+      await this.transition(
+        inputs[index],
+        target,
+        state,
+        transitions[index].detail,
+      );
     }
   }
 
@@ -253,18 +297,29 @@ export class BatchProcessor<T extends DefaultBatcherInput> {
         `caller and recording the terminal state.`,
     );
 
+    const terminalDetails = new Map<string, RequestTransitionDetail>();
     for (const input of dropped) {
       const retryCount = input.retryCount ?? maxRetries;
       const diagnostic = reasons?.get(computeRequestId(input, target));
       const message = `Input dropped after ${retryCount} failed submission ` +
         `attempt(s) for target ${target}` +
         (diagnostic ? `: ${diagnostic}` : ".");
-
-      await this.transition(input, target, "failed", {
+      terminalDetails.set(computeRequestId(input, target), {
         errorCode: RETRIES_EXHAUSTED,
         message,
         retryCount,
       });
+    }
+    await this.transitionAll(
+      dropped,
+      target,
+      "failed",
+      (input) => terminalDetails.get(computeRequestId(input, target)),
+    );
+
+    for (const input of dropped) {
+      const detail = terminalDetails.get(computeRequestId(input, target))!;
+      const message = detail.message!;
 
       // The callback key excludes `retryCount`, so the row storage handed back
       // still finds the caller that submitted it.
@@ -623,14 +678,23 @@ export class BatchProcessor<T extends DefaultBatcherInput> {
       );
     }
 
+    const rejectionDetails = new Map<string, RequestTransitionDetail>(
+      rejections.map((rejection) => [
+        computeRequestId(rejection.input, target),
+        { errorCode: rejection.errorCode, message: rejection.error },
+      ]),
+    );
+    await this.transitionAll(
+      rejections.map((rejection) => rejection.input),
+      target,
+      "failed",
+      (input) => rejectionDetails.get(computeRequestId(input, target)),
+    );
+
     for (const rejection of rejections) {
       // The adapter's own verdict, recorded verbatim: a poller and a waiting
       // caller must be told the same thing, and the errorCode is what a client
       // is supposed to branch on.
-      await this.transition(rejection.input, target, "failed", {
-        errorCode: rejection.errorCode,
-        message: rejection.error,
-      });
       await this.emitTerminal(rejection.input, target, "failed", {
         errorCode: rejection.errorCode,
       });
@@ -773,17 +837,32 @@ export class BatchProcessor<T extends DefaultBatcherInput> {
       receipt,
     );
 
+    const details = new Map<string, RequestTransitionDetail>();
+    selectedInputs.forEach((input, index) => {
+      const inputHash = isMultiHash ? hashes[index] : receipt.hash;
+      details.set(
+        computeRequestId(input, target),
+        receipt.status === 0
+          ? {
+            transactionHash: inputHash,
+            errorCode: ONCHAIN_FAILED,
+            message: `Transaction failed on-chain: ${inputHash}`,
+          }
+          : { transactionHash: inputHash, blockNumber: receipt.blockNumber },
+      );
+    });
+    await this.transitionAll(
+      selectedInputs,
+      target,
+      receipt.status === 0 ? "failed" : "confirmed",
+      (input) => details.get(computeRequestId(input, target)),
+    );
+
     for (let i = 0; i < selectedInputs.length; i++) {
       const input = selectedInputs[i];
       const inputHash = isMultiHash ? hashes[i] : receipt.hash;
 
       if (receipt.status === 0) {
-        const message = `Transaction failed on-chain: ${inputHash}`;
-        await this.transition(input, target, "failed", {
-          transactionHash: inputHash,
-          errorCode: ONCHAIN_FAILED,
-          message,
-        });
         await this.emitTerminal(input, target, "failed", {
           transactionHash: inputHash,
           errorCode: ONCHAIN_FAILED,
@@ -791,10 +870,6 @@ export class BatchProcessor<T extends DefaultBatcherInput> {
         continue;
       }
 
-      await this.transition(input, target, "confirmed", {
-        transactionHash: inputHash,
-        blockNumber: receipt.blockNumber,
-      });
       await this.emitTerminal(input, target, "confirmed", {
         transactionHash: inputHash,
       });

--- a/packages/batcher/core/batcher.ts
+++ b/packages/batcher/core/batcher.ts
@@ -728,32 +728,13 @@ export class Batcher<T extends DefaultBatcherInput = DefaultBatcherInput> {
       }
     }
 
-    // 3. Replay gate (spec FR-006b): never pay twice for one signed spend.
+    // 3. Replay key (spec FR-006b): never pay twice for one signed spend.
     //
-    // After validation — an input we would refuse anyway is not worth a lookup,
-    // and a replay key derived from a payload we have not judged is not a
-    // measurement worth trusting — and before anything is queued.
+    // After validation — an input we would refuse anyway is not worth deriving
+    // a key for. The acceptance write below is the one authoritative claim;
+    // an advisory lookup here only added a database round trip and could never
+    // settle concurrent duplicates safely.
     const replayKey = this.replayKeyFor(adapter, input, target);
-    if (replayKey !== undefined && isTrackingStorage(this.storage)) {
-      const known = await this.storage.findByReplayKey(replayKey);
-      if (known) {
-        // Not an error and not a refusal: the work is already tracked, so the
-        // caller gets a 200 carrying the id that answers for it. Client retries
-        // are therefore idempotent and free.
-        console.log(
-          `♻️ Duplicate submission from ${input.address} for target ${target}; ` +
-            `returning the original request ${known.requestId.substring(0, 12)}… ` +
-            `(state=${known.state}) without queueing it again.`,
-        );
-        await this.emitRequestEvent("request:accepted", {
-          requestId: known.requestId,
-          target,
-          duplicate: true,
-          time: Date.now(),
-        });
-        return { requestId: known.requestId, receipt: null, duplicate: true };
-      }
-    }
 
     // 4. Add to Storage (Only if all validation passes)
     //
@@ -770,15 +751,14 @@ export class Batcher<T extends DefaultBatcherInput = DefaultBatcherInput> {
       time: Date.now(),
     });
     if (accepted.duplicate) {
-      // The pre-check above is a READ, so concurrent copies of one request all
-      // pass it; the claim inside the acceptance transaction is what actually
-      // stops the second. Same answer, arrived at one layer down.
+      console.log(
+        `♻️ Duplicate submission from ${input.address} for target ${target}; ` +
+          `returning the original request ${requestId.substring(0, 12)}… ` +
+          `without queueing it again.`,
+      );
       return { requestId, receipt: null, duplicate: true };
     }
-    const { count, size } = await this.storage.getInputCountAndSize();
-    console.log(
-      `✅ Added input from ${input.address} to batch queue. Queue size: ${count} inputs, ${size} bytes`,
-    );
+    console.log(`✅ Added input from ${input.address} to batch queue.`);
 
     if (confirmationLevel === "no-wait") {
       return { requestId, receipt: null };

--- a/packages/batcher/core/database-storage.ts
+++ b/packages/batcher/core/database-storage.ts
@@ -25,10 +25,10 @@ import { isNotFoundError } from "@effectstream/utils/runtime";
  * set of statements to keep correct.
  *
  * Why a database at all: the queue alone is happy in a JSONL file, but request
- * tracking needs the queue, the per-request status and the replay/dedup key to
- * move together or not at all. Two files cannot be written atomically; two
- * tables in one transaction can. The status and replay tables are created here
- * and stay empty — their write paths arrive with the request-tracking phases.
+ * tracking needs the queue, the per-request status and the replay/dedup owner
+ * to move together or not at all. Two files cannot be written atomically; one
+ * database statement can. The live status row owns its replay key so pruning
+ * the record releases ownership in the same atomic fate.
  */
 
 /** Anything that can run a parameterised statement (a pool, or one transaction). */
@@ -392,6 +392,12 @@ export class DatabaseStorage<
       `CREATE INDEX IF NOT EXISTS request_status_terminal_recency_idx
          ON request_status (terminal, updated_at DESC, seq DESC)`,
     );
+    // The live status row is the replay owner. This removes a redundant write
+    // from acceptance while making retention reclaim ownership automatically.
+    await this.db.query(
+      `CREATE UNIQUE INDEX IF NOT EXISTS request_status_replay_key_unique_idx
+         ON request_status (replay_key) WHERE replay_key IS NOT NULL`,
+    );
 
     // Replay/dedup keys: "have we already paid for this signed request?".
     await this.db.query(`
@@ -406,6 +412,94 @@ export class DatabaseStorage<
       `CREATE INDEX IF NOT EXISTS replay_keys_request_idx
          ON replay_keys (request_id)`,
     );
+
+    // One public query for the whole acceptance. Keeping this logic in a
+    // VOLATILE database function is deliberate: after an INSERT waits on a
+    // concurrent replay-key claimant, the following SELECT gets a fresh
+    // command snapshot and can return that claimant's status. A writable CTE
+    // was measured and was slightly slower for PgLite's durable write floor.
+    await this.db.query(`
+      CREATE OR REPLACE FUNCTION batcher_record_accepted(
+        p_replay_key text,
+        p_request_id text,
+        p_row_target text,
+        p_address text,
+        p_address_type integer,
+        p_ts text,
+        p_signature text,
+        p_input text,
+        p_retry_count integer,
+        p_payload text,
+        p_content_key text,
+        p_queue_request_id text
+      ) RETURNS TABLE (
+        request_id text,
+        row_target text,
+        address text,
+        state text,
+        terminal boolean,
+        transaction_hash text,
+        block_number bigint,
+        error_code text,
+        message text,
+        retry_count integer,
+        replay_key text,
+        accepted_at timestamptz,
+        updated_at timestamptz,
+        outcome_created boolean,
+        outcome_duplicate boolean
+      ) LANGUAGE plpgsql VOLATILE AS $$
+      DECLARE
+        v_status request_status%ROWTYPE;
+        v_created boolean := false;
+      BEGIN
+        INSERT INTO request_status
+          (request_id, row_target, address, state, terminal, retry_count, replay_key)
+        VALUES
+          (p_request_id, p_row_target, p_address, 'queued', false,
+           p_retry_count, p_replay_key)
+        ON CONFLICT DO NOTHING
+        RETURNING * INTO v_status;
+        v_created := FOUND;
+
+        IF NOT v_created THEN
+          IF p_replay_key IS NOT NULL THEN
+            SELECT s.* INTO v_status
+              FROM request_status s
+             WHERE s.replay_key = p_replay_key;
+            IF FOUND THEN
+              RETURN QUERY SELECT
+                v_status.request_id, v_status.row_target, v_status.address,
+                v_status.state, v_status.terminal,
+                v_status.transaction_hash, v_status.block_number,
+                v_status.error_code, v_status.message, v_status.retry_count,
+                v_status.replay_key, v_status.accepted_at, v_status.updated_at,
+                false, true;
+              RETURN;
+            END IF;
+          END IF;
+          SELECT s.* INTO STRICT v_status
+            FROM request_status s
+           WHERE s.request_id = p_request_id;
+        END IF;
+
+        INSERT INTO pending_inputs
+          (content_key, request_id, row_target, address, address_type, ts,
+           signature, input, retry_count, payload)
+        VALUES
+          (p_content_key, p_queue_request_id, p_row_target, p_address,
+           p_address_type, p_ts, p_signature, p_input, p_retry_count, p_payload);
+
+        RETURN QUERY SELECT
+          v_status.request_id, v_status.row_target, v_status.address,
+          v_status.state, v_status.terminal,
+          v_status.transaction_hash, v_status.block_number,
+          v_status.error_code, v_status.message, v_status.retry_count,
+          v_status.replay_key, v_status.accepted_at, v_status.updated_at,
+          v_created, false;
+      END;
+      $$
+    `);
   }
 
   /**
@@ -865,10 +959,9 @@ export class DatabaseStorage<
    *
    * With a replay key, the key is CLAIMED first and an already-claimed key
    * aborts the acceptance: nothing is written and the claimant's record is
-   * returned with `duplicate: true` (spec FR-006b). This is the half of the
-   * replay gate that survives concurrency — `Batcher`'s `findByReplayKey`
-   * pre-check is a read, and N simultaneous copies of one request all pass it.
-   * Claiming first also means the abort costs no wasted insert.
+   * returned with `duplicate: true` (spec FR-006b). This atomic claim is the
+   * whole replay gate: it survives concurrency and claiming first means the
+   * abort costs no wasted queue/status insert.
    */
   async recordAccepted(
     requestId: string,
@@ -877,65 +970,37 @@ export class DatabaseStorage<
     replayKey?: string,
   ): Promise<AcceptanceOutcome> {
     try {
-      const outcome = await this.db.transaction(async (tx) => {
-        if (replayKey !== undefined) {
-          // The key belongs to whoever claimed it FIRST. A later claimant must
-          // not steal it, or the original request's dedup record would end up
-          // answering for someone else's payment.
-          const claimed = await tx.query<{ request_id: string }>(
-            `INSERT INTO replay_keys (replay_key, request_id, row_target)
-             VALUES ($1, $2, $3)
-             ON CONFLICT (replay_key) DO NOTHING
-             RETURNING request_id`,
-            [replayKey, requestId, input.target ?? target],
-          );
-          if (claimed.length === 0) {
-            const [owner] = await tx.query<StatusRow>(
-              `SELECT s.* FROM replay_keys k
-                 JOIN request_status s ON s.request_id = k.request_id
-                WHERE k.replay_key = $1`,
-              [replayKey],
-            );
-            // A key whose owning record has been pruned is a tombstone with
-            // nothing to report; treat it as free rather than refusing work on
-            // the strength of a record that no longer exists.
-            if (owner) {
-              return { row: owner, created: false, duplicate: true } as const;
-            }
-            await tx.query(
-              "UPDATE replay_keys SET request_id = $2, row_target = $3 WHERE replay_key = $1",
-              [replayKey, requestId, input.target ?? target],
-            );
-          }
-        }
+      const resolvedTarget = resolveRowTarget(input, target);
+      const row = input.target === undefined
+        ? { ...input, target: resolvedTarget }
+        : input;
+      const payload = JSON.stringify(row);
+      const contentKey = contentKeyOf(row, resolvedTarget);
+      const [outcome] = await this.db.query<StatusRow & {
+        outcome_created: boolean;
+        outcome_duplicate: boolean;
+      }>(
+        `SELECT * FROM batcher_record_accepted(
+          $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12
+        )`,
+        [
+          replayKey ?? null,
+          requestId,
+          resolvedTarget,
+          row.address,
+          row.addressType,
+          row.timestamp,
+          row.signature ?? "",
+          row.input,
+          row.retryCount ?? 0,
+          payload,
+          contentKey,
+          requestIdFromKey(contentKey),
+        ],
+      );
 
-        const { resolvedTarget } = await this.insertRow(tx, input, target);
-        const inserted = await tx.query<StatusRow>(
-          `INSERT INTO request_status
-             (request_id, row_target, address, state, terminal, retry_count, replay_key)
-           VALUES ($1, $2, $3, 'queued', false, $4, $5)
-           ON CONFLICT (request_id) DO NOTHING
-           RETURNING *`,
-          [
-            requestId,
-            resolvedTarget,
-            input.address,
-            input.retryCount ?? 0,
-            replayKey ?? null,
-          ],
-        );
-        if (inserted.length > 0) {
-          return { row: inserted[0], created: true, duplicate: false } as const;
-        }
-        const [existing] = await tx.query<StatusRow>(
-          "SELECT * FROM request_status WHERE request_id = $1",
-          [requestId],
-        );
-        return { row: existing, created: false, duplicate: false } as const;
-      });
-
-      const record = toStatusRecord(outcome.row);
-      if (outcome.duplicate) {
+      const record = toStatusRecord(outcome);
+      if (outcome.outcome_duplicate) {
         console.log(
           `[Storage] Replay key already claimed by request ` +
             `${record.requestId.substring(0, 12)}… (state=${record.state}); ` +
@@ -948,13 +1013,13 @@ export class DatabaseStorage<
           duplicate: true,
         };
       }
-      if (!outcome.created) {
+      if (!outcome.outcome_created) {
         console.log(
           `[Storage] Request ${requestId.substring(0, 12)}… was already tracked ` +
             `(state=${record.state}); keeping its existing record.`,
         );
       }
-      return { requestId, created: outcome.created, record };
+      return { requestId, created: outcome.outcome_created, record };
     } catch (error) {
       console.error("Error recording accepted request:", error);
       throw new Error(`Failed to record accepted request: ${error}`);
@@ -1070,9 +1135,7 @@ export class DatabaseStorage<
   ): Promise<RequestStatusRecord | undefined> {
     try {
       const [row] = await this.db.query<StatusRow>(
-        `SELECT s.* FROM replay_keys k
-           JOIN request_status s ON s.request_id = k.request_id
-          WHERE k.replay_key = $1`,
+        `SELECT s.* FROM request_status s WHERE s.replay_key = $1`,
         [replayKey],
       );
       return row ? toStatusRecord(row) : undefined;

--- a/packages/batcher/core/database-storage.ts
+++ b/packages/batcher/core/database-storage.ts
@@ -14,6 +14,35 @@ import { buildRequestKey, requestIdFromKey } from "./request-id.ts";
 import { mkdirSync } from "node:fs";
 import { readFile, rename } from "node:fs/promises";
 import { isNotFoundError } from "@effectstream/utils/runtime";
+import type { IDatabaseConnection } from "@pgtyped/runtime";
+import batcherStorageMigration from "./sql/migrations/00001-batcher-storage.sql" with {
+  type: "text",
+};
+import {
+  backfillPendingRequestId,
+  clearPendingInputs,
+  countOrphanedStatuses,
+  countPendingInputs,
+  deletePendingByContentKeys,
+  deletePendingByIdentity,
+  deleteReplayKeysByRequestIds,
+  findPendingWithoutRequestId,
+  getAllPendingPayloads,
+  getPendingForRetry,
+  getPendingInputCountAndSize,
+  getPendingPayloadsByTarget,
+  getStatus as getStatusQuery,
+  getStatusByReplayKey,
+  getStatusForUpdate,
+  insertPendingInput,
+  pruneTerminalByAge,
+  pruneTerminalByCount,
+  recordAccepted as recordAcceptedQuery,
+  recordTransitions as recordTransitionsQuery,
+  synthesizeQueuedStatuses,
+  updatePendingRetry,
+  updateRequestStatus,
+} from "./sql/queries/database-storage.queries.ts";
 
 /**
  * Database-backed batcher storage.
@@ -32,13 +61,9 @@ import { isNotFoundError } from "@effectstream/utils/runtime";
  * the record releases ownership in the same atomic fate.
  */
 
-/** Anything that can run a parameterised statement (a pool, or one transaction). */
-interface SqlExecutor {
-  query<R>(sql: string, params?: unknown[]): Promise<R[]>;
-}
-
-interface SqlDriver extends SqlExecutor {
-  transaction<R>(fn: (tx: SqlExecutor) => Promise<R>): Promise<R>;
+interface SqlDriver extends IDatabaseConnection {
+  transaction<R>(fn: (tx: IDatabaseConnection) => Promise<R>): Promise<R>;
+  migrate(sql: string): Promise<void>;
   close(): Promise<void>;
 }
 
@@ -56,18 +81,32 @@ class PgliteDriver implements SqlDriver {
     return new PgliteDriver(db);
   }
 
-  async query<R>(sql: string, params: unknown[] = []): Promise<R[]> {
+  async query(sql: string, params: unknown[] = []) {
     const result = await this.db.query(sql, params);
-    return (result?.rows ?? []) as R[];
+    const rows = result?.rows ?? [];
+    return {
+      rows,
+      rowCount: result?.rowCount ?? result?.affectedRows ?? rows.length,
+    };
   }
 
-  async transaction<R>(fn: (tx: SqlExecutor) => Promise<R>): Promise<R> {
+  async transaction<R>(fn: (tx: IDatabaseConnection) => Promise<R>): Promise<R> {
     return await this.db.transaction(async (tx: any) =>
       await fn({
-        query: async <Row>(sql: string, params: unknown[] = []) =>
-          ((await tx.query(sql, params))?.rows ?? []) as Row[],
+        query: async (sql: string, params: unknown[] = []) => {
+          const result = await tx.query(sql, params);
+          const rows = result?.rows ?? [];
+          return {
+            rows,
+            rowCount: result?.rowCount ?? result?.affectedRows ?? rows.length,
+          };
+        },
       })
     );
+  }
+
+  async migrate(sql: string): Promise<void> {
+    await this.db.exec(sql);
   }
 
   async close(): Promise<void> {
@@ -98,18 +137,20 @@ class PostgresDriver implements SqlDriver {
     return new PostgresDriver(new Pool({ connectionString }));
   }
 
-  async query<R>(sql: string, params: unknown[] = []): Promise<R[]> {
+  async query(sql: string, params: unknown[] = []) {
     const result = await this.pool.query(sql, params);
-    return (result?.rows ?? []) as R[];
+    return { rows: result?.rows ?? [], rowCount: result?.rowCount ?? 0 };
   }
 
-  async transaction<R>(fn: (tx: SqlExecutor) => Promise<R>): Promise<R> {
+  async transaction<R>(fn: (tx: IDatabaseConnection) => Promise<R>): Promise<R> {
     const client = await this.pool.connect();
     try {
       await client.query("BEGIN");
       const result = await fn({
-        query: async <Row>(sql: string, params: unknown[] = []) =>
-          ((await client.query(sql, params))?.rows ?? []) as Row[],
+        query: async (sql: string, params: unknown[] = []) => {
+          const result = await client.query(sql, params);
+          return { rows: result?.rows ?? [], rowCount: result?.rowCount ?? 0 };
+        },
       });
       await client.query("COMMIT");
       return result;
@@ -123,6 +164,10 @@ class PostgresDriver implements SqlDriver {
     } finally {
       client.release();
     }
+  }
+
+  async migrate(sql: string): Promise<void> {
+    await this.pool.query(sql);
   }
 
   async close(): Promise<void> {
@@ -192,33 +237,31 @@ function resolveRowTarget(
   return resolved;
 }
 
-/** `$1, $2, …` for `count` values starting at `from`. */
-function placeholders(count: number, from = 1): string {
-  return Array.from({ length: count }, (_, i) => `$${from + i}`).join(", ");
-}
-
-interface PayloadRow {
-  payload: string;
-}
-
 /** A `request_status` row as the driver hands it back. */
 interface StatusRow {
-  request_id: string;
-  row_target: string;
+  request_id: string | null;
+  row_target: string | null;
   address: string | null;
-  state: string;
-  terminal: boolean;
+  state: string | null;
+  terminal: boolean | null;
   transaction_hash: string | null;
   block_number: string | number | null;
   error_code: string | null;
   message: string | null;
-  retry_count: number | string;
+  retry_count: number | string | null;
   replay_key: string | null;
-  accepted_at: string | Date;
-  updated_at: string | Date;
+  accepted_at: string | Date | null;
+  updated_at: string | Date | null;
 }
 
 function toStatusRecord(row: StatusRow): RequestStatusRecord {
+  if (
+    row.request_id === null || row.row_target === null || row.state === null ||
+    row.terminal === null || row.retry_count === null ||
+    row.accepted_at === null || row.updated_at === null
+  ) {
+    throw new Error("DatabaseStorage received an incomplete request_status row");
+  }
   return {
     requestId: row.request_id,
     target: row.row_target,
@@ -322,185 +365,10 @@ export class DatabaseStorage<
     return this.driver;
   }
 
-  /**
-   * Schema. `CREATE TABLE IF NOT EXISTS` is the whole migration story for now:
-   * these tables are new, so there is no earlier shape to migrate from.
-   */
+  /** Apply the reviewed immutable schema/function migration as one asset. */
   private async migrate(): Promise<void> {
-    // The queue. `content_key` + `seq` is the primary key rather than
-    // `content_key` alone because two byte-identical submissions are two rows
-    // today (FileStorage appends both, and removes both together) — collapsing
-    // them into one row would silently drop a user's second request.
-    await this.db.query(`
-      CREATE TABLE IF NOT EXISTS pending_inputs (
-        content_key  text   NOT NULL,
-        request_id   text   NOT NULL DEFAULT '',
-        seq          bigserial NOT NULL,
-        row_target   text   NOT NULL,
-        address      text   NOT NULL,
-        address_type integer NOT NULL,
-        ts           text   NOT NULL,
-        signature    text   NOT NULL DEFAULT '',
-        input        text   NOT NULL,
-        retry_count  integer NOT NULL DEFAULT 0,
-        payload      text   NOT NULL,
-        created_at   timestamptz NOT NULL DEFAULT now(),
-        PRIMARY KEY (content_key, seq)
-      )
-    `);
-    await this.db.query(
-      `CREATE INDEX IF NOT EXISTS pending_inputs_target_seq_idx
-         ON pending_inputs (row_target, seq)`,
-    );
-    // A row knows its own request id. Without it, matching a queue row back to
-    // its status record after an unclean stop would mean re-hashing every row
-    // in SQL — a second implementation of the identity that must not drift.
-    // `IF NOT EXISTS` because a database created before this column exists in
-    // the wild (this branch's own earlier phase) must migrate, not restart.
-    await this.db.query(
-      `ALTER TABLE pending_inputs
-         ADD COLUMN IF NOT EXISTS request_id text NOT NULL DEFAULT ''`,
-    );
-    await this.db.query(
-      `CREATE INDEX IF NOT EXISTS pending_inputs_request_idx
-         ON pending_inputs (request_id)`,
-    );
+    await this.db.migrate(batcherStorageMigration);
     await this.backfillRequestIds();
-
-    // Per-request lifecycle. Written from the request-tracking phases; created
-    // here so the queue and the status it belongs to live in one database and
-    // can be written in one transaction.
-    await this.db.query(`
-      CREATE TABLE IF NOT EXISTS request_status (
-        request_id       text PRIMARY KEY,
-        seq              bigserial NOT NULL,
-        row_target       text NOT NULL,
-        address          text,
-        state            text NOT NULL,
-        terminal         boolean NOT NULL DEFAULT false,
-        transaction_hash text,
-        block_number     bigint,
-        error_code       text,
-        message          text,
-        retry_count      integer NOT NULL DEFAULT 0,
-        replay_key       text,
-        accepted_at      timestamptz NOT NULL DEFAULT now(),
-        updated_at       timestamptz NOT NULL DEFAULT now()
-      )
-    `);
-    // Retention sweeps read terminal rows by recency; nothing else does.
-    await this.db.query(
-      `CREATE INDEX IF NOT EXISTS request_status_terminal_recency_idx
-         ON request_status (terminal, updated_at DESC, seq DESC)`,
-    );
-    // The live status row is the replay owner. This removes a redundant write
-    // from acceptance while making retention reclaim ownership automatically.
-    await this.db.query(
-      `CREATE UNIQUE INDEX IF NOT EXISTS request_status_replay_key_unique_idx
-         ON request_status (replay_key) WHERE replay_key IS NOT NULL`,
-    );
-
-    // Replay/dedup keys: "have we already paid for this signed request?".
-    await this.db.query(`
-      CREATE TABLE IF NOT EXISTS replay_keys (
-        replay_key text PRIMARY KEY,
-        request_id text NOT NULL,
-        row_target text NOT NULL,
-        created_at timestamptz NOT NULL DEFAULT now()
-      )
-    `);
-    await this.db.query(
-      `CREATE INDEX IF NOT EXISTS replay_keys_request_idx
-         ON replay_keys (request_id)`,
-    );
-
-    // One public query for the whole acceptance. Keeping this logic in a
-    // VOLATILE database function is deliberate: after an INSERT waits on a
-    // concurrent replay-key claimant, the following SELECT gets a fresh
-    // command snapshot and can return that claimant's status. A writable CTE
-    // was measured and was slightly slower for PgLite's durable write floor.
-    await this.db.query(`
-      CREATE OR REPLACE FUNCTION batcher_record_accepted(
-        p_replay_key text,
-        p_request_id text,
-        p_row_target text,
-        p_address text,
-        p_address_type integer,
-        p_ts text,
-        p_signature text,
-        p_input text,
-        p_retry_count integer,
-        p_payload text,
-        p_content_key text,
-        p_queue_request_id text
-      ) RETURNS TABLE (
-        request_id text,
-        row_target text,
-        address text,
-        state text,
-        terminal boolean,
-        transaction_hash text,
-        block_number bigint,
-        error_code text,
-        message text,
-        retry_count integer,
-        replay_key text,
-        accepted_at timestamptz,
-        updated_at timestamptz,
-        outcome_created boolean,
-        outcome_duplicate boolean
-      ) LANGUAGE plpgsql VOLATILE AS $$
-      DECLARE
-        v_status request_status%ROWTYPE;
-        v_created boolean := false;
-      BEGIN
-        INSERT INTO request_status
-          (request_id, row_target, address, state, terminal, retry_count, replay_key)
-        VALUES
-          (p_request_id, p_row_target, p_address, 'queued', false,
-           p_retry_count, p_replay_key)
-        ON CONFLICT DO NOTHING
-        RETURNING * INTO v_status;
-        v_created := FOUND;
-
-        IF NOT v_created THEN
-          IF p_replay_key IS NOT NULL THEN
-            SELECT s.* INTO v_status
-              FROM request_status s
-             WHERE s.replay_key = p_replay_key;
-            IF FOUND THEN
-              RETURN QUERY SELECT
-                v_status.request_id, v_status.row_target, v_status.address,
-                v_status.state, v_status.terminal,
-                v_status.transaction_hash, v_status.block_number,
-                v_status.error_code, v_status.message, v_status.retry_count,
-                v_status.replay_key, v_status.accepted_at, v_status.updated_at,
-                false, true;
-              RETURN;
-            END IF;
-          END IF;
-          SELECT s.* INTO STRICT v_status
-            FROM request_status s
-           WHERE s.request_id = p_request_id;
-        END IF;
-
-        INSERT INTO pending_inputs
-          (content_key, request_id, row_target, address, address_type, ts,
-           signature, input, retry_count, payload)
-        VALUES
-          (p_content_key, p_queue_request_id, p_row_target, p_address,
-           p_address_type, p_ts, p_signature, p_input, p_retry_count, p_payload);
-
-        RETURN QUERY SELECT
-          v_status.request_id, v_status.row_target, v_status.address,
-          v_status.state, v_status.terminal,
-          v_status.transaction_hash, v_status.block_number,
-          v_status.error_code, v_status.message, v_status.retry_count,
-          v_status.replay_key, v_status.accepted_at, v_status.updated_at,
-          v_created, false;
-      END;
-      $$
-    `);
   }
 
   /**
@@ -512,16 +380,15 @@ export class DatabaseStorage<
    * pending queue, which is small by construction.
    */
   private async backfillRequestIds(): Promise<void> {
-    const stale = await this.db.query<{ content_key: string; seq: string }>(
-      "SELECT content_key, seq FROM pending_inputs WHERE request_id = ''",
-    );
+    const stale = await findPendingWithoutRequestId.run(undefined, this.db);
     if (stale.length === 0) return;
     await this.db.transaction(async (tx) => {
       for (const row of stale) {
-        await tx.query(
-          "UPDATE pending_inputs SET request_id = $1 WHERE content_key = $2 AND seq = $3",
-          [requestIdFromKey(row.content_key), row.content_key, row.seq],
-        );
+        await backfillPendingRequestId.run({
+          request_id: requestIdFromKey(row.content_key),
+          content_key: row.content_key,
+          seq: row.seq,
+        }, tx);
       }
     });
     console.log(
@@ -549,9 +416,7 @@ export class DatabaseStorage<
       throw error;
     }
 
-    const [{ count }] = await this.db.query<{ count: number }>(
-      "SELECT count(*)::int AS count FROM pending_inputs",
-    );
+    const [{ count }] = await countPendingInputs.run(undefined, this.db);
     if (Number(count) > 0) {
       console.warn(
         `[Storage] Found ${LEGACY_QUEUE_FILE} in ${this.dataDirectory} but the ` +
@@ -621,32 +486,9 @@ export class DatabaseStorage<
     // GROUP BY, not one INSERT per row: duplicate submissions are two rows with
     // ONE identity, and inserting per row would collide on the primary key and
     // take the whole boot down.
-    const synthesized = await this.db.query<{ request_id: string }>(
-      `INSERT INTO request_status
-         (request_id, row_target, address, state, terminal, retry_count, accepted_at, updated_at)
-       SELECT p.request_id,
-              min(p.row_target),
-              min(p.address),
-              'queued',
-              false,
-              min(p.retry_count),
-              min(p.created_at),
-              now()
-         FROM pending_inputs p
-         LEFT JOIN request_status s ON s.request_id = p.request_id
-        WHERE s.request_id IS NULL
-        GROUP BY p.request_id
-       RETURNING request_id`,
-    );
+    const synthesized = await synthesizeQueuedStatuses.run(undefined, this.db);
 
-    const [orphans] = await this.db.query<{ count: number }>(
-      `SELECT count(*)::int AS count
-         FROM request_status s
-        WHERE NOT s.terminal
-          AND NOT EXISTS (
-            SELECT 1 FROM pending_inputs p WHERE p.request_id = s.request_id
-          )`,
-    );
+    const [orphans] = await countOrphanedStatuses.run(undefined, this.db);
 
     this.lastReconciliation = {
       synthesizedFromRows: synthesized.length,
@@ -677,7 +519,7 @@ export class DatabaseStorage<
    * payload would match it and remove or retry-charge the wrong request.
    */
   private async insertRow(
-    tx: SqlExecutor,
+    tx: IDatabaseConnection,
     input: DefaultBatcherInput,
     target?: string,
   ): Promise<{ requestId: string; resolvedTarget: string }> {
@@ -688,23 +530,18 @@ export class DatabaseStorage<
     const payload = JSON.stringify(row);
     const contentKey = contentKeyOf(row, resolvedTarget);
     const requestId = requestIdFromKey(contentKey);
-    await tx.query(
-      `INSERT INTO pending_inputs
-         (content_key, request_id, row_target, address, address_type, ts, signature, input, retry_count, payload)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
-      [
-        contentKey,
-        requestId,
-        resolvedTarget,
-        row.address,
-        row.addressType,
-        row.timestamp,
-        row.signature ?? "",
-        row.input,
-        row.retryCount ?? 0,
-        payload,
-      ],
-    );
+    await insertPendingInput.run({
+      content_key: contentKey,
+      request_id: requestId,
+      row_target: resolvedTarget,
+      address: row.address,
+      address_type: row.addressType,
+      ts: row.timestamp,
+      signature: row.signature ?? "",
+      input: row.input,
+      retry_count: row.retryCount ?? 0,
+      payload,
+    }, tx);
     return { requestId, resolvedTarget };
   }
 
@@ -719,9 +556,7 @@ export class DatabaseStorage<
 
   async getAllInputs(): Promise<T[]> {
     try {
-      const rows = await this.db.query<PayloadRow>(
-        "SELECT payload FROM pending_inputs ORDER BY seq",
-      );
+      const rows = await getAllPendingPayloads.run(undefined, this.db);
       return rows.map((row) => JSON.parse(row.payload) as T);
     } catch (error) {
       console.error("Error reading inputs from storage:", error);
@@ -733,12 +568,10 @@ export class DatabaseStorage<
     try {
       // Mirrors `input.target || defaultTarget` — an empty string falls back
       // the same way the JavaScript does.
-      const rows = await this.db.query<PayloadRow>(
-        `SELECT payload FROM pending_inputs
-          WHERE (CASE WHEN row_target IS NULL OR row_target = '' THEN $2 ELSE row_target END) = $1
-          ORDER BY seq`,
-        [target, defaultTarget],
-      );
+      const rows = await getPendingPayloadsByTarget.run({
+        target,
+        default_target: defaultTarget,
+      }, this.db);
       return rows.map((row) => JSON.parse(row.payload) as T);
     } catch (error) {
       console.error("Error getting inputs by target:", error);
@@ -756,15 +589,10 @@ export class DatabaseStorage<
         ...new Set(processedInputs.map((input) => contentKeyOf(input, target))),
       ];
       const { removed, total } = await this.db.transaction(async (tx) => {
-        const [{ count }] = await tx.query<{ count: number }>(
-          "SELECT count(*)::int AS count FROM pending_inputs",
-        );
-        const deleted = await tx.query<{ one: number }>(
-          `DELETE FROM pending_inputs
-            WHERE content_key IN (${placeholders(keys.length)})
-            RETURNING 1 AS one`,
-          keys,
-        );
+        const [{ count }] = await countPendingInputs.run(undefined, tx);
+        const deleted = await deletePendingByContentKeys.run({
+          content_keys: keys,
+        }, tx);
         return { removed: deleted.length, total: Number(count) };
       });
 
@@ -792,11 +620,7 @@ export class DatabaseStorage<
       // `length()` counts characters; `JSON.stringify(...).length` counts UTF-16
       // units. They agree for every payload the batcher actually carries (hex,
       // base64, JSON of those) and differ only for astral-plane characters.
-      const [row] = await this.db.query<{ count: number; size: string }>(
-        `SELECT count(*)::int AS count,
-                COALESCE(sum(length(payload)), 0)::bigint AS size
-           FROM pending_inputs`,
-      );
+      const [row] = await getPendingInputCountAndSize.run(undefined, this.db);
       return { count: Number(row?.count ?? 0), size: Number(row?.size ?? 0) };
     } catch (error) {
       console.error("Error getting input count:", error);
@@ -816,16 +640,7 @@ export class DatabaseStorage<
       ];
       const dropped: T[] = [];
       await this.db.transaction(async (tx) => {
-        const rows = await tx.query<
-          { content_key: string; seq: string; retry_count: number; payload: string }
-        >(
-          `SELECT content_key, seq, retry_count, payload
-             FROM pending_inputs
-            WHERE content_key IN (${placeholders(keys.length)})
-            ORDER BY seq
-              FOR UPDATE`,
-          keys,
-        );
+        const rows = await getPendingForRetry.run({ content_keys: keys }, tx);
 
         for (const row of rows) {
           // The charge is against the STORED count, not whatever the caller's
@@ -840,10 +655,10 @@ export class DatabaseStorage<
                   row.content_key.substring(0, 100)
                 }...`,
             );
-            await tx.query(
-              "DELETE FROM pending_inputs WHERE content_key = $1 AND seq = $2",
-              [row.content_key, row.seq],
-            );
+            await deletePendingByIdentity.run({
+              content_key: row.content_key,
+              seq: row.seq,
+            }, tx);
             // Reported, not just logged: the caller waiting on this input can
             // only be told it is gone if something tells the batcher first.
             dropped.push({ ...parsed, retryCount: newRetryCount } as T);
@@ -854,11 +669,12 @@ export class DatabaseStorage<
             ...parsed,
             retryCount: newRetryCount,
           });
-          await tx.query(
-            `UPDATE pending_inputs SET retry_count = $1, payload = $2
-              WHERE content_key = $3 AND seq = $4`,
-            [newRetryCount, payload, row.content_key, row.seq],
-          );
+          await updatePendingRetry.run({
+            retry_count: newRetryCount,
+            payload,
+            content_key: row.content_key,
+            seq: row.seq,
+          }, tx);
         }
       });
       return dropped;
@@ -870,7 +686,7 @@ export class DatabaseStorage<
 
   async clearAllInputs(): Promise<void> {
     try {
-      await this.db.query("DELETE FROM pending_inputs");
+      await clearPendingInputs.run(undefined, this.db);
     } catch (error) {
       console.error("Error clearing inputs:", error);
       throw new Error(`Failed to clear inputs: ${error}`);
@@ -902,34 +718,16 @@ export class DatabaseStorage<
     }
     try {
       return await this.db.transaction(async (tx) => {
-        const aged = await tx.query<{ request_id: string }>(
-          `DELETE FROM request_status
-            WHERE terminal
-              AND updated_at < now() - ($1::bigint * interval '1 millisecond')
-            RETURNING request_id`,
-          [Math.floor(ttlMs)],
-        );
-        const overflow = await tx.query<{ request_id: string }>(
-          `DELETE FROM request_status rs
-             USING (
-               SELECT request_id,
-                      row_number() OVER (ORDER BY updated_at DESC, seq DESC) AS rn
-                 FROM request_status
-                WHERE terminal
-             ) ranked
-            WHERE rs.request_id = ranked.request_id
-              AND ranked.rn > $1
-            RETURNING rs.request_id`,
-          [Math.floor(keepCount)],
-        );
+        const aged = await pruneTerminalByAge.run({
+          ttl_ms: Math.floor(ttlMs),
+        }, tx);
+        const overflow = await pruneTerminalByCount.run({
+          keep_count: Math.floor(keepCount),
+        }, tx);
 
         const removed = [...aged, ...overflow].map((row) => row.request_id);
         if (removed.length > 0) {
-          await tx.query(
-            `DELETE FROM replay_keys
-              WHERE request_id IN (${placeholders(removed.length)})`,
-            removed,
-          );
+          await deleteReplayKeysByRequestIds.run({ request_ids: removed }, tx);
         }
         return { prunedByAge: aged.length, prunedByCount: overflow.length };
       });
@@ -977,31 +775,26 @@ export class DatabaseStorage<
         : input;
       const payload = JSON.stringify(row);
       const contentKey = contentKeyOf(row, resolvedTarget);
-      const [outcome] = await this.db.query<StatusRow & {
-        outcome_created: boolean;
-        outcome_duplicate: boolean;
-      }>(
-        `SELECT * FROM batcher_record_accepted(
-          $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12
-        )`,
-        [
-          replayKey ?? null,
-          requestId,
-          resolvedTarget,
-          row.address,
-          row.addressType,
-          row.timestamp,
-          row.signature ?? "",
-          row.input,
-          row.retryCount ?? 0,
-          payload,
-          contentKey,
-          requestIdFromKey(contentKey),
-        ],
-      );
+      const [outcome] = await recordAcceptedQuery.run({
+        replay_key: replayKey ?? null,
+        request_id: requestId,
+        row_target: resolvedTarget,
+        address: row.address,
+        address_type: row.addressType,
+        ts: row.timestamp,
+        signature: row.signature ?? "",
+        input: row.input,
+        retry_count: row.retryCount ?? 0,
+        payload,
+        content_key: contentKey,
+        queue_request_id: requestIdFromKey(contentKey),
+      }, this.db);
+      if (!outcome) {
+        throw new Error("batcher_record_accepted returned no outcome");
+      }
 
       const record = toStatusRecord(outcome);
-      if (outcome.outcome_duplicate) {
+      if (outcome.outcome_duplicate === true) {
         console.log(
           `[Storage] Replay key already claimed by request ` +
             `${record.requestId.substring(0, 12)}… (state=${record.state}); ` +
@@ -1014,13 +807,13 @@ export class DatabaseStorage<
           duplicate: true,
         };
       }
-      if (!outcome.outcome_created) {
+      if (outcome.outcome_created !== true) {
         console.log(
           `[Storage] Request ${requestId.substring(0, 12)}… was already tracked ` +
             `(state=${record.state}); keeping its existing record.`,
         );
       }
-      return { requestId, created: outcome.outcome_created, record };
+      return { requestId, created: outcome.outcome_created === true, record };
     } catch (error) {
       console.error("Error recording accepted request:", error);
       throw new Error(`Failed to record accepted request: ${error}`);
@@ -1044,10 +837,9 @@ export class DatabaseStorage<
       return await this.db.transaction(async (tx) => {
         // FOR UPDATE: two workers reporting on the same request must not both
         // read the pre-transition state and both decide they may write.
-        const [currentRow] = await tx.query<StatusRow>(
-          "SELECT * FROM request_status WHERE request_id = $1 FOR UPDATE",
-          [requestId],
-        );
+        const [currentRow] = await getStatusForUpdate.run({
+          request_id: requestId,
+        }, tx);
         if (!currentRow) {
           // Deliberately does NOT create the record: `recordAccepted` is the
           // only way one comes into existence, because a status with no queue
@@ -1083,33 +875,23 @@ export class DatabaseStorage<
           return { applied: false, refused: "regression" as const, current };
         }
 
-        const [updated] = await tx.query<StatusRow>(
-          `UPDATE request_status SET
-             state            = $2,
-             terminal         = $3,
-             transaction_hash = COALESCE($4, transaction_hash),
-             block_number     = COALESCE($5::bigint, block_number),
-             error_code       = COALESCE($6, error_code),
-             message          = COALESCE($7, message),
-             retry_count      = COALESCE($8::int, retry_count),
-             updated_at       = now()
-           WHERE request_id = $1
-           RETURNING *`,
-          [
-            requestId,
-            state,
-            TERMINAL_STATES.has(state),
-            detail.transactionHash ?? null,
-            // Every detail field is COALESCEd: a transition that knows less
-            // than its predecessor must not erase the hash a caller needs.
-            detail.blockNumber === undefined
-              ? null
-              : String(detail.blockNumber),
-            detail.errorCode ?? null,
-            detail.message ?? null,
-            detail.retryCount ?? null,
-          ],
-        );
+        const [updated] = await updateRequestStatus.run({
+          request_id: requestId,
+          state,
+          terminal: TERMINAL_STATES.has(state),
+          transaction_hash: detail.transactionHash ?? null,
+          // Every detail field is COALESCEd: a transition that knows less
+          // than its predecessor must not erase the hash a caller needs.
+          block_number: detail.blockNumber === undefined
+            ? null
+            : String(detail.blockNumber),
+          error_code: detail.errorCode ?? null,
+          message: detail.message ?? null,
+          retry_count: detail.retryCount ?? null,
+        }, tx);
+        if (!updated) {
+          throw new Error(`request_status row ${requestId} disappeared while locked`);
+        }
         return { applied: true as const, record: toStatusRecord(updated) };
       });
     } catch (error) {
@@ -1150,98 +932,24 @@ export class DatabaseStorage<
     );
 
     try {
-      const rows = await this.db.query<StatusRow & {
-        ord: number | string;
-        applied: boolean;
-        refused: "unknown-request" | "regression" | "already-terminal" | null;
-      }>(
-        `WITH input AS MATERIALIZED (
-           SELECT
-             ordinality::int AS ord,
-             item->>'requestId' AS requested_id,
-             item->>'state' AS next_state,
-             item->'detail'->>'transactionHash' AS next_transaction_hash,
-             NULLIF(item->'detail'->>'blockNumber', '')::bigint AS next_block_number,
-             item->'detail'->>'errorCode' AS next_error_code,
-             item->'detail'->>'message' AS next_message,
-             NULLIF(item->'detail'->>'retryCount', '')::int AS next_retry_count
-           FROM jsonb_array_elements($1::jsonb) WITH ORDINALITY AS source(item, ordinality)
-         ), locked AS MATERIALIZED (
-           SELECT
-             i.*,
-             s.request_id, s.row_target, s.address, s.state, s.terminal,
-             s.transaction_hash, s.block_number, s.error_code, s.message,
-             s.retry_count, s.replay_key, s.accepted_at, s.updated_at
-           FROM input i
-           JOIN request_status s ON s.request_id = i.requested_id
-           ORDER BY s.request_id
-           FOR UPDATE OF s
-         ), evaluated AS MATERIALIZED (
-           SELECT l.*,
-             CASE
-               WHEN l.terminal THEN 'already-terminal'
-               WHEN
-                 CASE l.next_state
-                   WHEN 'queued' THEN 0 WHEN 'batching' THEN 1
-                   WHEN 'submitted' THEN 2 ELSE 3
-                 END <
-                 CASE l.state
-                   WHEN 'queued' THEN 0 WHEN 'batching' THEN 1
-                   WHEN 'submitted' THEN 2 ELSE 3
-                 END THEN 'regression'
-               ELSE NULL
-             END AS refusal
-           FROM locked l
-         ), updated AS (
-           UPDATE request_status s SET
-             state = e.next_state,
-             terminal = e.next_state IN ('confirmed', 'failed'),
-             transaction_hash = COALESCE(e.next_transaction_hash, s.transaction_hash),
-             block_number = COALESCE(e.next_block_number, s.block_number),
-             error_code = COALESCE(e.next_error_code, s.error_code),
-             message = COALESCE(e.next_message, s.message),
-             retry_count = COALESCE(e.next_retry_count, s.retry_count),
-             updated_at = now()
-           FROM evaluated e
-           WHERE s.request_id = e.requested_id AND e.refusal IS NULL
-           RETURNING e.ord, true AS applied, NULL::text AS refused,
-             s.request_id, s.row_target, s.address, s.state, s.terminal,
-             s.transaction_hash, s.block_number, s.error_code, s.message,
-             s.retry_count, s.replay_key, s.accepted_at, s.updated_at
-         ), refused AS (
-           SELECT e.ord, false AS applied, e.refusal AS refused,
-             e.request_id, e.row_target, e.address, e.state, e.terminal,
-             e.transaction_hash, e.block_number, e.error_code, e.message,
-             e.retry_count, e.replay_key, e.accepted_at, e.updated_at
-           FROM evaluated e WHERE e.refusal IS NOT NULL
-         ), unknown AS (
-           SELECT i.ord, false AS applied, 'unknown-request'::text AS refused,
-             NULL::text AS request_id, NULL::text AS row_target,
-             NULL::text AS address, NULL::text AS state, NULL::boolean AS terminal,
-             NULL::text AS transaction_hash, NULL::bigint AS block_number,
-             NULL::text AS error_code, NULL::text AS message,
-             NULL::integer AS retry_count, NULL::text AS replay_key,
-             NULL::timestamptz AS accepted_at, NULL::timestamptz AS updated_at
-           FROM input i LEFT JOIN locked l ON l.ord = i.ord
-           WHERE l.ord IS NULL
-         )
-         SELECT * FROM updated
-         UNION ALL SELECT * FROM refused
-         UNION ALL SELECT * FROM unknown
-         ORDER BY ord`,
-        [encoded],
-      );
+      const rows = await recordTransitionsQuery.run({ transitions: encoded }, this.db);
 
       return rows.map((row): TransitionOutcome => {
-        if (row.applied) {
+        if (row.applied === true) {
           return { applied: true, record: toStatusRecord(row) };
+        }
+        if (row.applied !== false) {
+          throw new Error("Bulk transition returned an outcome without applied state");
         }
         if (row.refused === "unknown-request") {
           return { applied: false, refused: "unknown-request" };
         }
+        if (row.refused !== "regression" && row.refused !== "already-terminal") {
+          throw new Error(`Bulk transition returned invalid refusal: ${row.refused}`);
+        }
         return {
           applied: false,
-          refused: row.refused!,
+          refused: row.refused,
           current: toStatusRecord(row),
         };
       });
@@ -1253,10 +961,7 @@ export class DatabaseStorage<
 
   async getStatus(requestId: string): Promise<RequestStatusRecord | undefined> {
     try {
-      const [row] = await this.db.query<StatusRow>(
-        "SELECT * FROM request_status WHERE request_id = $1",
-        [requestId],
-      );
+      const [row] = await getStatusQuery.run({ request_id: requestId }, this.db);
       return row ? toStatusRecord(row) : undefined;
     } catch (error) {
       console.error("Error reading request status:", error);
@@ -1268,10 +973,9 @@ export class DatabaseStorage<
     replayKey: string,
   ): Promise<RequestStatusRecord | undefined> {
     try {
-      const [row] = await this.db.query<StatusRow>(
-        `SELECT s.* FROM request_status s WHERE s.replay_key = $1`,
-        [replayKey],
-      );
+      const [row] = await getStatusByReplayKey.run({
+        replay_key: replayKey,
+      }, this.db);
       return row ? toStatusRecord(row) : undefined;
     } catch (error) {
       console.error("Error reading request status by replay key:", error);

--- a/packages/batcher/core/database-storage.ts
+++ b/packages/batcher/core/database-storage.ts
@@ -5,6 +5,7 @@ import type {
   ReconciliationReport,
   RequestState,
   RequestStatusRecord,
+  RequestTransition,
   RequestTransitionDetail,
   TrackingStorage,
   TransitionOutcome,
@@ -1114,6 +1115,139 @@ export class DatabaseStorage<
     } catch (error) {
       console.error("Error recording request transition:", error);
       throw new Error(`Failed to record request transition: ${error}`);
+    }
+  }
+
+  /** Set-based counterpart to `recordTransition`; one statement, N outcomes. */
+  async recordTransitions(
+    transitions: readonly RequestTransition[],
+  ): Promise<TransitionOutcome[]> {
+    if (transitions.length === 0) return [];
+    const seen = new Set<string>();
+    for (const transition of transitions) {
+      if (seen.has(transition.requestId)) {
+        throw new Error(
+          `recordTransitions received duplicate request id ${transition.requestId}; ` +
+            `each target row may appear only once per bulk statement.`,
+        );
+      }
+      seen.add(transition.requestId);
+    }
+
+    const encoded = JSON.stringify(
+      transitions.map((transition) => ({
+        requestId: transition.requestId,
+        state: transition.state,
+        detail: transition.detail === undefined
+          ? undefined
+          : {
+            ...transition.detail,
+            blockNumber: transition.detail.blockNumber === undefined
+              ? undefined
+              : String(transition.detail.blockNumber),
+          },
+      })),
+    );
+
+    try {
+      const rows = await this.db.query<StatusRow & {
+        ord: number | string;
+        applied: boolean;
+        refused: "unknown-request" | "regression" | "already-terminal" | null;
+      }>(
+        `WITH input AS MATERIALIZED (
+           SELECT
+             ordinality::int AS ord,
+             item->>'requestId' AS requested_id,
+             item->>'state' AS next_state,
+             item->'detail'->>'transactionHash' AS next_transaction_hash,
+             NULLIF(item->'detail'->>'blockNumber', '')::bigint AS next_block_number,
+             item->'detail'->>'errorCode' AS next_error_code,
+             item->'detail'->>'message' AS next_message,
+             NULLIF(item->'detail'->>'retryCount', '')::int AS next_retry_count
+           FROM jsonb_array_elements($1::jsonb) WITH ORDINALITY AS source(item, ordinality)
+         ), locked AS MATERIALIZED (
+           SELECT
+             i.*,
+             s.request_id, s.row_target, s.address, s.state, s.terminal,
+             s.transaction_hash, s.block_number, s.error_code, s.message,
+             s.retry_count, s.replay_key, s.accepted_at, s.updated_at
+           FROM input i
+           JOIN request_status s ON s.request_id = i.requested_id
+           ORDER BY s.request_id
+           FOR UPDATE OF s
+         ), evaluated AS MATERIALIZED (
+           SELECT l.*,
+             CASE
+               WHEN l.terminal THEN 'already-terminal'
+               WHEN
+                 CASE l.next_state
+                   WHEN 'queued' THEN 0 WHEN 'batching' THEN 1
+                   WHEN 'submitted' THEN 2 ELSE 3
+                 END <
+                 CASE l.state
+                   WHEN 'queued' THEN 0 WHEN 'batching' THEN 1
+                   WHEN 'submitted' THEN 2 ELSE 3
+                 END THEN 'regression'
+               ELSE NULL
+             END AS refusal
+           FROM locked l
+         ), updated AS (
+           UPDATE request_status s SET
+             state = e.next_state,
+             terminal = e.next_state IN ('confirmed', 'failed'),
+             transaction_hash = COALESCE(e.next_transaction_hash, s.transaction_hash),
+             block_number = COALESCE(e.next_block_number, s.block_number),
+             error_code = COALESCE(e.next_error_code, s.error_code),
+             message = COALESCE(e.next_message, s.message),
+             retry_count = COALESCE(e.next_retry_count, s.retry_count),
+             updated_at = now()
+           FROM evaluated e
+           WHERE s.request_id = e.requested_id AND e.refusal IS NULL
+           RETURNING e.ord, true AS applied, NULL::text AS refused,
+             s.request_id, s.row_target, s.address, s.state, s.terminal,
+             s.transaction_hash, s.block_number, s.error_code, s.message,
+             s.retry_count, s.replay_key, s.accepted_at, s.updated_at
+         ), refused AS (
+           SELECT e.ord, false AS applied, e.refusal AS refused,
+             e.request_id, e.row_target, e.address, e.state, e.terminal,
+             e.transaction_hash, e.block_number, e.error_code, e.message,
+             e.retry_count, e.replay_key, e.accepted_at, e.updated_at
+           FROM evaluated e WHERE e.refusal IS NOT NULL
+         ), unknown AS (
+           SELECT i.ord, false AS applied, 'unknown-request'::text AS refused,
+             NULL::text AS request_id, NULL::text AS row_target,
+             NULL::text AS address, NULL::text AS state, NULL::boolean AS terminal,
+             NULL::text AS transaction_hash, NULL::bigint AS block_number,
+             NULL::text AS error_code, NULL::text AS message,
+             NULL::integer AS retry_count, NULL::text AS replay_key,
+             NULL::timestamptz AS accepted_at, NULL::timestamptz AS updated_at
+           FROM input i LEFT JOIN locked l ON l.ord = i.ord
+           WHERE l.ord IS NULL
+         )
+         SELECT * FROM updated
+         UNION ALL SELECT * FROM refused
+         UNION ALL SELECT * FROM unknown
+         ORDER BY ord`,
+        [encoded],
+      );
+
+      return rows.map((row): TransitionOutcome => {
+        if (row.applied) {
+          return { applied: true, record: toStatusRecord(row) };
+        }
+        if (row.refused === "unknown-request") {
+          return { applied: false, refused: "unknown-request" };
+        }
+        return {
+          applied: false,
+          refused: row.refused!,
+          current: toStatusRecord(row),
+        };
+      });
+    } catch (error) {
+      console.error("Error recording bulk request transitions:", error);
+      throw new Error(`Failed to record bulk request transitions: ${error}`);
     }
   }
 

--- a/packages/batcher/core/sql/migrations/00001-batcher-storage.sql
+++ b/packages/batcher/core/sql/migrations/00001-batcher-storage.sql
@@ -1,0 +1,138 @@
+CREATE TABLE IF NOT EXISTS pending_inputs (
+  content_key  text      NOT NULL,
+  request_id   text      NOT NULL DEFAULT '',
+  seq          bigserial NOT NULL,
+  row_target   text      NOT NULL,
+  address      text      NOT NULL,
+  address_type integer   NOT NULL,
+  ts           text      NOT NULL,
+  signature    text      NOT NULL DEFAULT '',
+  input        text      NOT NULL,
+  retry_count  integer   NOT NULL DEFAULT 0,
+  payload      text      NOT NULL,
+  created_at   timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (content_key, seq)
+);
+
+CREATE INDEX IF NOT EXISTS pending_inputs_target_seq_idx
+  ON pending_inputs (row_target, seq);
+
+ALTER TABLE pending_inputs
+  ADD COLUMN IF NOT EXISTS request_id text NOT NULL DEFAULT '';
+
+CREATE INDEX IF NOT EXISTS pending_inputs_request_idx
+  ON pending_inputs (request_id);
+
+CREATE TABLE IF NOT EXISTS request_status (
+  request_id       text PRIMARY KEY,
+  seq              bigserial NOT NULL,
+  row_target       text NOT NULL,
+  address          text,
+  state            text NOT NULL,
+  terminal         boolean NOT NULL DEFAULT false,
+  transaction_hash text,
+  block_number     bigint,
+  error_code       text,
+  message          text,
+  retry_count      integer NOT NULL DEFAULT 0,
+  replay_key       text,
+  accepted_at      timestamptz NOT NULL DEFAULT now(),
+  updated_at       timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS request_status_terminal_recency_idx
+  ON request_status (terminal, updated_at DESC, seq DESC);
+
+CREATE UNIQUE INDEX IF NOT EXISTS request_status_replay_key_unique_idx
+  ON request_status (replay_key) WHERE replay_key IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS replay_keys (
+  replay_key text PRIMARY KEY,
+  request_id text NOT NULL,
+  row_target text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS replay_keys_request_idx
+  ON replay_keys (request_id);
+
+CREATE OR REPLACE FUNCTION batcher_record_accepted(
+  p_replay_key text,
+  p_request_id text,
+  p_row_target text,
+  p_address text,
+  p_address_type integer,
+  p_ts text,
+  p_signature text,
+  p_input text,
+  p_retry_count integer,
+  p_payload text,
+  p_content_key text,
+  p_queue_request_id text
+) RETURNS TABLE (
+  request_id text,
+  row_target text,
+  address text,
+  state text,
+  terminal boolean,
+  transaction_hash text,
+  block_number bigint,
+  error_code text,
+  message text,
+  retry_count integer,
+  replay_key text,
+  accepted_at timestamptz,
+  updated_at timestamptz,
+  outcome_created boolean,
+  outcome_duplicate boolean
+) LANGUAGE plpgsql VOLATILE AS $$
+DECLARE
+  v_status request_status%ROWTYPE;
+  v_created boolean := false;
+BEGIN
+  INSERT INTO request_status
+    (request_id, row_target, address, state, terminal, retry_count, replay_key)
+  VALUES
+    (p_request_id, p_row_target, p_address, 'queued', false,
+     p_retry_count, p_replay_key)
+  ON CONFLICT DO NOTHING
+  RETURNING * INTO v_status;
+  v_created := FOUND;
+
+  IF NOT v_created THEN
+    IF p_replay_key IS NOT NULL THEN
+      SELECT s.* INTO v_status
+        FROM request_status s
+       WHERE s.replay_key = p_replay_key;
+      IF FOUND THEN
+        RETURN QUERY SELECT
+          v_status.request_id, v_status.row_target, v_status.address,
+          v_status.state, v_status.terminal,
+          v_status.transaction_hash, v_status.block_number,
+          v_status.error_code, v_status.message, v_status.retry_count,
+          v_status.replay_key, v_status.accepted_at, v_status.updated_at,
+          false, true;
+        RETURN;
+      END IF;
+    END IF;
+    SELECT s.* INTO STRICT v_status
+      FROM request_status s
+     WHERE s.request_id = p_request_id;
+  END IF;
+
+  INSERT INTO pending_inputs
+    (content_key, request_id, row_target, address, address_type, ts,
+     signature, input, retry_count, payload)
+  VALUES
+    (p_content_key, p_queue_request_id, p_row_target, p_address,
+     p_address_type, p_ts, p_signature, p_input, p_retry_count, p_payload);
+
+  RETURN QUERY SELECT
+    v_status.request_id, v_status.row_target, v_status.address,
+    v_status.state, v_status.terminal,
+    v_status.transaction_hash, v_status.block_number,
+    v_status.error_code, v_status.message, v_status.retry_count,
+    v_status.replay_key, v_status.accepted_at, v_status.updated_at,
+    v_created, false;
+END;
+$$;

--- a/packages/batcher/core/sql/queries/database-storage.queries.ts
+++ b/packages/batcher/core/sql/queries/database-storage.queries.ts
@@ -1,0 +1,905 @@
+/** Types generated for queries found in "core/sql/queries/database-storage.sql" */
+import { PreparedQuery } from '@pgtyped/runtime';
+
+export type Json = null | boolean | number | string | Json[] | { [key: string]: Json };
+
+export type NumberOrString = number | string;
+
+/** 'FindPendingWithoutRequestId' parameters type */
+export type IFindPendingWithoutRequestIdParams = void;
+
+/** 'FindPendingWithoutRequestId' return type */
+export interface IFindPendingWithoutRequestIdResult {
+  content_key: string;
+  seq: string;
+}
+
+/** 'FindPendingWithoutRequestId' query type */
+export interface IFindPendingWithoutRequestIdQuery {
+  params: IFindPendingWithoutRequestIdParams;
+  result: IFindPendingWithoutRequestIdResult;
+}
+
+const findPendingWithoutRequestIdIR: any = {"usedParamSet":{},"params":[],"statement":"SELECT content_key, seq\nFROM pending_inputs\nWHERE request_id = ''"};
+
+/**
+ * Query generated from SQL:
+ * ```
+ * SELECT content_key, seq
+ * FROM pending_inputs
+ * WHERE request_id = ''
+ * ```
+ */
+export const findPendingWithoutRequestId = new PreparedQuery<IFindPendingWithoutRequestIdParams,IFindPendingWithoutRequestIdResult>(findPendingWithoutRequestIdIR);
+
+
+/** 'BackfillPendingRequestId' parameters type */
+export interface IBackfillPendingRequestIdParams {
+  content_key: string;
+  request_id: string;
+  seq: NumberOrString;
+}
+
+/** 'BackfillPendingRequestId' return type */
+export type IBackfillPendingRequestIdResult = void;
+
+/** 'BackfillPendingRequestId' query type */
+export interface IBackfillPendingRequestIdQuery {
+  params: IBackfillPendingRequestIdParams;
+  result: IBackfillPendingRequestIdResult;
+}
+
+const backfillPendingRequestIdIR: any = {"usedParamSet":{"request_id":true,"content_key":true,"seq":true},"params":[{"name":"request_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":39,"b":50}]},{"name":"content_key","required":true,"transform":{"type":"scalar"},"locs":[{"a":72,"b":84}]},{"name":"seq","required":true,"transform":{"type":"scalar"},"locs":[{"a":98,"b":102}]}],"statement":"UPDATE pending_inputs\nSET request_id = :request_id!\nWHERE content_key = :content_key!\n  AND seq = :seq!"};
+
+/**
+ * Query generated from SQL:
+ * ```
+ * UPDATE pending_inputs
+ * SET request_id = :request_id!
+ * WHERE content_key = :content_key!
+ *   AND seq = :seq!
+ * ```
+ */
+export const backfillPendingRequestId = new PreparedQuery<IBackfillPendingRequestIdParams,IBackfillPendingRequestIdResult>(backfillPendingRequestIdIR);
+
+
+/** 'CountPendingInputs' parameters type */
+export type ICountPendingInputsParams = void;
+
+/** 'CountPendingInputs' return type */
+export interface ICountPendingInputsResult {
+  count: number | null;
+}
+
+/** 'CountPendingInputs' query type */
+export interface ICountPendingInputsQuery {
+  params: ICountPendingInputsParams;
+  result: ICountPendingInputsResult;
+}
+
+const countPendingInputsIR: any = {"usedParamSet":{},"params":[],"statement":"SELECT count(*)::int AS count\nFROM pending_inputs"};
+
+/**
+ * Query generated from SQL:
+ * ```
+ * SELECT count(*)::int AS count
+ * FROM pending_inputs
+ * ```
+ */
+export const countPendingInputs = new PreparedQuery<ICountPendingInputsParams,ICountPendingInputsResult>(countPendingInputsIR);
+
+
+/** 'SynthesizeQueuedStatuses' parameters type */
+export type ISynthesizeQueuedStatusesParams = void;
+
+/** 'SynthesizeQueuedStatuses' return type */
+export interface ISynthesizeQueuedStatusesResult {
+  request_id: string;
+}
+
+/** 'SynthesizeQueuedStatuses' query type */
+export interface ISynthesizeQueuedStatusesQuery {
+  params: ISynthesizeQueuedStatusesParams;
+  result: ISynthesizeQueuedStatusesResult;
+}
+
+const synthesizeQueuedStatusesIR: any = {"usedParamSet":{},"params":[],"statement":"INSERT INTO request_status\n  (request_id, row_target, address, state, terminal, retry_count, accepted_at, updated_at)\nSELECT p.request_id,\n       min(p.row_target),\n       min(p.address),\n       'queued',\n       false,\n       min(p.retry_count),\n       min(p.created_at),\n       now()\nFROM pending_inputs p\nLEFT JOIN request_status s ON s.request_id = p.request_id\nWHERE s.request_id IS NULL\nGROUP BY p.request_id\nRETURNING request_id"};
+
+/**
+ * Query generated from SQL:
+ * ```
+ * INSERT INTO request_status
+ *   (request_id, row_target, address, state, terminal, retry_count, accepted_at, updated_at)
+ * SELECT p.request_id,
+ *        min(p.row_target),
+ *        min(p.address),
+ *        'queued',
+ *        false,
+ *        min(p.retry_count),
+ *        min(p.created_at),
+ *        now()
+ * FROM pending_inputs p
+ * LEFT JOIN request_status s ON s.request_id = p.request_id
+ * WHERE s.request_id IS NULL
+ * GROUP BY p.request_id
+ * RETURNING request_id
+ * ```
+ */
+export const synthesizeQueuedStatuses = new PreparedQuery<ISynthesizeQueuedStatusesParams,ISynthesizeQueuedStatusesResult>(synthesizeQueuedStatusesIR);
+
+
+/** 'CountOrphanedStatuses' parameters type */
+export type ICountOrphanedStatusesParams = void;
+
+/** 'CountOrphanedStatuses' return type */
+export interface ICountOrphanedStatusesResult {
+  count: number | null;
+}
+
+/** 'CountOrphanedStatuses' query type */
+export interface ICountOrphanedStatusesQuery {
+  params: ICountOrphanedStatusesParams;
+  result: ICountOrphanedStatusesResult;
+}
+
+const countOrphanedStatusesIR: any = {"usedParamSet":{},"params":[],"statement":"SELECT count(*)::int AS count\nFROM request_status s\nWHERE NOT s.terminal\n  AND NOT EXISTS (\n    SELECT 1\n    FROM pending_inputs p\n    WHERE p.request_id = s.request_id\n  )"};
+
+/**
+ * Query generated from SQL:
+ * ```
+ * SELECT count(*)::int AS count
+ * FROM request_status s
+ * WHERE NOT s.terminal
+ *   AND NOT EXISTS (
+ *     SELECT 1
+ *     FROM pending_inputs p
+ *     WHERE p.request_id = s.request_id
+ *   )
+ * ```
+ */
+export const countOrphanedStatuses = new PreparedQuery<ICountOrphanedStatusesParams,ICountOrphanedStatusesResult>(countOrphanedStatusesIR);
+
+
+/** 'InsertPendingInput' parameters type */
+export interface IInsertPendingInputParams {
+  address: string;
+  address_type: number;
+  content_key: string;
+  input: string;
+  payload: string;
+  request_id: string;
+  retry_count: number;
+  row_target: string;
+  signature: string;
+  ts: string;
+}
+
+/** 'InsertPendingInput' return type */
+export type IInsertPendingInputResult = void;
+
+/** 'InsertPendingInput' query type */
+export interface IInsertPendingInputQuery {
+  params: IInsertPendingInputParams;
+  result: IInsertPendingInputResult;
+}
+
+const insertPendingInputIR: any = {"usedParamSet":{"content_key":true,"request_id":true,"row_target":true,"address":true,"address_type":true,"ts":true,"signature":true,"input":true,"retry_count":true,"payload":true},"params":[{"name":"content_key","required":true,"transform":{"type":"scalar"},"locs":[{"a":147,"b":159}]},{"name":"request_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":162,"b":173}]},{"name":"row_target","required":true,"transform":{"type":"scalar"},"locs":[{"a":176,"b":187}]},{"name":"address","required":true,"transform":{"type":"scalar"},"locs":[{"a":190,"b":198}]},{"name":"address_type","required":true,"transform":{"type":"scalar"},"locs":[{"a":201,"b":214}]},{"name":"ts","required":true,"transform":{"type":"scalar"},"locs":[{"a":217,"b":220}]},{"name":"signature","required":true,"transform":{"type":"scalar"},"locs":[{"a":226,"b":236}]},{"name":"input","required":true,"transform":{"type":"scalar"},"locs":[{"a":239,"b":245}]},{"name":"retry_count","required":true,"transform":{"type":"scalar"},"locs":[{"a":248,"b":260}]},{"name":"payload","required":true,"transform":{"type":"scalar"},"locs":[{"a":263,"b":271}]}],"statement":"INSERT INTO pending_inputs\n  (content_key, request_id, row_target, address, address_type, ts,\n   signature, input, retry_count, payload)\nVALUES\n  (:content_key!, :request_id!, :row_target!, :address!, :address_type!, :ts!,\n   :signature!, :input!, :retry_count!, :payload!)"};
+
+/**
+ * Query generated from SQL:
+ * ```
+ * INSERT INTO pending_inputs
+ *   (content_key, request_id, row_target, address, address_type, ts,
+ *    signature, input, retry_count, payload)
+ * VALUES
+ *   (:content_key!, :request_id!, :row_target!, :address!, :address_type!, :ts!,
+ *    :signature!, :input!, :retry_count!, :payload!)
+ * ```
+ */
+export const insertPendingInput = new PreparedQuery<IInsertPendingInputParams,IInsertPendingInputResult>(insertPendingInputIR);
+
+
+/** 'GetAllPendingPayloads' parameters type */
+export type IGetAllPendingPayloadsParams = void;
+
+/** 'GetAllPendingPayloads' return type */
+export interface IGetAllPendingPayloadsResult {
+  payload: string;
+}
+
+/** 'GetAllPendingPayloads' query type */
+export interface IGetAllPendingPayloadsQuery {
+  params: IGetAllPendingPayloadsParams;
+  result: IGetAllPendingPayloadsResult;
+}
+
+const getAllPendingPayloadsIR: any = {"usedParamSet":{},"params":[],"statement":"SELECT payload\nFROM pending_inputs\nORDER BY seq"};
+
+/**
+ * Query generated from SQL:
+ * ```
+ * SELECT payload
+ * FROM pending_inputs
+ * ORDER BY seq
+ * ```
+ */
+export const getAllPendingPayloads = new PreparedQuery<IGetAllPendingPayloadsParams,IGetAllPendingPayloadsResult>(getAllPendingPayloadsIR);
+
+
+/** 'GetPendingPayloadsByTarget' parameters type */
+export interface IGetPendingPayloadsByTargetParams {
+  default_target: string;
+  target: string;
+}
+
+/** 'GetPendingPayloadsByTarget' return type */
+export interface IGetPendingPayloadsByTargetResult {
+  payload: string;
+}
+
+/** 'GetPendingPayloadsByTarget' query type */
+export interface IGetPendingPayloadsByTargetQuery {
+  params: IGetPendingPayloadsByTargetParams;
+  result: IGetPendingPayloadsByTargetResult;
+}
+
+const getPendingPayloadsByTargetIR: any = {"usedParamSet":{"default_target":true,"target":true},"params":[{"name":"default_target","required":true,"transform":{"type":"scalar"},"locs":[{"a":102,"b":117}]},{"name":"target","required":true,"transform":{"type":"scalar"},"locs":[{"a":149,"b":156}]}],"statement":"SELECT payload\nFROM pending_inputs\nWHERE (\n  CASE\n    WHEN row_target IS NULL OR row_target = '' THEN :default_target!\n    ELSE row_target\n  END\n) = :target!\nORDER BY seq"};
+
+/**
+ * Query generated from SQL:
+ * ```
+ * SELECT payload
+ * FROM pending_inputs
+ * WHERE (
+ *   CASE
+ *     WHEN row_target IS NULL OR row_target = '' THEN :default_target!
+ *     ELSE row_target
+ *   END
+ * ) = :target!
+ * ORDER BY seq
+ * ```
+ */
+export const getPendingPayloadsByTarget = new PreparedQuery<IGetPendingPayloadsByTargetParams,IGetPendingPayloadsByTargetResult>(getPendingPayloadsByTargetIR);
+
+
+/** 'DeletePendingByContentKeys' parameters type */
+export interface IDeletePendingByContentKeysParams {
+  content_keys: readonly (string)[];
+}
+
+/** 'DeletePendingByContentKeys' return type */
+export interface IDeletePendingByContentKeysResult {
+  one: number | null;
+}
+
+/** 'DeletePendingByContentKeys' query type */
+export interface IDeletePendingByContentKeysQuery {
+  params: IDeletePendingByContentKeysParams;
+  result: IDeletePendingByContentKeysResult;
+}
+
+const deletePendingByContentKeysIR: any = {"usedParamSet":{"content_keys":true},"params":[{"name":"content_keys","required":true,"transform":{"type":"array_spread"},"locs":[{"a":48,"b":61}]}],"statement":"DELETE FROM pending_inputs\nWHERE content_key IN :content_keys!\nRETURNING 1::int AS one"};
+
+/**
+ * Query generated from SQL:
+ * ```
+ * DELETE FROM pending_inputs
+ * WHERE content_key IN :content_keys!
+ * RETURNING 1::int AS one
+ * ```
+ */
+export const deletePendingByContentKeys = new PreparedQuery<IDeletePendingByContentKeysParams,IDeletePendingByContentKeysResult>(deletePendingByContentKeysIR);
+
+
+/** 'GetPendingInputCountAndSize' parameters type */
+export type IGetPendingInputCountAndSizeParams = void;
+
+/** 'GetPendingInputCountAndSize' return type */
+export interface IGetPendingInputCountAndSizeResult {
+  count: number | null;
+  size: string | null;
+}
+
+/** 'GetPendingInputCountAndSize' query type */
+export interface IGetPendingInputCountAndSizeQuery {
+  params: IGetPendingInputCountAndSizeParams;
+  result: IGetPendingInputCountAndSizeResult;
+}
+
+const getPendingInputCountAndSizeIR: any = {"usedParamSet":{},"params":[],"statement":"SELECT count(*)::int AS count,\n       COALESCE(sum(length(payload)), 0)::bigint AS size\nFROM pending_inputs"};
+
+/**
+ * Query generated from SQL:
+ * ```
+ * SELECT count(*)::int AS count,
+ *        COALESCE(sum(length(payload)), 0)::bigint AS size
+ * FROM pending_inputs
+ * ```
+ */
+export const getPendingInputCountAndSize = new PreparedQuery<IGetPendingInputCountAndSizeParams,IGetPendingInputCountAndSizeResult>(getPendingInputCountAndSizeIR);
+
+
+/** 'GetPendingForRetry' parameters type */
+export interface IGetPendingForRetryParams {
+  content_keys: readonly (string)[];
+}
+
+/** 'GetPendingForRetry' return type */
+export interface IGetPendingForRetryResult {
+  content_key: string;
+  payload: string;
+  retry_count: number;
+  seq: string;
+}
+
+/** 'GetPendingForRetry' query type */
+export interface IGetPendingForRetryQuery {
+  params: IGetPendingForRetryParams;
+  result: IGetPendingForRetryResult;
+}
+
+const getPendingForRetryIR: any = {"usedParamSet":{"content_keys":true},"params":[{"name":"content_keys","required":true,"transform":{"type":"array_spread"},"locs":[{"a":87,"b":100}]}],"statement":"SELECT content_key, seq, retry_count, payload\nFROM pending_inputs\nWHERE content_key IN :content_keys!\nORDER BY seq\nFOR UPDATE"};
+
+/**
+ * Query generated from SQL:
+ * ```
+ * SELECT content_key, seq, retry_count, payload
+ * FROM pending_inputs
+ * WHERE content_key IN :content_keys!
+ * ORDER BY seq
+ * FOR UPDATE
+ * ```
+ */
+export const getPendingForRetry = new PreparedQuery<IGetPendingForRetryParams,IGetPendingForRetryResult>(getPendingForRetryIR);
+
+
+/** 'DeletePendingByIdentity' parameters type */
+export interface IDeletePendingByIdentityParams {
+  content_key: string;
+  seq: NumberOrString;
+}
+
+/** 'DeletePendingByIdentity' return type */
+export type IDeletePendingByIdentityResult = void;
+
+/** 'DeletePendingByIdentity' query type */
+export interface IDeletePendingByIdentityQuery {
+  params: IDeletePendingByIdentityParams;
+  result: IDeletePendingByIdentityResult;
+}
+
+const deletePendingByIdentityIR: any = {"usedParamSet":{"content_key":true,"seq":true},"params":[{"name":"content_key","required":true,"transform":{"type":"scalar"},"locs":[{"a":47,"b":59}]},{"name":"seq","required":true,"transform":{"type":"scalar"},"locs":[{"a":73,"b":77}]}],"statement":"DELETE FROM pending_inputs\nWHERE content_key = :content_key!\n  AND seq = :seq!"};
+
+/**
+ * Query generated from SQL:
+ * ```
+ * DELETE FROM pending_inputs
+ * WHERE content_key = :content_key!
+ *   AND seq = :seq!
+ * ```
+ */
+export const deletePendingByIdentity = new PreparedQuery<IDeletePendingByIdentityParams,IDeletePendingByIdentityResult>(deletePendingByIdentityIR);
+
+
+/** 'UpdatePendingRetry' parameters type */
+export interface IUpdatePendingRetryParams {
+  content_key: string;
+  payload: string;
+  retry_count: number;
+  seq: NumberOrString;
+}
+
+/** 'UpdatePendingRetry' return type */
+export type IUpdatePendingRetryResult = void;
+
+/** 'UpdatePendingRetry' query type */
+export interface IUpdatePendingRetryQuery {
+  params: IUpdatePendingRetryParams;
+  result: IUpdatePendingRetryResult;
+}
+
+const updatePendingRetryIR: any = {"usedParamSet":{"retry_count":true,"payload":true,"content_key":true,"seq":true},"params":[{"name":"retry_count","required":true,"transform":{"type":"scalar"},"locs":[{"a":40,"b":52}]},{"name":"payload","required":true,"transform":{"type":"scalar"},"locs":[{"a":69,"b":77}]},{"name":"content_key","required":true,"transform":{"type":"scalar"},"locs":[{"a":99,"b":111}]},{"name":"seq","required":true,"transform":{"type":"scalar"},"locs":[{"a":125,"b":129}]}],"statement":"UPDATE pending_inputs\nSET retry_count = :retry_count!,\n    payload = :payload!\nWHERE content_key = :content_key!\n  AND seq = :seq!"};
+
+/**
+ * Query generated from SQL:
+ * ```
+ * UPDATE pending_inputs
+ * SET retry_count = :retry_count!,
+ *     payload = :payload!
+ * WHERE content_key = :content_key!
+ *   AND seq = :seq!
+ * ```
+ */
+export const updatePendingRetry = new PreparedQuery<IUpdatePendingRetryParams,IUpdatePendingRetryResult>(updatePendingRetryIR);
+
+
+/** 'ClearPendingInputs' parameters type */
+export type IClearPendingInputsParams = void;
+
+/** 'ClearPendingInputs' return type */
+export type IClearPendingInputsResult = void;
+
+/** 'ClearPendingInputs' query type */
+export interface IClearPendingInputsQuery {
+  params: IClearPendingInputsParams;
+  result: IClearPendingInputsResult;
+}
+
+const clearPendingInputsIR: any = {"usedParamSet":{},"params":[],"statement":"DELETE FROM pending_inputs"};
+
+/**
+ * Query generated from SQL:
+ * ```
+ * DELETE FROM pending_inputs
+ * ```
+ */
+export const clearPendingInputs = new PreparedQuery<IClearPendingInputsParams,IClearPendingInputsResult>(clearPendingInputsIR);
+
+
+/** 'PruneTerminalByAge' parameters type */
+export interface IPruneTerminalByAgeParams {
+  ttl_ms: NumberOrString;
+}
+
+/** 'PruneTerminalByAge' return type */
+export interface IPruneTerminalByAgeResult {
+  request_id: string;
+}
+
+/** 'PruneTerminalByAge' query type */
+export interface IPruneTerminalByAgeQuery {
+  params: IPruneTerminalByAgeParams;
+  result: IPruneTerminalByAgeResult;
+}
+
+const pruneTerminalByAgeIR: any = {"usedParamSet":{"ttl_ms":true},"params":[{"name":"ttl_ms","required":true,"transform":{"type":"scalar"},"locs":[{"a":70,"b":77}]}],"statement":"DELETE FROM request_status\nWHERE terminal\n  AND updated_at < now() - (:ttl_ms!::bigint * interval '1 millisecond')\nRETURNING request_id"};
+
+/**
+ * Query generated from SQL:
+ * ```
+ * DELETE FROM request_status
+ * WHERE terminal
+ *   AND updated_at < now() - (:ttl_ms!::bigint * interval '1 millisecond')
+ * RETURNING request_id
+ * ```
+ */
+export const pruneTerminalByAge = new PreparedQuery<IPruneTerminalByAgeParams,IPruneTerminalByAgeResult>(pruneTerminalByAgeIR);
+
+
+/** 'PruneTerminalByCount' parameters type */
+export interface IPruneTerminalByCountParams {
+  keep_count: NumberOrString;
+}
+
+/** 'PruneTerminalByCount' return type */
+export interface IPruneTerminalByCountResult {
+  request_id: string;
+}
+
+/** 'PruneTerminalByCount' query type */
+export interface IPruneTerminalByCountQuery {
+  params: IPruneTerminalByCountParams;
+  result: IPruneTerminalByCountResult;
+}
+
+const pruneTerminalByCountIR: any = {"usedParamSet":{"keep_count":true},"params":[{"name":"keep_count","required":true,"transform":{"type":"scalar"},"locs":[{"a":235,"b":246}]}],"statement":"DELETE FROM request_status rs\nUSING (\n  SELECT request_id,\n         row_number() OVER (ORDER BY updated_at DESC, seq DESC) AS rn\n  FROM request_status\n  WHERE terminal\n) ranked\nWHERE rs.request_id = ranked.request_id\n  AND ranked.rn > :keep_count!\nRETURNING rs.request_id"};
+
+/**
+ * Query generated from SQL:
+ * ```
+ * DELETE FROM request_status rs
+ * USING (
+ *   SELECT request_id,
+ *          row_number() OVER (ORDER BY updated_at DESC, seq DESC) AS rn
+ *   FROM request_status
+ *   WHERE terminal
+ * ) ranked
+ * WHERE rs.request_id = ranked.request_id
+ *   AND ranked.rn > :keep_count!
+ * RETURNING rs.request_id
+ * ```
+ */
+export const pruneTerminalByCount = new PreparedQuery<IPruneTerminalByCountParams,IPruneTerminalByCountResult>(pruneTerminalByCountIR);
+
+
+/** 'DeleteReplayKeysByRequestIds' parameters type */
+export interface IDeleteReplayKeysByRequestIdsParams {
+  request_ids: readonly (string)[];
+}
+
+/** 'DeleteReplayKeysByRequestIds' return type */
+export type IDeleteReplayKeysByRequestIdsResult = void;
+
+/** 'DeleteReplayKeysByRequestIds' query type */
+export interface IDeleteReplayKeysByRequestIdsQuery {
+  params: IDeleteReplayKeysByRequestIdsParams;
+  result: IDeleteReplayKeysByRequestIdsResult;
+}
+
+const deleteReplayKeysByRequestIdsIR: any = {"usedParamSet":{"request_ids":true},"params":[{"name":"request_ids","required":true,"transform":{"type":"array_spread"},"locs":[{"a":44,"b":56}]}],"statement":"DELETE FROM replay_keys\nWHERE request_id IN :request_ids!"};
+
+/**
+ * Query generated from SQL:
+ * ```
+ * DELETE FROM replay_keys
+ * WHERE request_id IN :request_ids!
+ * ```
+ */
+export const deleteReplayKeysByRequestIds = new PreparedQuery<IDeleteReplayKeysByRequestIdsParams,IDeleteReplayKeysByRequestIdsResult>(deleteReplayKeysByRequestIdsIR);
+
+
+/** 'RecordAccepted' parameters type */
+export interface IRecordAcceptedParams {
+  address: string;
+  address_type: number;
+  content_key: string;
+  input: string;
+  payload: string;
+  queue_request_id: string;
+  replay_key?: string | null | void;
+  request_id: string;
+  retry_count: number;
+  row_target: string;
+  signature: string;
+  ts: string;
+}
+
+/** 'RecordAccepted' return type */
+export interface IRecordAcceptedResult {
+  accepted_at: Date | null;
+  address: string | null;
+  block_number: string | null;
+  error_code: string | null;
+  message: string | null;
+  outcome_created: boolean | null;
+  outcome_duplicate: boolean | null;
+  replay_key: string | null;
+  request_id: string | null;
+  retry_count: number | null;
+  row_target: string | null;
+  state: string | null;
+  terminal: boolean | null;
+  transaction_hash: string | null;
+  updated_at: Date | null;
+}
+
+/** 'RecordAccepted' query type */
+export interface IRecordAcceptedQuery {
+  params: IRecordAcceptedParams;
+  result: IRecordAcceptedResult;
+}
+
+const recordAcceptedIR: any = {"usedParamSet":{"replay_key":true,"request_id":true,"row_target":true,"address":true,"address_type":true,"ts":true,"signature":true,"input":true,"retry_count":true,"payload":true,"content_key":true,"queue_request_id":true},"params":[{"name":"replay_key","required":false,"transform":{"type":"scalar"},"locs":[{"a":41,"b":51}]},{"name":"request_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":56,"b":67}]},{"name":"row_target","required":true,"transform":{"type":"scalar"},"locs":[{"a":72,"b":83}]},{"name":"address","required":true,"transform":{"type":"scalar"},"locs":[{"a":88,"b":96}]},{"name":"address_type","required":true,"transform":{"type":"scalar"},"locs":[{"a":101,"b":114}]},{"name":"ts","required":true,"transform":{"type":"scalar"},"locs":[{"a":119,"b":122}]},{"name":"signature","required":true,"transform":{"type":"scalar"},"locs":[{"a":127,"b":137}]},{"name":"input","required":true,"transform":{"type":"scalar"},"locs":[{"a":142,"b":148}]},{"name":"retry_count","required":true,"transform":{"type":"scalar"},"locs":[{"a":153,"b":165}]},{"name":"payload","required":true,"transform":{"type":"scalar"},"locs":[{"a":170,"b":178}]},{"name":"content_key","required":true,"transform":{"type":"scalar"},"locs":[{"a":183,"b":195}]},{"name":"queue_request_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":200,"b":217}]}],"statement":"SELECT *\nFROM batcher_record_accepted(\n  :replay_key,\n  :request_id!,\n  :row_target!,\n  :address!,\n  :address_type!,\n  :ts!,\n  :signature!,\n  :input!,\n  :retry_count!,\n  :payload!,\n  :content_key!,\n  :queue_request_id!\n)"};
+
+/**
+ * Query generated from SQL:
+ * ```
+ * SELECT *
+ * FROM batcher_record_accepted(
+ *   :replay_key,
+ *   :request_id!,
+ *   :row_target!,
+ *   :address!,
+ *   :address_type!,
+ *   :ts!,
+ *   :signature!,
+ *   :input!,
+ *   :retry_count!,
+ *   :payload!,
+ *   :content_key!,
+ *   :queue_request_id!
+ * )
+ * ```
+ */
+export const recordAccepted = new PreparedQuery<IRecordAcceptedParams,IRecordAcceptedResult>(recordAcceptedIR);
+
+
+/** 'GetStatusForUpdate' parameters type */
+export interface IGetStatusForUpdateParams {
+  request_id: string;
+}
+
+/** 'GetStatusForUpdate' return type */
+export interface IGetStatusForUpdateResult {
+  accepted_at: Date;
+  address: string | null;
+  block_number: string | null;
+  error_code: string | null;
+  message: string | null;
+  replay_key: string | null;
+  request_id: string;
+  retry_count: number;
+  row_target: string;
+  seq: string;
+  state: string;
+  terminal: boolean;
+  transaction_hash: string | null;
+  updated_at: Date;
+}
+
+/** 'GetStatusForUpdate' query type */
+export interface IGetStatusForUpdateQuery {
+  params: IGetStatusForUpdateParams;
+  result: IGetStatusForUpdateResult;
+}
+
+const getStatusForUpdateIR: any = {"usedParamSet":{"request_id":true},"params":[{"name":"request_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":48,"b":59}]}],"statement":"SELECT *\nFROM request_status\nWHERE request_id = :request_id!\nFOR UPDATE"};
+
+/**
+ * Query generated from SQL:
+ * ```
+ * SELECT *
+ * FROM request_status
+ * WHERE request_id = :request_id!
+ * FOR UPDATE
+ * ```
+ */
+export const getStatusForUpdate = new PreparedQuery<IGetStatusForUpdateParams,IGetStatusForUpdateResult>(getStatusForUpdateIR);
+
+
+/** 'UpdateRequestStatus' parameters type */
+export interface IUpdateRequestStatusParams {
+  block_number?: NumberOrString | null | void;
+  error_code?: string | null | void;
+  message?: string | null | void;
+  request_id: string;
+  retry_count?: number | null | void;
+  state: string;
+  terminal: boolean;
+  transaction_hash?: string | null | void;
+}
+
+/** 'UpdateRequestStatus' return type */
+export interface IUpdateRequestStatusResult {
+  accepted_at: Date;
+  address: string | null;
+  block_number: string | null;
+  error_code: string | null;
+  message: string | null;
+  replay_key: string | null;
+  request_id: string;
+  retry_count: number;
+  row_target: string;
+  seq: string;
+  state: string;
+  terminal: boolean;
+  transaction_hash: string | null;
+  updated_at: Date;
+}
+
+/** 'UpdateRequestStatus' query type */
+export interface IUpdateRequestStatusQuery {
+  params: IUpdateRequestStatusParams;
+  result: IUpdateRequestStatusResult;
+}
+
+const updateRequestStatusIR: any = {"usedParamSet":{"state":true,"terminal":true,"transaction_hash":true,"block_number":true,"error_code":true,"message":true,"retry_count":true,"request_id":true},"params":[{"name":"state","required":true,"transform":{"type":"scalar"},"locs":[{"a":34,"b":40}]},{"name":"terminal","required":true,"transform":{"type":"scalar"},"locs":[{"a":58,"b":67}]},{"name":"transaction_hash","required":false,"transform":{"type":"scalar"},"locs":[{"a":102,"b":118}]},{"name":"block_number","required":false,"transform":{"type":"scalar"},"locs":[{"a":168,"b":180}]},{"name":"error_code","required":false,"transform":{"type":"scalar"},"locs":[{"a":232,"b":242}]},{"name":"message","required":false,"transform":{"type":"scalar"},"locs":[{"a":281,"b":288}]},{"name":"retry_count","required":false,"transform":{"type":"scalar"},"locs":[{"a":328,"b":339}]},{"name":"request_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":403,"b":414}]}],"statement":"UPDATE request_status\nSET state = :state!,\n    terminal = :terminal!,\n    transaction_hash = COALESCE(:transaction_hash, transaction_hash),\n    block_number = COALESCE(:block_number::bigint, block_number),\n    error_code = COALESCE(:error_code, error_code),\n    message = COALESCE(:message, message),\n    retry_count = COALESCE(:retry_count::int, retry_count),\n    updated_at = now()\nWHERE request_id = :request_id!\nRETURNING *"};
+
+/**
+ * Query generated from SQL:
+ * ```
+ * UPDATE request_status
+ * SET state = :state!,
+ *     terminal = :terminal!,
+ *     transaction_hash = COALESCE(:transaction_hash, transaction_hash),
+ *     block_number = COALESCE(:block_number::bigint, block_number),
+ *     error_code = COALESCE(:error_code, error_code),
+ *     message = COALESCE(:message, message),
+ *     retry_count = COALESCE(:retry_count::int, retry_count),
+ *     updated_at = now()
+ * WHERE request_id = :request_id!
+ * RETURNING *
+ * ```
+ */
+export const updateRequestStatus = new PreparedQuery<IUpdateRequestStatusParams,IUpdateRequestStatusResult>(updateRequestStatusIR);
+
+
+/** 'RecordTransitions' parameters type */
+export interface IRecordTransitionsParams {
+  transitions: Json;
+}
+
+/** 'RecordTransitions' return type */
+export interface IRecordTransitionsResult {
+  accepted_at: Date | null;
+  address: string | null;
+  applied: boolean | null;
+  block_number: string | null;
+  error_code: string | null;
+  message: string | null;
+  ord: number | null;
+  refused: string | null;
+  replay_key: string | null;
+  request_id: string | null;
+  retry_count: number | null;
+  row_target: string | null;
+  state: string | null;
+  terminal: boolean | null;
+  transaction_hash: string | null;
+  updated_at: Date | null;
+}
+
+/** 'RecordTransitions' query type */
+export interface IRecordTransitionsQuery {
+  params: IRecordTransitionsParams;
+  result: IRecordTransitionsResult;
+}
+
+const recordTransitionsIR: any = {"usedParamSet":{"transitions":true},"params":[{"name":"transitions","required":true,"transform":{"type":"scalar"},"locs":[{"a":482,"b":494}]}],"statement":"WITH input AS MATERIALIZED (\n  SELECT\n    ordinality::int AS ord,\n    item->>'requestId' AS requested_id,\n    item->>'state' AS next_state,\n    item->'detail'->>'transactionHash' AS next_transaction_hash,\n    NULLIF(item->'detail'->>'blockNumber', '')::bigint AS next_block_number,\n    item->'detail'->>'errorCode' AS next_error_code,\n    item->'detail'->>'message' AS next_message,\n    NULLIF(item->'detail'->>'retryCount', '')::int AS next_retry_count\n  FROM jsonb_array_elements(:transitions!::jsonb)\n       WITH ORDINALITY AS source(item, ordinality)\n), locked AS MATERIALIZED (\n  SELECT\n    i.*,\n    s.request_id, s.row_target, s.address, s.state, s.terminal,\n    s.transaction_hash, s.block_number, s.error_code, s.message,\n    s.retry_count, s.replay_key, s.accepted_at, s.updated_at\n  FROM input i\n  JOIN request_status s ON s.request_id = i.requested_id\n  ORDER BY s.request_id\n  FOR UPDATE OF s\n), evaluated AS MATERIALIZED (\n  SELECT l.*,\n    CASE\n      WHEN l.terminal THEN 'already-terminal'\n      WHEN\n        CASE l.next_state\n          WHEN 'queued' THEN 0\n          WHEN 'batching' THEN 1\n          WHEN 'submitted' THEN 2\n          ELSE 3\n        END <\n        CASE l.state\n          WHEN 'queued' THEN 0\n          WHEN 'batching' THEN 1\n          WHEN 'submitted' THEN 2\n          ELSE 3\n        END THEN 'regression'\n      ELSE NULL\n    END AS refusal\n  FROM locked l\n), updated AS (\n  UPDATE request_status s\n  SET state = e.next_state,\n      terminal = e.next_state IN ('confirmed', 'failed'),\n      transaction_hash = COALESCE(e.next_transaction_hash, s.transaction_hash),\n      block_number = COALESCE(e.next_block_number, s.block_number),\n      error_code = COALESCE(e.next_error_code, s.error_code),\n      message = COALESCE(e.next_message, s.message),\n      retry_count = COALESCE(e.next_retry_count, s.retry_count),\n      updated_at = now()\n  FROM evaluated e\n  WHERE s.request_id = e.requested_id\n    AND e.refusal IS NULL\n  RETURNING e.ord, true AS applied, NULL::text AS refused,\n    s.request_id, s.row_target, s.address, s.state, s.terminal,\n    s.transaction_hash, s.block_number, s.error_code, s.message,\n    s.retry_count, s.replay_key, s.accepted_at, s.updated_at\n), refused AS (\n  SELECT e.ord, false AS applied, e.refusal AS refused,\n    e.request_id, e.row_target, e.address, e.state, e.terminal,\n    e.transaction_hash, e.block_number, e.error_code, e.message,\n    e.retry_count, e.replay_key, e.accepted_at, e.updated_at\n  FROM evaluated e\n  WHERE e.refusal IS NOT NULL\n), unknown AS (\n  SELECT i.ord, false AS applied, 'unknown-request'::text AS refused,\n    NULL::text AS request_id, NULL::text AS row_target,\n    NULL::text AS address, NULL::text AS state, NULL::boolean AS terminal,\n    NULL::text AS transaction_hash, NULL::bigint AS block_number,\n    NULL::text AS error_code, NULL::text AS message,\n    NULL::integer AS retry_count, NULL::text AS replay_key,\n    NULL::timestamptz AS accepted_at, NULL::timestamptz AS updated_at\n  FROM input i\n  LEFT JOIN locked l ON l.ord = i.ord\n  WHERE l.ord IS NULL\n)\nSELECT * FROM updated\nUNION ALL\nSELECT * FROM refused\nUNION ALL\nSELECT * FROM unknown\nORDER BY ord"};
+
+/**
+ * Query generated from SQL:
+ * ```
+ * WITH input AS MATERIALIZED (
+ *   SELECT
+ *     ordinality::int AS ord,
+ *     item->>'requestId' AS requested_id,
+ *     item->>'state' AS next_state,
+ *     item->'detail'->>'transactionHash' AS next_transaction_hash,
+ *     NULLIF(item->'detail'->>'blockNumber', '')::bigint AS next_block_number,
+ *     item->'detail'->>'errorCode' AS next_error_code,
+ *     item->'detail'->>'message' AS next_message,
+ *     NULLIF(item->'detail'->>'retryCount', '')::int AS next_retry_count
+ *   FROM jsonb_array_elements(:transitions!::jsonb)
+ *        WITH ORDINALITY AS source(item, ordinality)
+ * ), locked AS MATERIALIZED (
+ *   SELECT
+ *     i.*,
+ *     s.request_id, s.row_target, s.address, s.state, s.terminal,
+ *     s.transaction_hash, s.block_number, s.error_code, s.message,
+ *     s.retry_count, s.replay_key, s.accepted_at, s.updated_at
+ *   FROM input i
+ *   JOIN request_status s ON s.request_id = i.requested_id
+ *   ORDER BY s.request_id
+ *   FOR UPDATE OF s
+ * ), evaluated AS MATERIALIZED (
+ *   SELECT l.*,
+ *     CASE
+ *       WHEN l.terminal THEN 'already-terminal'
+ *       WHEN
+ *         CASE l.next_state
+ *           WHEN 'queued' THEN 0
+ *           WHEN 'batching' THEN 1
+ *           WHEN 'submitted' THEN 2
+ *           ELSE 3
+ *         END <
+ *         CASE l.state
+ *           WHEN 'queued' THEN 0
+ *           WHEN 'batching' THEN 1
+ *           WHEN 'submitted' THEN 2
+ *           ELSE 3
+ *         END THEN 'regression'
+ *       ELSE NULL
+ *     END AS refusal
+ *   FROM locked l
+ * ), updated AS (
+ *   UPDATE request_status s
+ *   SET state = e.next_state,
+ *       terminal = e.next_state IN ('confirmed', 'failed'),
+ *       transaction_hash = COALESCE(e.next_transaction_hash, s.transaction_hash),
+ *       block_number = COALESCE(e.next_block_number, s.block_number),
+ *       error_code = COALESCE(e.next_error_code, s.error_code),
+ *       message = COALESCE(e.next_message, s.message),
+ *       retry_count = COALESCE(e.next_retry_count, s.retry_count),
+ *       updated_at = now()
+ *   FROM evaluated e
+ *   WHERE s.request_id = e.requested_id
+ *     AND e.refusal IS NULL
+ *   RETURNING e.ord, true AS applied, NULL::text AS refused,
+ *     s.request_id, s.row_target, s.address, s.state, s.terminal,
+ *     s.transaction_hash, s.block_number, s.error_code, s.message,
+ *     s.retry_count, s.replay_key, s.accepted_at, s.updated_at
+ * ), refused AS (
+ *   SELECT e.ord, false AS applied, e.refusal AS refused,
+ *     e.request_id, e.row_target, e.address, e.state, e.terminal,
+ *     e.transaction_hash, e.block_number, e.error_code, e.message,
+ *     e.retry_count, e.replay_key, e.accepted_at, e.updated_at
+ *   FROM evaluated e
+ *   WHERE e.refusal IS NOT NULL
+ * ), unknown AS (
+ *   SELECT i.ord, false AS applied, 'unknown-request'::text AS refused,
+ *     NULL::text AS request_id, NULL::text AS row_target,
+ *     NULL::text AS address, NULL::text AS state, NULL::boolean AS terminal,
+ *     NULL::text AS transaction_hash, NULL::bigint AS block_number,
+ *     NULL::text AS error_code, NULL::text AS message,
+ *     NULL::integer AS retry_count, NULL::text AS replay_key,
+ *     NULL::timestamptz AS accepted_at, NULL::timestamptz AS updated_at
+ *   FROM input i
+ *   LEFT JOIN locked l ON l.ord = i.ord
+ *   WHERE l.ord IS NULL
+ * )
+ * SELECT * FROM updated
+ * UNION ALL
+ * SELECT * FROM refused
+ * UNION ALL
+ * SELECT * FROM unknown
+ * ORDER BY ord
+ * ```
+ */
+export const recordTransitions = new PreparedQuery<IRecordTransitionsParams,IRecordTransitionsResult>(recordTransitionsIR);
+
+
+/** 'GetStatus' parameters type */
+export interface IGetStatusParams {
+  request_id: string;
+}
+
+/** 'GetStatus' return type */
+export interface IGetStatusResult {
+  accepted_at: Date;
+  address: string | null;
+  block_number: string | null;
+  error_code: string | null;
+  message: string | null;
+  replay_key: string | null;
+  request_id: string;
+  retry_count: number;
+  row_target: string;
+  seq: string;
+  state: string;
+  terminal: boolean;
+  transaction_hash: string | null;
+  updated_at: Date;
+}
+
+/** 'GetStatus' query type */
+export interface IGetStatusQuery {
+  params: IGetStatusParams;
+  result: IGetStatusResult;
+}
+
+const getStatusIR: any = {"usedParamSet":{"request_id":true},"params":[{"name":"request_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":48,"b":59}]}],"statement":"SELECT *\nFROM request_status\nWHERE request_id = :request_id!"};
+
+/**
+ * Query generated from SQL:
+ * ```
+ * SELECT *
+ * FROM request_status
+ * WHERE request_id = :request_id!
+ * ```
+ */
+export const getStatus = new PreparedQuery<IGetStatusParams,IGetStatusResult>(getStatusIR);
+
+
+/** 'GetStatusByReplayKey' parameters type */
+export interface IGetStatusByReplayKeyParams {
+  replay_key: string;
+}
+
+/** 'GetStatusByReplayKey' return type */
+export interface IGetStatusByReplayKeyResult {
+  accepted_at: Date;
+  address: string | null;
+  block_number: string | null;
+  error_code: string | null;
+  message: string | null;
+  replay_key: string | null;
+  request_id: string;
+  retry_count: number;
+  row_target: string;
+  seq: string;
+  state: string;
+  terminal: boolean;
+  transaction_hash: string | null;
+  updated_at: Date;
+}
+
+/** 'GetStatusByReplayKey' query type */
+export interface IGetStatusByReplayKeyQuery {
+  params: IGetStatusByReplayKeyParams;
+  result: IGetStatusByReplayKeyResult;
+}
+
+const getStatusByReplayKeyIR: any = {"usedParamSet":{"replay_key":true},"params":[{"name":"replay_key","required":true,"transform":{"type":"scalar"},"locs":[{"a":54,"b":65}]}],"statement":"SELECT s.*\nFROM request_status s\nWHERE s.replay_key = :replay_key!"};
+
+/**
+ * Query generated from SQL:
+ * ```
+ * SELECT s.*
+ * FROM request_status s
+ * WHERE s.replay_key = :replay_key!
+ * ```
+ */
+export const getStatusByReplayKey = new PreparedQuery<IGetStatusByReplayKeyParams,IGetStatusByReplayKeyResult>(getStatusByReplayKeyIR);
+
+

--- a/packages/batcher/core/sql/queries/database-storage.sql
+++ b/packages/batcher/core/sql/queries/database-storage.sql
@@ -1,0 +1,260 @@
+/* @name findPendingWithoutRequestId */
+SELECT content_key, seq
+FROM pending_inputs
+WHERE request_id = '';
+
+/* @name backfillPendingRequestId */
+UPDATE pending_inputs
+SET request_id = :request_id!
+WHERE content_key = :content_key!
+  AND seq = :seq!;
+
+/* @name countPendingInputs */
+SELECT count(*)::int AS count
+FROM pending_inputs;
+
+/* @name synthesizeQueuedStatuses */
+INSERT INTO request_status
+  (request_id, row_target, address, state, terminal, retry_count, accepted_at, updated_at)
+SELECT p.request_id,
+       min(p.row_target),
+       min(p.address),
+       'queued',
+       false,
+       min(p.retry_count),
+       min(p.created_at),
+       now()
+FROM pending_inputs p
+LEFT JOIN request_status s ON s.request_id = p.request_id
+WHERE s.request_id IS NULL
+GROUP BY p.request_id
+RETURNING request_id;
+
+/* @name countOrphanedStatuses */
+SELECT count(*)::int AS count
+FROM request_status s
+WHERE NOT s.terminal
+  AND NOT EXISTS (
+    SELECT 1
+    FROM pending_inputs p
+    WHERE p.request_id = s.request_id
+  );
+
+/* @name insertPendingInput */
+INSERT INTO pending_inputs
+  (content_key, request_id, row_target, address, address_type, ts,
+   signature, input, retry_count, payload)
+VALUES
+  (:content_key!, :request_id!, :row_target!, :address!, :address_type!, :ts!,
+   :signature!, :input!, :retry_count!, :payload!);
+
+/* @name getAllPendingPayloads */
+SELECT payload
+FROM pending_inputs
+ORDER BY seq;
+
+/* @name getPendingPayloadsByTarget */
+SELECT payload
+FROM pending_inputs
+WHERE (
+  CASE
+    WHEN row_target IS NULL OR row_target = '' THEN :default_target!
+    ELSE row_target
+  END
+) = :target!
+ORDER BY seq;
+
+/*
+ @name deletePendingByContentKeys
+ @param content_keys -> (...)
+*/
+DELETE FROM pending_inputs
+WHERE content_key IN :content_keys!
+RETURNING 1::int AS one;
+
+/* @name getPendingInputCountAndSize */
+SELECT count(*)::int AS count,
+       COALESCE(sum(length(payload)), 0)::bigint AS size
+FROM pending_inputs;
+
+/*
+ @name getPendingForRetry
+ @param content_keys -> (...)
+*/
+SELECT content_key, seq, retry_count, payload
+FROM pending_inputs
+WHERE content_key IN :content_keys!
+ORDER BY seq
+FOR UPDATE;
+
+/* @name deletePendingByIdentity */
+DELETE FROM pending_inputs
+WHERE content_key = :content_key!
+  AND seq = :seq!;
+
+/* @name updatePendingRetry */
+UPDATE pending_inputs
+SET retry_count = :retry_count!,
+    payload = :payload!
+WHERE content_key = :content_key!
+  AND seq = :seq!;
+
+/* @name clearPendingInputs */
+DELETE FROM pending_inputs;
+
+/* @name pruneTerminalByAge */
+DELETE FROM request_status
+WHERE terminal
+  AND updated_at < now() - (:ttl_ms!::bigint * interval '1 millisecond')
+RETURNING request_id;
+
+/* @name pruneTerminalByCount */
+DELETE FROM request_status rs
+USING (
+  SELECT request_id,
+         row_number() OVER (ORDER BY updated_at DESC, seq DESC) AS rn
+  FROM request_status
+  WHERE terminal
+) ranked
+WHERE rs.request_id = ranked.request_id
+  AND ranked.rn > :keep_count!
+RETURNING rs.request_id;
+
+/*
+ @name deleteReplayKeysByRequestIds
+ @param request_ids -> (...)
+*/
+DELETE FROM replay_keys
+WHERE request_id IN :request_ids!;
+
+/* @name recordAccepted */
+SELECT *
+FROM batcher_record_accepted(
+  :replay_key,
+  :request_id!,
+  :row_target!,
+  :address!,
+  :address_type!,
+  :ts!,
+  :signature!,
+  :input!,
+  :retry_count!,
+  :payload!,
+  :content_key!,
+  :queue_request_id!
+);
+
+/* @name getStatusForUpdate */
+SELECT *
+FROM request_status
+WHERE request_id = :request_id!
+FOR UPDATE;
+
+/* @name updateRequestStatus */
+UPDATE request_status
+SET state = :state!,
+    terminal = :terminal!,
+    transaction_hash = COALESCE(:transaction_hash, transaction_hash),
+    block_number = COALESCE(:block_number::bigint, block_number),
+    error_code = COALESCE(:error_code, error_code),
+    message = COALESCE(:message, message),
+    retry_count = COALESCE(:retry_count::int, retry_count),
+    updated_at = now()
+WHERE request_id = :request_id!
+RETURNING *;
+
+/* @name recordTransitions */
+WITH input AS MATERIALIZED (
+  SELECT
+    ordinality::int AS ord,
+    item->>'requestId' AS requested_id,
+    item->>'state' AS next_state,
+    item->'detail'->>'transactionHash' AS next_transaction_hash,
+    NULLIF(item->'detail'->>'blockNumber', '')::bigint AS next_block_number,
+    item->'detail'->>'errorCode' AS next_error_code,
+    item->'detail'->>'message' AS next_message,
+    NULLIF(item->'detail'->>'retryCount', '')::int AS next_retry_count
+  FROM jsonb_array_elements(:transitions!::jsonb)
+       WITH ORDINALITY AS source(item, ordinality)
+), locked AS MATERIALIZED (
+  SELECT
+    i.*,
+    s.request_id, s.row_target, s.address, s.state, s.terminal,
+    s.transaction_hash, s.block_number, s.error_code, s.message,
+    s.retry_count, s.replay_key, s.accepted_at, s.updated_at
+  FROM input i
+  JOIN request_status s ON s.request_id = i.requested_id
+  ORDER BY s.request_id
+  FOR UPDATE OF s
+), evaluated AS MATERIALIZED (
+  SELECT l.*,
+    CASE
+      WHEN l.terminal THEN 'already-terminal'
+      WHEN
+        CASE l.next_state
+          WHEN 'queued' THEN 0
+          WHEN 'batching' THEN 1
+          WHEN 'submitted' THEN 2
+          ELSE 3
+        END <
+        CASE l.state
+          WHEN 'queued' THEN 0
+          WHEN 'batching' THEN 1
+          WHEN 'submitted' THEN 2
+          ELSE 3
+        END THEN 'regression'
+      ELSE NULL
+    END AS refusal
+  FROM locked l
+), updated AS (
+  UPDATE request_status s
+  SET state = e.next_state,
+      terminal = e.next_state IN ('confirmed', 'failed'),
+      transaction_hash = COALESCE(e.next_transaction_hash, s.transaction_hash),
+      block_number = COALESCE(e.next_block_number, s.block_number),
+      error_code = COALESCE(e.next_error_code, s.error_code),
+      message = COALESCE(e.next_message, s.message),
+      retry_count = COALESCE(e.next_retry_count, s.retry_count),
+      updated_at = now()
+  FROM evaluated e
+  WHERE s.request_id = e.requested_id
+    AND e.refusal IS NULL
+  RETURNING e.ord, true AS applied, NULL::text AS refused,
+    s.request_id, s.row_target, s.address, s.state, s.terminal,
+    s.transaction_hash, s.block_number, s.error_code, s.message,
+    s.retry_count, s.replay_key, s.accepted_at, s.updated_at
+), refused AS (
+  SELECT e.ord, false AS applied, e.refusal AS refused,
+    e.request_id, e.row_target, e.address, e.state, e.terminal,
+    e.transaction_hash, e.block_number, e.error_code, e.message,
+    e.retry_count, e.replay_key, e.accepted_at, e.updated_at
+  FROM evaluated e
+  WHERE e.refusal IS NOT NULL
+), unknown AS (
+  SELECT i.ord, false AS applied, 'unknown-request'::text AS refused,
+    NULL::text AS request_id, NULL::text AS row_target,
+    NULL::text AS address, NULL::text AS state, NULL::boolean AS terminal,
+    NULL::text AS transaction_hash, NULL::bigint AS block_number,
+    NULL::text AS error_code, NULL::text AS message,
+    NULL::integer AS retry_count, NULL::text AS replay_key,
+    NULL::timestamptz AS accepted_at, NULL::timestamptz AS updated_at
+  FROM input i
+  LEFT JOIN locked l ON l.ord = i.ord
+  WHERE l.ord IS NULL
+)
+SELECT * FROM updated
+UNION ALL
+SELECT * FROM refused
+UNION ALL
+SELECT * FROM unknown
+ORDER BY ord;
+
+/* @name getStatus */
+SELECT *
+FROM request_status
+WHERE request_id = :request_id!;
+
+/* @name getStatusByReplayKey */
+SELECT s.*
+FROM request_status s
+WHERE s.replay_key = :replay_key!;

--- a/packages/batcher/core/storage.ts
+++ b/packages/batcher/core/storage.ts
@@ -186,6 +186,13 @@ export interface RequestTransitionDetail {
   retryCount?: number;
 }
 
+/** One requested lifecycle move in an ordered bulk status write. */
+export interface RequestTransition {
+  requestId: string;
+  state: RequestState;
+  detail?: RequestTransitionDetail;
+}
+
 /** Why a transition was refused. Terminal states and backwards moves are not errors — they are answers. */
 export type TransitionRefusal =
   | "unknown-request"
@@ -285,6 +292,15 @@ export interface TrackingStorage<
     state: RequestState,
     detail?: RequestTransitionDetail,
   ): Promise<TransitionOutcome>;
+
+  /**
+   * Move several independent requests in one set-based database statement.
+   * OPTIONAL: older/custom tracking backends remain valid and the processor
+   * falls back to `recordTransition` when this capability is absent.
+   */
+  recordTransitions?(
+    transitions: readonly RequestTransition[],
+  ): Promise<TransitionOutcome[]>;
 
   /** The record for an id, or undefined if this batcher never accepted it (or it aged out). */
   getStatus(requestId: string): Promise<RequestStatusRecord | undefined>;

--- a/packages/batcher/core/storage.ts
+++ b/packages/batcher/core/storage.ts
@@ -221,12 +221,11 @@ export interface AcceptanceOutcome {
    * queue row, no status record (spec FR-006b — the batcher must not pay twice
    * for one signed spend). `requestId` and `record` describe the claimant.
    *
-   * This is the atomic half of the replay gate. `Batcher` checks
-   * `findByReplayKey` first so the common duplicate never opens a write
-   * transaction, but that check is a READ: two concurrent copies of one request
-   * both pass it, and only the claim inside this transaction can stop the
-   * second. Absent when no replay key was supplied — there is then nothing to
-   * claim and the queue keeps its historical duplicate-rows behaviour.
+   * This is the replay gate. The claim inside this atomic acceptance is the
+   * sole authority: an earlier lookup cannot settle concurrent copies and only
+   * adds latency. Absent when no replay key was supplied — there is then
+   * nothing to claim and the queue keeps its historical duplicate-rows
+   * behaviour.
    */
   duplicate?: boolean;
 }

--- a/packages/batcher/mod.ts
+++ b/packages/batcher/mod.ts
@@ -38,6 +38,7 @@ export type {
   ReconciliationReport,
   RequestState,
   RequestStatusRecord,
+  RequestTransition,
   RequestTransitionDetail,
   TrackingStorage,
   TransitionOutcome,

--- a/packages/batcher/package.json
+++ b/packages/batcher/package.json
@@ -11,6 +11,9 @@
   "bugs": {
     "url": "https://github.com/effectstream/effectstream/issues"
   },
+  "scripts": {
+    "pgtyped:generate": "node ./node_modules/@paima/pgtyped-cli/lib/index.js -c pgtypedconfig.json"
+  },
   "exports": {
     ".": {
       "bun": "./mod.ts",
@@ -22,6 +25,7 @@
     }
   },
   "dependencies": {
+    "@pgtyped/runtime": "2.4.2",
     "@sinclair/typebox": "0.34.41",
     "@electric-sql/pglite": "^0.3.14",
     "pg": "8.21.0",
@@ -63,6 +67,9 @@
     "@effectstream/crypto": "workspace:*",
     "@effectstream/midnight-contracts": "workspace:*",
     "@effectstream/event-client": "workspace:*"
+  },
+  "devDependencies": {
+    "@paima/pgtyped-cli": "^2.4.5"
   },
   "description": "Cross-chain transaction batching SDK for EffectStream"
 }

--- a/packages/batcher/pgtypedconfig.json
+++ b/packages/batcher/pgtypedconfig.json
@@ -1,0 +1,21 @@
+{
+  "transforms": [
+    {
+      "mode": "sql",
+      "include": "queries/*.sql",
+      "emitTemplate": "{{dir}}/{{name}}.queries.ts"
+    }
+  ],
+  "srcDir": "./core/sql",
+  "failOnError": true,
+  "camelCaseColumnNames": false,
+  "db": {
+    "dbName": "postgres",
+    "user": "postgres",
+    "password": "postgres",
+    "host": "postgres",
+    "port": 5432,
+    "ssl": false
+  },
+  "maxWorkerThreads": 1
+}

--- a/packages/batcher/test/accept-atomicity-crash.test.ts
+++ b/packages/batcher/test/accept-atomicity-crash.test.ts
@@ -1,11 +1,11 @@
 // Acceptance is ONE write — probed with a signal, not argued in a comment.
 //
-// The construction argument is simple: `recordAccepted` issues the queue insert
-// and the status insert inside a single `db.transaction`, so there is no
-// instant at which one exists without the other. Constructions like that are
-// exactly where a WASM Postgres, a driver wrapper and an emulated filesystem
-// get to disagree quietly, so this kills a writer mid-flight and asks the store
-// what it kept.
+// The construction argument is simple: `recordAccepted` issues one database
+// function call whose queue/status/replay work shares the function transaction,
+// so there is no instant at which one exists without the other. Constructions
+// like that are exactly where a WASM Postgres, a driver wrapper and an emulated
+// filesystem get to disagree quietly, so this kills a writer mid-flight and
+// asks the store what it kept.
 //
 // The detector is the reconciliation counter itself: `init()` reports how many
 // queue rows it had to invent a status for, and how many in-flight statuses had

--- a/packages/batcher/test/database-storage-sql-source.test.ts
+++ b/packages/batcher/test/database-storage-sql-source.test.ts
@@ -1,0 +1,109 @@
+import { describe, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+interface SourceString {
+  readonly line: number;
+  readonly quote: "'" | '"' | "`";
+  readonly value: string;
+}
+
+const databaseStorageUrl = new URL("../core/database-storage.ts", import.meta.url);
+
+/**
+ * Collect TypeScript string and template literals while ignoring comments.
+ * This intentionally treats a template interpolation as literal content: SQL
+ * structure assembled with `${...}` is exactly what this guard must reject.
+ */
+function sourceStrings(source: string): SourceString[] {
+  const strings: SourceString[] = [];
+  let index = 0;
+  let line = 1;
+
+  while (index < source.length) {
+    if (source[index] === "\n") {
+      line += 1;
+      index += 1;
+      continue;
+    }
+
+    if (source.startsWith("//", index)) {
+      const newline = source.indexOf("\n", index + 2);
+      index = newline === -1 ? source.length : newline;
+      continue;
+    }
+
+    if (source.startsWith("/*", index)) {
+      index += 2;
+      while (index < source.length && !source.startsWith("*/", index)) {
+        if (source[index] === "\n") line += 1;
+        index += 1;
+      }
+      index = Math.min(index + 2, source.length);
+      continue;
+    }
+
+    const quote = source[index];
+    if (quote !== "'" && quote !== '"' && quote !== "`") {
+      index += 1;
+      continue;
+    }
+
+    const startLine = line;
+    let value = "";
+    index += 1;
+    while (index < source.length) {
+      const character = source[index];
+      if (character === "\\") {
+        value += source.slice(index, index + 2);
+        index += 2;
+        continue;
+      }
+      if (character === quote) {
+        index += 1;
+        break;
+      }
+      if (character === "\n") line += 1;
+      value += character;
+      index += 1;
+    }
+    strings.push({ line: startLine, quote, value });
+  }
+
+  return strings;
+}
+
+function preview(value: string): string {
+  return value.replace(/\s+/g, " ").trim().slice(0, 100);
+}
+
+describe("DatabaseStorage SQL source policy", () => {
+  test("application TypeScript contains no operational SQL literals", () => {
+    const source = readFileSync(databaseStorageUrl, "utf8");
+    const operational = sourceStrings(source)
+      .filter(({ value }) => /\b(?:SELECT|INSERT|UPDATE|DELETE)\b/i.test(value))
+      .map(({ line, value }) => `line ${line}: ${preview(value)}`);
+
+    if (operational.length > 0) {
+      throw new Error(
+        "Operational SQL must live in named pgtyped .sql sources:\n" +
+          operational.map((entry) => `- ${entry}`).join("\n"),
+      );
+    }
+  });
+
+  test("application TypeScript contains no dynamic placeholder builder", () => {
+    const source = readFileSync(databaseStorageUrl, "utf8");
+    const placeholderLines = source.split("\n")
+      .map((value, index) => ({ line: index + 1, value: value.trim() }))
+      .filter(({ value }) => /\bplaceholders\s*\(/.test(value));
+
+    if (placeholderLines.length > 0) {
+      throw new Error(
+        "Dynamic placeholders must use pgtyped spread parameters:\n" +
+          placeholderLines
+            .map(({ line, value }) => `- line ${line}: ${value}`)
+            .join("\n"),
+      );
+    }
+  });
+});

--- a/packages/batcher/test/database-storage.test.ts
+++ b/packages/batcher/test/database-storage.test.ts
@@ -325,7 +325,7 @@ async function allStatusIds(storage: DatabaseStorage): Promise<string[]> {
 async function replayKeys(storage: DatabaseStorage): Promise<string[]> {
   const rows = await query<{ replay_key: string }>(
     storage,
-    "SELECT replay_key FROM replay_keys ORDER BY replay_key",
+    "SELECT replay_key FROM request_status WHERE replay_key IS NOT NULL ORDER BY replay_key",
   );
   return rows.map((row) => row.replay_key);
 }

--- a/packages/batcher/test/database-storage.test.ts
+++ b/packages/batcher/test/database-storage.test.ts
@@ -301,9 +301,14 @@ async function seedStatuses(
 // inventing one here would prejudge its shape.
 async function query<R>(storage: DatabaseStorage, sql: string): Promise<R[]> {
   const db = (storage as unknown as {
-    db: { query<T>(sql: string, params?: unknown[]): Promise<T[]> };
+    db: {
+      query<T>(
+        sql: string,
+        params?: unknown[],
+      ): Promise<{ rows: T[]; rowCount: number }>;
+    };
   }).db;
-  return await db.query<R>(sql);
+  return (await db.query<R>(sql)).rows;
 }
 
 async function terminalIds(storage: DatabaseStorage): Promise<string[]> {

--- a/packages/batcher/test/dedup-gate.test.ts
+++ b/packages/batcher/test/dedup-gate.test.ts
@@ -385,7 +385,12 @@ for (const backend of STORAGE_BACKENDS) {
       if (backend.reset) {
         // One server serves every case, so each case starts from empty.
         await (storage as unknown as {
-          db: { query(sql: string, params?: unknown[]): Promise<unknown[]> };
+          db: {
+            query(
+              sql: string,
+              params?: unknown[],
+            ): Promise<{ rows: unknown[]; rowCount: number }>;
+          };
         }).db.query(
           "TRUNCATE pending_inputs, request_status, replay_keys RESTART IDENTITY",
         );

--- a/packages/batcher/test/dedup-gate.test.ts
+++ b/packages/batcher/test/dedup-gate.test.ts
@@ -9,12 +9,9 @@
 //   request". The signature does not. Without this gate the batcher balances,
 //   proves and submits that spend a second time, out of its own dust.
 //
-// Two layers, deliberately:
-//   1. a `findByReplayKey` pre-check in `batchInput`, so the common duplicate
-//      never opens a write transaction;
-//   2. an atomic claim inside `recordAccepted`, because the pre-check is a
-//      read and two concurrent copies of one request both pass it. The claim is
-//      the truth; the pre-check is only an optimisation.
+// One authoritative layer, deliberately: the atomic claim inside
+// `recordAccepted`. A pre-read cannot settle concurrent copies and only adds a
+// round trip to the common acceptance path.
 
 import { describe, expect, test } from "bun:test";
 import { mkdtempSync, rmSync } from "node:fs";
@@ -225,9 +222,8 @@ describe("the replay gate at the accept path", () => {
     await withBatcher(async ({ batcher, storage }) => {
       const payload = input();
 
-      // Every one of these passes the `findByReplayKey` pre-check before any
-      // of them has written. Only the atomic claim inside the acceptance
-      // transaction can stop the rest.
+      // All eight race the same unique owner. Only the authoritative claim
+      // inside atomic acceptance can let one queue and stop the rest.
       const results = await Promise.all(
         Array.from({ length: 8 }, () => batcher.batchInput(payload, "no-wait")),
       );

--- a/packages/batcher/test/request-status.test.ts
+++ b/packages/batcher/test/request-status.test.ts
@@ -169,6 +169,51 @@ for (const backend of BACKENDS) {
       });
     });
 
+    test("a failure after the status claim rolls the whole acceptance back", async () => {
+      await withStorage(backend, async ({ storage }) => {
+        await rawQuery(storage, `
+          CREATE OR REPLACE FUNCTION batcher_test_reject_pending_insert()
+          RETURNS trigger LANGUAGE plpgsql AS $$
+          BEGIN
+            RAISE EXCEPTION 'injected pending insert failure';
+          END;
+          $$
+        `);
+        await rawQuery(
+          storage,
+          `CREATE TRIGGER batcher_test_reject_pending_insert_trigger
+             BEFORE INSERT ON pending_inputs
+             FOR EACH ROW EXECUTE FUNCTION batcher_test_reject_pending_insert()`,
+        );
+
+        const payload = input({ timestamp: "rollback" });
+        const requestId = computeRequestId(payload, "product-a");
+        try {
+          await expect(storage.recordAccepted(
+            requestId,
+            payload,
+            "product-a",
+            "replay-rollback",
+          )).rejects.toThrow(/injected pending insert failure/);
+
+          expect(await storage.getStatus(requestId)).toBeUndefined();
+          expect(await storage.findByReplayKey("replay-rollback")).toBeUndefined();
+          expect(await storage.getAllInputs()).toEqual([]);
+          expect(await statusCount(storage)).toBe(0);
+          expect(await replayKeyCount(storage)).toBe(0);
+        } finally {
+          await rawQuery(
+            storage,
+            "DROP TRIGGER IF EXISTS batcher_test_reject_pending_insert_trigger ON pending_inputs",
+          );
+          await rawQuery(
+            storage,
+            "DROP FUNCTION IF EXISTS batcher_test_reject_pending_insert()",
+          );
+        }
+      });
+    });
+
     test("an untracked addInput still stamps the row's request id", async () => {
       await withStorage(backend, async ({ storage }) => {
         const payload = input();
@@ -431,7 +476,7 @@ async function statusCount(storage: DatabaseStorage): Promise<number> {
 async function replayKeyCount(storage: DatabaseStorage): Promise<number> {
   const [row] = await rawQuery<{ count: number }>(
     storage,
-    "SELECT count(*)::int AS count FROM replay_keys",
+    "SELECT count(*)::int AS count FROM request_status WHERE replay_key IS NOT NULL",
   );
   return Number(row.count);
 }

--- a/packages/batcher/test/request-status.test.ts
+++ b/packages/batcher/test/request-status.test.ts
@@ -462,6 +462,66 @@ for (const backend of BACKENDS) {
         expect(moved!.acceptedAt.getTime()).toBe(opened!.acceptedAt.getTime());
       });
     });
+
+    test("bulk transitions preserve ordered independent outcomes and detail", async () => {
+      await withStorage(backend, async ({ storage, accept }) => {
+        const regression = await accept(input({ timestamp: "bulk-1" }));
+        const terminal = await accept(input({ timestamp: "bulk-2" }));
+        const valid = await accept(input({ timestamp: "bulk-3" }));
+        await storage.recordTransition(regression.requestId, "submitted", {
+          transactionHash: "0xkept",
+        });
+        await storage.recordTransition(terminal.requestId, "confirmed", {
+          transactionHash: "0xterminal",
+          blockNumber: 1n,
+        });
+
+        const outcomes = await storage.recordTransitions([
+          { requestId: "d".repeat(64), state: "confirmed" },
+          { requestId: regression.requestId, state: "batching" },
+          { requestId: terminal.requestId, state: "failed" },
+          {
+            requestId: valid.requestId,
+            state: "submitted",
+            detail: { transactionHash: "0xvalid", retryCount: 2 },
+          },
+        ]);
+
+        expect(outcomes.map((outcome) =>
+          outcome.applied === true ? "applied" : outcome.refused
+        )).toEqual([
+          "unknown-request",
+          "regression",
+          "already-terminal",
+          "applied",
+        ]);
+        expect((await storage.getStatus(regression.requestId))?.transactionHash)
+          .toBe("0xkept");
+        expect((await storage.getStatus(terminal.requestId))?.state)
+          .toBe("confirmed");
+        expect(await storage.getStatus(valid.requestId)).toMatchObject({
+          state: "submitted",
+          transactionHash: "0xvalid",
+          retryCount: 2,
+        });
+        expect(await storage.recordTransitions([])).toEqual([]);
+        expect(storage.recordTransitions([
+          { requestId: valid.requestId, state: "submitted" },
+          { requestId: valid.requestId, state: "confirmed" },
+        ])).rejects.toThrow(/duplicate request id/);
+      });
+    });
+
+    test("racing bulk calls never regress a request", async () => {
+      await withStorage(backend, async ({ storage, accept }) => {
+        const { requestId } = await accept(input({ timestamp: "bulk-race" }));
+        await Promise.all([
+          storage.recordTransitions([{ requestId, state: "submitted" }]),
+          storage.recordTransitions([{ requestId, state: "batching" }]),
+        ]);
+        expect((await storage.getStatus(requestId))?.state).toBe("submitted");
+      });
+    });
   });
 }
 

--- a/packages/batcher/test/request-status.test.ts
+++ b/packages/batcher/test/request-status.test.ts
@@ -114,9 +114,14 @@ async function rawQuery<R>(
   params: unknown[] = [],
 ): Promise<R[]> {
   const db = (storage as unknown as {
-    db: { query<T>(sql: string, params?: unknown[]): Promise<T[]> };
+    db: {
+      query(
+        sql: string,
+        params?: unknown[],
+      ): Promise<{ rows: R[]; rowCount: number }>;
+    };
   }).db;
-  return await db.query<R>(sql, params);
+  return (await db.query(sql, params)).rows;
 }
 
 test("a DatabaseStorage advertises tracking; a FileStorage does not", async () => {
@@ -287,6 +292,51 @@ for (const backend of BACKENDS) {
     test("an id this batcher never accepted has no status", async () => {
       await withStorage(backend, async ({ storage }) => {
         expect(await storage.getStatus("f".repeat(64))).toBeUndefined();
+      });
+    });
+
+    test("pgtyped treats injection-shaped scalar and spread values as data", async () => {
+      await withStorage(backend, async ({ storage }) => {
+        const injection = "x'); DROP TABLE request_status; --";
+        const payload = input({
+          address: injection,
+          input: JSON.stringify({ statement: injection }),
+          signature: injection,
+          target: injection,
+          timestamp: injection,
+        });
+        const requestId = computeRequestId(payload, injection);
+
+        const accepted = await storage.recordAccepted(
+          requestId,
+          payload,
+          injection,
+          injection,
+        );
+        expect(accepted).toMatchObject({ requestId, created: true });
+        expect(await storage.findByReplayKey(injection)).toMatchObject({
+          requestId,
+          target: injection,
+          address: injection,
+          replayKey: injection,
+        });
+
+        await storage.recordTransition(requestId, "failed", {
+          errorCode: injection,
+          message: injection,
+        });
+        expect(await storage.getStatus(requestId)).toMatchObject({
+          state: "failed",
+          errorCode: injection,
+          message: injection,
+        });
+
+        // `removeProcessedInputs` passes the injection-shaped content key as a
+        // pgtyped array-spread parameter. If it were interpolated, the table
+        // damage would be visible in the status assertion below.
+        await storage.removeProcessedInputs([payload], injection);
+        expect(await storage.getAllInputs()).toEqual([]);
+        expect((await storage.getStatus(requestId))?.state).toBe("failed");
       });
     });
   });

--- a/packages/batcher/test/retention-timer.test.ts
+++ b/packages/batcher/test/retention-timer.test.ts
@@ -133,11 +133,10 @@ describe("the retention sweep", () => {
     // duplicate, with nothing left to poll.
     //
     // Asserted end to end through `batchInput` rather than by looking for the
-    // absence of a `replay_keys` row. The property is upheld by TWO independent
-    // mechanisms (`findByReplayKey` JOINs through `request_status`, AND the
-    // prune deletes the keys), so an assertion phrased against the table would
-    // pass even with the deletion disabled — measured: probe K removed the
-    // deletion and changed nothing. This asserts the behaviour the user gets.
+    // absence of a storage row. The live `request_status` row now owns its
+    // replay key directly, so pruning that record atomically releases the key;
+    // an assertion phrased against the historical mirror table would no longer
+    // prove anything. This asserts the behaviour the user gets.
     await withBatcher(async ({ batcher, storage }) => {
       const payload = input({ signature: "0xspend-once" });
       const first = await batcher.batchInput(payload, "no-wait");


### PR DESCRIPTION
## Relationship to #873

This PR **extends and blocks #873; do not merge #873 until this PR lands**, is audited, and #873's delivery gate is rerun. Its base is exactly `00011-batcher-request-tracking` at `ee85c0c3`.

## Summary

This recovers the default embedded PgLite `no-wait` submit tail while preserving #873's durable immediate-poll semantics and moves all `DatabaseStorage` SQL to generated pgtyped queries.

- Atomic tracked acceptance is one authoritative database call. It removes the advisory replay-key pre-read and accepted-path queue aggregate while keeping replay ownership, queue insertion, and the initial status on one transaction fate.
- Lifecycle status writes use an optional ordered `recordTransitions` capability. `DatabaseStorage` applies a whole stage set-wise; older/custom stores retain individual fallback, and an exceptional bulk failure falls back without blocking blockchain work.
- Schema/function DDL now lives in an immutable migration SQL asset. All 23 operational statements are named pgtyped SQL with committed generated `PreparedQuery` bindings; the three array-valued paths use generated spread parameters instead of dynamic placeholder construction.

## Measured causes and operation counts

On the pinned #873 parent, a 32-input round executed 32 public transactions plus 64 transaction statements for each of `batching`, `submitted`, and `confirmed`: 96 transactions and 192 transaction statements per round. The final implementation executes each stage as 0 public transactions, 1 direct set-based statement, and 0 transaction statements.

A new tracked acceptance previously executed one replay-key pre-read, one acceptance transaction, and one queue aggregate: 1 public transaction, 2 direct statements, and 3 transaction statements. It now executes 0 public transactions, 1 direct authoritative statement, 0 transaction statements, 0 replay pre-reads, and 0 aggregates. The pgtyped migration adds no public database operation.

## Latency evidence

All runs used Docker, Bun 1.3.10, 300 warm-ups plus 2,000 measured sequential submissions, precomputed unique payloads, one target, and active batches of roughly 32 inputs on a 200ms window.

The reproduced #873 PgLite-active distribution was p99 **194.972ms** / max **236.173ms**, with **42/42/42** samples above 20/50/100ms. The historical pre-pgtyped final tree then passed three active runs at p99 **7.536/7.144/7.274ms** and removed the former once-per-round 100–200ms stalls.

The first typed tree retained valid one-off failures: active p99 **9.194ms** / max **67.689ms**, parked max **122.828ms**, and PostgreSQL **24.0%** above its paired FileStorage control. Those results are not discarded. Same-window profiling isolated only about **26–45µs** of generated-query overhead, with no causal typed tail or evidence-backed product correction. The approved final gate therefore used three adjacent exact-`60c5f93b`/typed pairs per backend in A→B/B→A/A→B order and judged their predeclared median/pooled non-inferiority rules.

| Backend | Typed p99s | Pair ratios | Binding aggregate | Result |
|---|---|---|---|---|
| FileStorage | 3.667 / 3.388 / 14.013ms | 0.9553 / 0.1325 / 1.1240 | median ratio **0.9553 <=1.10** | PASS |
| PgLite active | 9.492 / 7.834 / 7.663ms | 1.2948 / 1.0803 / 1.1037 | median p99 **7.834 <=8.415ms**; median ratio **1.1037 <=1.15**; pooled p99.9 **44.215 <=60ms**; typed-old >50/>100 deltas **-4/0** | PASS |
| PgLite parked | 8.064 / 7.361 / 8.803ms | 1.1220 / 1.0368 / 1.1501 | median p99 **8.064 <=8.415ms**; median ratio **1.1220 <=1.15**; pooled p99.9 **12.508 <=50ms**; deltas **-1/0** | PASS |
| PostgreSQL | 4.574 / 4.268 / 4.254ms | 1.1415 / 1.0114 / 1.0414 | median ratio **1.0414 <=1.10** | PASS |

All 24 final configurations had zero HTTP errors. Every individual miss and delayed control remains recorded in project 00015's plan; none was reclassified or omitted.

## Pgtyped and correctness verification

- The generator ran twice against PostgreSQL 16 and exited 0 both times. The generated binding stayed byte-identical at SHA-256 `ae83a9a074a8609e2f53eb2b9ab5ff91bfb9f31565c26b3ab45272a99c0ff8c8`.
- A static policy test rejects operational SQL literals and placeholder builders in application TypeScript.
- Injection-shaped scalar and spread-array values remain bound data on both PgLite and PostgreSQL.
- PgLite and PostgreSQL acceptance, dedup, mixed/refused transition, reconciliation, retention, and storage contracts pass, including injected rollback and eight-way one-owner races.
- Eight staggered acceptance-process SIGKILL cases and the confirmation/removal crash gate pass with no split fate or regression.
- Three consecutive complete Docker batcher runs on the exact typed tree passed **554/554** tests each; targeted crash/processor coverage passed **61/61**.

## Dependency and compatibility assessment

The batcher now declares direct `@pgtyped/runtime` 2.4.2 and development-only `@paima/pgtyped-cli` ^2.4.5 dependencies. `bun.lock` changes only add those declarations to the batcher importer; no package-resolution entry changed.

PgLite and PostgreSQL adapters implement pgtyped's connection contract, including transaction-scoped clients, without changing transaction boundaries. `recordTransitions` remains additive and optional. FileStorage remains queue-only and unchanged, and custom stores implementing only `recordTransition` retain their fallback. PgLite remains the default and PostgreSQL opt-in. This PR introduces no new intentional breaking change and inherits #873's separately documented breaking changes.

## Commits

- `de761443` — atomic one-call tracked acceptance
- `60c5f93b` — set-based lifecycle transitions
- `1db144e3` — migration SQL, 23 named pgtyped queries, generated bindings, static/injection tests, and scoped dependencies

## Delivery state

- Local codegen/correctness/crash/operation-count/full-suite gates: PASS.
- Final repeated same-window latency/control gate: PASS.
- Exact-head GitHub Actions run 32585204286: GREEN on full SHA `1db144e3a170b4f9825fe1ff729efca4b3cd2032`; independent delivery audit: REVIEW-COMPLETED / PASS (qualified only by this P3 wording correction, now resolved).
- Do not merge this PR or #873 during the delivery audit.
