### PR TITLE
fix(db): make PGlite force-close opt-in

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -69,6 +69,12 @@ jobs:
       - name: Build testing image
         run: docker build -t testing_image:${{ github.sha }} -f .github/Dockerfile .
 
+      - name: Run PGlite lifecycle regression
+        run: |
+          docker run --rm --name db_lifecycle_${{ github.run_number }} testing_image:${{ github.sha }} \
+            bun test packages/node-sdk/db/test/start-pglite.test.ts \
+              packages/node-sdk/db/test/start-pglite-multifile.test.ts
+
       - name: Run e2e tests
         run: docker run --rm --name e2e_${{ github.run_number }} testing_image:${{ github.sha }}
 

--- a/docs/site/docs/home/500-packages/520-node/db.md
+++ b/docs/site/docs/home/500-packages/520-node/db.md
@@ -63,6 +63,53 @@ small executable subpaths - used directly by the orchestrator.
 > `acquireDBMutex(name)` / `releaseDBMutex(name)` so concurrent generators
 > don't trample each other.
 
+### PgLite gateway lifecycle
+
+`startPglite(0)` binds only to `127.0.0.1` and reports the actual assigned port.
+Its handle has two shutdown modes:
+
+```typescript
+const database = await startPglite(0);
+
+// Compatibility default: stop accepting, preserve accepted client sockets.
+await database.close();
+
+// Explicit owner shutdown: destroy any stragglers and wait for teardown.
+await database.close({ force: true });
+```
+
+The no-argument close is bounded even if a consumer deliberately retains a raw
+`pg.Client`: it stops new accepts, unrefs and preserves accepted sockets, and
+settles without waiting for those clients. Existing clients may finish work
+while they remain connected. PGlite database cleanup is deferred until the last
+accepted socket drains, so a client retained forever can defer that cleanup
+forever. A resolved default-close promise therefore does not mean database
+cleanup has completed. Consumers remain responsible for their client lifecycle.
+
+Use `{ force: true }` only when your framework owns every connected client.
+Forced close destroys tracked sockets and waits for listener/socket teardown,
+so raw clients can emit their normal `Connection terminated unexpectedly`
+error; owners must end clients first or handle that event.
+
+Every call returns the same stored cleanup promise. The first call selects the
+mode, including when default and force calls race; a later force call cannot
+escalate cleanup already started in default mode. Startup listen failure still
+attempts database cleanup. Forced shutdown and default shutdown with no retained
+socket attempt database cleanup even if the listener fails to close. When both
+operations fail, the promise rejects with an `AggregateError` in
+listener-then-database order. If default shutdown deferred database cleanup, a
+later cleanup failure is observed and logged, but cannot change the already
+settled close promise.
+
+Migration note: forced socket destruction became the implicit default in
+`0.104.0` and was observed downstream during an upgrade to `0.200.1`. The
+corrected no-argument close restores the non-destructive compatibility default;
+PGlite cleanup waits for the last accepted socket, and forced teardown is
+explicit. The useful `0.104.0` changes remain: IPv4 loopback binding, startup
+rejection, address validation, actual-port reporting, and listener-close error
+propagation. Cleanup idempotency is strengthened from a boolean early return to
+a shared promise.
+
 ## Inside EffectStream
 
 `@effectstream/db` is the canonical access path. The runtime gets a
@@ -99,7 +146,8 @@ Dynamic table / event helpers:
 
 Subpath entry points (executable scripts):
 
-- `@effectstream/db/start-pglite`: boot a PgLite instance.
+- `@effectstream/db/start-pglite`: boot a PgLite instance and choose bounded
+  default or explicit forced teardown as described above.
 - `@effectstream/db/apply-migrations` - apply SQL migrations against the active DB.
 - `@effectstream/db/db-wait`: block until the DB accepts a connection.
 - `@effectstream/db/pgtyped-update`: regenerate pgtyped types.

--- a/docs/site/docs/home/500-packages/520-node/node-sdk.md
+++ b/docs/site/docs/home/500-packages/520-node/node-sdk.md
@@ -37,8 +37,47 @@ import { getConnection } from "@effectstream/node-sdk/db";
 import { ConfigBuilder, ConfigNetworkType } from "@effectstream/node-sdk/config";
 ```
 
+## Single-file applications
+
+The root entrypoint also exposes a small in-process facade for concise,
+read-only nodes:
+
+```typescript
+import { midnightContract, pglite, runNode } from "@effectstream/node-sdk";
+
+await runNode({
+  appName: "counter-watch",
+  database: pglite(),
+  sources: {
+    counter: midnightContract({
+      network: "preview",
+      address: "<64-character-contract-address>",
+      startBlockHeight: "latest",
+      ledger: { round: "uint128" },
+    }),
+  },
+  transitions: {
+    counter: ({ state }) => console.log(state.round),
+  },
+});
+```
+
+`runNode` uses the normal Effectstream sync, primitive, STM, migration, and
+configuration-snapshot paths. It owns PGlite and runtime cleanup in the same
+process; it does not launch another script. A fresh `"latest"` source begins at
+the current indexed block. When `pglite({ dataDir: "..." })` is persistent, a
+restart reads the saved numeric start height and resumes the stored checkpoint
+instead of jumping to a new tip.
+
 The subpaths are thin re-exports - semantics are identical to importing
 from the underlying packages.
+
+The re-exported `db/start-pglite` handle uses a bounded, non-destructive
+`close()` by default and an explicit owner-only `close({ force: true })` mode.
+Default close defers PGlite cleanup until the last accepted client socket drains.
+Concurrent calls share the first cleanup promise and the first requested mode
+wins. See the `@effectstream/db` PgLite gateway lifecycle section for the full
+client-ownership, failure, and `0.104.0`→`0.200.1` migration contract.
 
 ## Inside EffectStream
 

--- a/packages/node-sdk/db/README.md
+++ b/packages/node-sdk/db/README.md
@@ -55,6 +55,53 @@ small executable subpaths - used directly by the orchestrator.
 > `acquireDBMutex(name)` / `releaseDBMutex(name)` so concurrent generators
 > don't trample each other.
 
+### PgLite gateway lifecycle
+
+`startPglite(0)` binds only to `127.0.0.1` and reports the actual assigned port.
+Its handle has two shutdown modes:
+
+```typescript
+const database = await startPglite(0);
+
+// Compatibility default: stop accepting, preserve accepted client sockets.
+await database.close();
+
+// Explicit owner shutdown: destroy any stragglers and wait for teardown.
+await database.close({ force: true });
+```
+
+The no-argument close is bounded even if a consumer deliberately retains a raw
+`pg.Client`: it stops new accepts, unrefs and preserves accepted sockets, and
+settles without waiting for those clients. Existing clients may finish work
+while they remain connected. PGlite database cleanup is deferred until the last
+accepted socket drains, so a client retained forever can defer that cleanup
+forever. A resolved default-close promise therefore does not mean database
+cleanup has completed. Consumers remain responsible for their client lifecycle.
+
+Use `{ force: true }` only when your framework owns every connected client.
+Forced close destroys tracked sockets and waits for listener/socket teardown,
+so raw clients can emit their normal `Connection terminated unexpectedly`
+error; owners must end clients first or handle that event.
+
+Every call returns the same stored cleanup promise. The first call selects the
+mode, including when default and force calls race; a later force call cannot
+escalate cleanup already started in default mode. Startup listen failure still
+attempts database cleanup. Forced shutdown and default shutdown with no retained
+socket attempt database cleanup even if the listener fails to close. When both
+operations fail, the promise rejects with an `AggregateError` in
+listener-then-database order. If default shutdown deferred database cleanup, a
+later cleanup failure is observed and logged, but cannot change the already
+settled close promise.
+
+Migration note: forced socket destruction became the implicit default in
+`0.104.0` and was observed downstream during an upgrade to `0.200.1`. The
+corrected no-argument close restores the non-destructive compatibility default;
+PGlite cleanup waits for the last accepted socket, and forced teardown is
+explicit. The useful `0.104.0` changes remain: IPv4 loopback binding, startup
+rejection, address validation, actual-port reporting, and listener-close error
+propagation. Cleanup idempotency is strengthened from a boolean early return to
+a shared promise.
+
 ## Inside EffectStream
 
 `@effectstream/db` is the canonical access path. The runtime gets a
@@ -91,7 +138,8 @@ Dynamic table / event helpers:
 
 Subpath entry points (executable scripts):
 
-- `@effectstream/db/start-pglite`: boot a PgLite instance.
+- `@effectstream/db/start-pglite`: boot a PgLite instance and choose bounded
+  default or explicit forced teardown as described above.
 - `@effectstream/db/apply-migrations` - apply SQL migrations against the active DB.
 - `@effectstream/db/db-wait`: block until the DB accepts a connection.
 - `@effectstream/db/pgtyped-update`: regenerate pgtyped types.

--- a/packages/node-sdk/db/scripts/pgtyped-update.ts
+++ b/packages/node-sdk/db/scripts/pgtyped-update.ts
@@ -4,7 +4,9 @@
  */
 
 import { spawn } from "node:child_process";
-import { resolve } from "node:path";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
 import { existsSync } from "node:fs";
 
 import pg from "pg";
@@ -34,6 +36,47 @@ export interface PgtypedUpdateOptions {
   userMigrations?: UserMigration[];
   pgtypedConfigPath?: string;
   pgtypedBin?: string;
+  pgtypedTimeoutMs?: number;
+}
+
+async function preparePgtypedConfig(
+  configPath: string,
+  port: number,
+): Promise<{ cleanup: () => Promise<void>; path: string }> {
+  const parsed = JSON.parse(await readFile(configPath, "utf8")) as unknown;
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("Pgtyped config must be a JSON object.");
+  }
+
+  const config = parsed as Record<string, unknown>;
+  if (config.db !== undefined && (
+    !config.db || typeof config.db !== "object" || Array.isArray(config.db)
+  )) {
+    throw new Error("Pgtyped config db field must be an object.");
+  }
+  const { dbUrl: _ignoredDbUrl, ...configWithoutUri } = config;
+  const directory = await mkdtemp(join(tmpdir(), "effectstream-pgtyped-"));
+  const derivedPath = join(directory, "pgtypedconfig.json");
+  try {
+    await writeFile(derivedPath, JSON.stringify({
+      ...configWithoutUri,
+      db: {
+        ...(config.db as Record<string, unknown> | undefined),
+        dbName: "postgres",
+        host: "127.0.0.1",
+        port,
+        user: "postgres",
+      },
+    }));
+  } catch (error) {
+    await rm(directory, { force: true, recursive: true });
+    throw error;
+  }
+
+  return {
+    path: derivedPath,
+    cleanup: () => rm(directory, { force: true, recursive: true }),
+  };
 }
 
 async function resolveUserMigrations(): Promise<UserMigration[]> {
@@ -49,7 +92,7 @@ async function resolveUserMigrations(): Promise<UserMigration[]> {
   return mod.migrationTable ?? [];
 }
 
-async function applyUserMigrations(migrations: UserMigration[]): Promise<void> {
+async function applyUserMigrations(migrations: UserMigration[], port: number): Promise<void> {
   const prefix = createPrefix("user-migrations");
 
   if (migrations.length === 0) {
@@ -58,14 +101,14 @@ async function applyUserMigrations(migrations: UserMigration[]): Promise<void> {
   }
 
   const client = new pg.Client({
-    host: "localhost",
-    port: 5432,
+    host: "127.0.0.1",
+    port,
     user: "postgres",
     database: "postgres",
   });
-  await client.connect();
 
   try {
+    await client.connect();
     for (const migration of migrations) {
       console.log(`${prefix}Applying ${migration.name}`);
       await client.query(migration.sql);
@@ -76,67 +119,121 @@ async function applyUserMigrations(migrations: UserMigration[]): Promise<void> {
   }
 }
 
-async function applySystemMigrations(): Promise<void> {
+async function applySystemMigrations(port: number): Promise<void> {
   const prefix = createPrefix("apply-migrations");
-  const db = getConnection();
-  const migrations = await getMigrations();
-  for (const migration of migrations) {
-    await applyMigrations(db as any, 0, migration.version, migration.sql, true);
+  const db = getConnection({
+    host: "127.0.0.1",
+    port,
+    user: "postgres",
+    database: "postgres",
+    max: 1,
+  });
+  try {
+    const migrations = await getMigrations();
+    for (const migration of migrations) {
+      await applyMigrations(db as any, 0, migration.version, migration.sql, true);
+    }
+    console.log(`${prefix}✅ System migrations applied`);
+  } finally {
+    await db.end();
   }
-  console.log(`${prefix}✅ System migrations applied`);
-  await db.end();
 }
 
-async function runPgtyped(pgtypedBin: string, pgtypedConfigPath: string): Promise<void> {
+async function runPgtyped(
+  pgtypedBin: string,
+  pgtypedConfigPath: string,
+  port: number,
+  timeoutMs: number,
+): Promise<void> {
   const prefix = createPrefix("pgtyped");
   console.log(`${prefix}Starting...`);
 
-  return new Promise((resolve, reject) => {
-    const child = spawn("node", [pgtypedBin, "-c", pgtypedConfigPath], {
-      stdio: ["ignore", "pipe", "pipe"],
-      shell: false,
-    });
+  const preparedConfig = await preparePgtypedConfig(pgtypedConfigPath, port);
+  try {
+    await new Promise<void>((resolve, reject) => {
+      const childEnv = {
+        ...process.env,
+        PGDATABASE: "postgres",
+        PGHOST: "127.0.0.1",
+        PGPORT: String(port),
+        PGUSER: "postgres",
+      };
+      delete childEnv.DATABASE_URL;
+      delete childEnv.PGURI;
 
-    child.stdout?.on("data", (chunk: Buffer | string) => {
-      chunk.toString().split("\n").forEach((line) => {
-        if (line.trim()) console.log(`${prefix}${line}`);
+      const child = spawn("node", [
+        pgtypedBin,
+        "-c",
+        preparedConfig.path,
+      ], {
+        env: childEnv,
+        stdio: ["ignore", "pipe", "pipe"],
+        shell: false,
       });
-    });
 
-    child.stderr?.on("data", (chunk: Buffer | string) => {
-      chunk.toString().split("\n").forEach((line) => {
-        if (line.trim()) console.error(`${prefix}${line}`);
+      child.stdout?.on("data", (chunk: Buffer | string) => {
+        chunk.toString().split("\n").forEach((line) => {
+          if (line.trim()) console.log(`${prefix}${line}`);
+        });
       });
-    });
 
-    child.on("close", (code) => {
-      if (code === 0) {
-        console.log(`${prefix}✅ Completed successfully`);
-        resolve();
-      } else {
-        reject(new Error(`pgtyped failed with exit code ${code}`));
-      }
+      child.stderr?.on("data", (chunk: Buffer | string) => {
+        chunk.toString().split("\n").forEach((line) => {
+          if (line.trim()) console.error(`${prefix}${line}`);
+        });
+      });
+
+      let forceKillTimer: ReturnType<typeof setTimeout> | undefined;
+      let settled = false;
+      let timedOut = false;
+      const timeout = setTimeout(() => {
+        timedOut = true;
+        child.kill("SIGTERM");
+        forceKillTimer = setTimeout(() => child.kill("SIGKILL"), 5_000);
+      }, timeoutMs);
+      const settle = (operation: () => void) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timeout);
+        if (forceKillTimer) clearTimeout(forceKillTimer);
+        operation();
+      };
+
+      child.once("error", (error) => settle(() => reject(error)));
+      child.once("close", (code) => settle(() => {
+        if (timedOut) {
+          reject(new Error(`pgtyped timed out after ${timeoutMs}ms`));
+        } else if (code === 0) {
+          console.log(`${prefix}✅ Completed successfully`);
+          resolve();
+        } else {
+          reject(new Error(`pgtyped failed with exit code ${code}`));
+        }
+      }));
     });
-  });
+  } finally {
+    await preparedConfig.cleanup();
+  }
 }
 
 export async function main(options?: PgtypedUpdateOptions) {
   const userMigrations = options?.userMigrations ?? await resolveUserMigrations();
   const pgtypedConfigPath = options?.pgtypedConfigPath ?? "./pgtypedconfig.json";
   const pgtypedBin = options?.pgtypedBin ?? resolve(process.cwd(), "node_modules/@paima/pgtyped-cli/lib/index.js");
+  const pgtypedTimeoutMs = options?.pgtypedTimeoutMs ?? 600_000;
 
   console.log("🚀 Starting pgtyped-update...\n");
 
   let pglite: PgliteHandle | undefined;
   try {
-    pglite = await startPglite();
-    await waitForDb();
-    await applySystemMigrations();
-    await applyUserMigrations(userMigrations);
-    await runPgtyped(pgtypedBin, pgtypedConfigPath);
+    pglite = await startPglite(0);
+    await waitForDb(pglite.port, "127.0.0.1");
+    await applySystemMigrations(pglite.port);
+    await applyUserMigrations(userMigrations, pglite.port);
+    await runPgtyped(pgtypedBin, pgtypedConfigPath, pglite.port, pgtypedTimeoutMs);
     console.log("\n✅ All steps completed successfully");
   } finally {
-    await pglite?.close();
+    await pglite?.close({ force: true });
   }
 }
 

--- a/packages/node-sdk/db/scripts/start-pglite.ts
+++ b/packages/node-sdk/db/scripts/start-pglite.ts
@@ -11,7 +11,77 @@ export interface PgliteHandle {
   server: net.Server;
   db: PGlite;
   port: number;
-  close: () => Promise<void>;
+  close: (options?: PgliteCloseOptions) => Promise<void>;
+}
+
+export interface PgliteCloseOptions {
+  /**
+   * Destroy accepted client sockets before closing the gateway. Use this only
+   * when the caller owns those clients and has installed their error handling.
+   */
+  force?: boolean;
+}
+
+function throwCleanupErrors(errors: unknown[], message: string): void {
+  if (errors.length === 1) throw errors[0];
+  if (errors.length > 1) throw new AggregateError(errors, message);
+}
+
+async function closeListener(
+  server: net.Server,
+  sockets: Set<net.Socket>,
+  force: boolean,
+  waitForAcceptedSockets = true,
+): Promise<void> {
+  if (force) {
+    for (const socket of sockets) socket.destroy();
+  }
+
+  if (!server.listening) return;
+
+  if (!waitForAcceptedSockets) {
+    // `server.close(callback)` keeps Bun's listener-close lifecycle referenced
+    // until every preserved socket drains. The compatibility path cannot await
+    // that lifecycle, so initiate close without a callback after unrefing the
+    // listener and accepted sockets. Synchronous initiation failures still
+    // reject this operation.
+    server.close();
+    return;
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    try {
+      server.close((error) => {
+        if (error) reject(error);
+        else resolve();
+      });
+    } catch (error) {
+      reject(error);
+      return;
+    }
+  });
+}
+
+async function closeResources(
+  server: net.Server,
+  db: PGlite,
+  sockets: Set<net.Socket>,
+  force: boolean,
+): Promise<void> {
+  const errors: unknown[] = [];
+  try {
+    await closeListener(server, sockets, force);
+  } catch (error) {
+    errors.push(error);
+  }
+
+  try {
+    await db.close();
+  } catch (error) {
+    errors.push(error);
+  }
+
+  throwCleanupErrors(errors, "Failed to close the PGlite gateway and database.");
 }
 
 export async function startPglite(port = 5432): Promise<PgliteHandle> {
@@ -69,43 +139,126 @@ export async function startPglite(port = 5432): Promise<PgliteHandle> {
   });
 
   const sockets = new Set<net.Socket>();
+  let defaultCleanupDeferred = false;
+  let databaseCleanupPromise: Promise<void> | undefined;
+  let deferredCleanupObserved = false;
+
+  const closeDatabase = (): Promise<void> => {
+    databaseCleanupPromise ??= Promise.resolve().then(async () => {
+      // Once no accepted socket can deliver more ingress, finish the final live
+      // serialized operation before closing its PGlite backend.
+      await queue;
+      await db.close();
+    });
+    return databaseCleanupPromise;
+  };
+
+  const observeDeferredDatabaseCleanup = (): void => {
+    if (deferredCleanupObserved) return;
+    deferredCleanupObserved = true;
+    void closeDatabase().catch((error) => {
+      console.error("database: deferred PGlite cleanup failed", error);
+    });
+  };
+
   server.on("connection", (socket) => {
     sockets.add(socket);
-    socket.once("close", () => sockets.delete(socket));
-  });
-
-  await new Promise<void>((resolve, reject) => {
-    server.once("error", reject);
-    server.listen(port, "127.0.0.1", () => {
-      server.off("error", reject);
-      resolve();
+    if (defaultCleanupDeferred) socket.unref();
+    socket.once("close", () => {
+      sockets.delete(socket);
+      if (defaultCleanupDeferred && sockets.size === 0) {
+        observeDeferredDatabaseCleanup();
+      }
     });
   });
 
+  try {
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(port, "127.0.0.1", () => {
+        server.off("error", reject);
+        resolve();
+      });
+    });
+  } catch (listenError) {
+    const errors: unknown[] = [listenError];
+    try {
+      await db.close();
+    } catch (dbError) {
+      errors.push(dbError);
+    }
+    throwCleanupErrors(errors, "Failed to start the PGlite gateway and close its database.");
+    throw listenError;
+  }
+
   const address = server.address();
   if (!address || typeof address === "string") {
-    await db.close();
-    throw new Error("Unable to determine the PGlite gateway port.");
+    const addressError = new Error("Unable to determine the PGlite gateway port.");
+    const errors: unknown[] = [addressError];
+    try {
+      await closeResources(server, db, sockets, true);
+    } catch (cleanupError) {
+      if (cleanupError instanceof AggregateError) errors.push(...cleanupError.errors);
+      else errors.push(cleanupError);
+    }
+    throwCleanupErrors(errors, "Unable to determine and clean up the PGlite gateway.");
+    throw addressError;
   }
   const actualPort = address.port;
   console.info(`database: server listening on port ${actualPort}`);
 
-  let closed = false;
+  let cleanupPromise: Promise<void> | undefined;
+
+  const closeDefault = async (): Promise<void> => {
+    const errors: unknown[] = [];
+    const deferDatabaseCleanup = sockets.size > 0;
+    if (deferDatabaseCleanup) {
+      defaultCleanupDeferred = true;
+      server.unref();
+      for (const socket of sockets) socket.unref();
+    }
+
+    try {
+      await closeListener(server, sockets, false, !deferDatabaseCleanup);
+    } catch (error) {
+      errors.push(error);
+    }
+
+    if (!deferDatabaseCleanup) {
+      try {
+        await closeDatabase();
+      } catch (error) {
+        errors.push(error);
+      }
+    } else {
+      if (sockets.size === 0) observeDeferredDatabaseCleanup();
+    }
+
+    throwCleanupErrors(errors, "Failed to close the PGlite gateway and database.");
+  };
+
+  const closeForced = async (): Promise<void> => {
+    const errors: unknown[] = [];
+    try {
+      await closeListener(server, sockets, true);
+    } catch (error) {
+      errors.push(error);
+    }
+    try {
+      await closeDatabase();
+    } catch (error) {
+      errors.push(error);
+    }
+    throwCleanupErrors(errors, "Failed to close the PGlite gateway and database.");
+  };
 
   return {
     server,
     db,
     port: actualPort,
-    close: async () => {
-      if (closed) return;
-      closed = true;
-      for (const socket of sockets) socket.destroy();
-      if (server.listening) {
-        await new Promise<void>((resolve, reject) => {
-          server.close((error) => error ? reject(error) : resolve());
-        });
-      }
-      await db.close();
+    close: (options = {}) => {
+      cleanupPromise ??= options.force === true ? closeForced() : closeDefault();
+      return cleanupPromise;
     },
   };
 }

--- a/packages/node-sdk/db/scripts/start-pglite.ts
+++ b/packages/node-sdk/db/scripts/start-pglite.ts
@@ -22,22 +22,41 @@ export interface PgliteCloseOptions {
   force?: boolean;
 }
 
+interface ListenerCloseLifecycle {
+  complete: () => boolean;
+  completion: Promise<void>;
+}
+
 function throwCleanupErrors(errors: unknown[], message: string): void {
   if (errors.length === 1) throw errors[0];
   if (errors.length > 1) throw new AggregateError(errors, message);
+}
+
+async function destroyTrackedSockets(sockets: Set<net.Socket>): Promise<void> {
+  while (sockets.size > 0) {
+    const tracked = [...sockets];
+    const closed = tracked.map((socket) => new Promise<void>((resolve) => {
+      socket.once("close", resolve);
+    }));
+    for (const socket of tracked) socket.destroy();
+    await Promise.all(closed);
+  }
 }
 
 async function closeListener(
   server: net.Server,
   sockets: Set<net.Socket>,
   force: boolean,
+  lifecycle: ListenerCloseLifecycle,
   waitForAcceptedSockets = true,
 ): Promise<void> {
-  if (force) {
-    for (const socket of sockets) socket.destroy();
-  }
+  const socketTeardown = force ? destroyTrackedSockets(sockets) : undefined;
 
-  if (!server.listening) return;
+  if (!server.listening) {
+    await socketTeardown;
+    if (force && !lifecycle.complete()) await lifecycle.completion;
+    return;
+  }
 
   if (!waitForAcceptedSockets) {
     // `server.close(callback)` keeps Bun's listener-close lifecycle referenced
@@ -49,17 +68,24 @@ async function closeListener(
     return;
   }
 
-  await new Promise<void>((resolve, reject) => {
-    try {
-      server.close((error) => {
-        if (error) reject(error);
-        else resolve();
-      });
-    } catch (error) {
-      reject(error);
-      return;
-    }
-  });
+  let listenerError: unknown;
+  try {
+    await new Promise<void>((resolve, reject) => {
+      try {
+        server.close((error) => {
+          if (error) reject(error);
+          else resolve();
+        });
+      } catch (error) {
+        reject(error);
+      }
+    });
+  } catch (error) {
+    listenerError = error;
+  }
+
+  await socketTeardown;
+  if (listenerError !== undefined) throw listenerError;
 }
 
 async function closeResources(
@@ -67,10 +93,11 @@ async function closeResources(
   db: PGlite,
   sockets: Set<net.Socket>,
   force: boolean,
+  lifecycle: ListenerCloseLifecycle,
 ): Promise<void> {
   const errors: unknown[] = [];
   try {
-    await closeListener(server, sockets, force);
+    await closeListener(server, sockets, force, lifecycle);
   } catch (error) {
     errors.push(error);
   }
@@ -138,6 +165,18 @@ export async function startPglite(port = 5432): Promise<PgliteHandle> {
     });
   });
 
+  let listenerCloseComplete = false;
+  const listenerCloseCompletion = new Promise<void>((resolve) => {
+    server.once("close", () => {
+      listenerCloseComplete = true;
+      resolve();
+    });
+  });
+  const listenerLifecycle: ListenerCloseLifecycle = {
+    complete: () => listenerCloseComplete,
+    completion: listenerCloseCompletion,
+  };
+
   const sockets = new Set<net.Socket>();
   let defaultCleanupDeferred = false;
   let databaseCleanupPromise: Promise<void> | undefined;
@@ -196,7 +235,7 @@ export async function startPglite(port = 5432): Promise<PgliteHandle> {
     const addressError = new Error("Unable to determine the PGlite gateway port.");
     const errors: unknown[] = [addressError];
     try {
-      await closeResources(server, db, sockets, true);
+      await closeResources(server, db, sockets, true, listenerLifecycle);
     } catch (cleanupError) {
       if (cleanupError instanceof AggregateError) errors.push(...cleanupError.errors);
       else errors.push(cleanupError);
@@ -219,7 +258,13 @@ export async function startPglite(port = 5432): Promise<PgliteHandle> {
     }
 
     try {
-      await closeListener(server, sockets, false, !deferDatabaseCleanup);
+      await closeListener(
+        server,
+        sockets,
+        false,
+        listenerLifecycle,
+        !deferDatabaseCleanup,
+      );
     } catch (error) {
       errors.push(error);
     }
@@ -240,7 +285,7 @@ export async function startPglite(port = 5432): Promise<PgliteHandle> {
   const closeForced = async (): Promise<void> => {
     const errors: unknown[] = [];
     try {
-      await closeListener(server, sockets, true);
+      await closeListener(server, sockets, true, listenerLifecycle);
     } catch (error) {
       errors.push(error);
     }

--- a/packages/node-sdk/db/scripts/wait-for-db.ts
+++ b/packages/node-sdk/db/scripts/wait-for-db.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
-import { spawn } from "node:child_process";
-import { args, exit } from "@effectstream/utils/runtime";
+import net from "node:net";
+import { args } from "@effectstream/utils/runtime";
 
 // Get port from arguments.
 const portArgName = "--port";
@@ -12,28 +12,34 @@ if (isNaN(port)) {
   throw new Error(`Port argument ${portArgName} is not a number`);
 }
 
-async function waitForDb() {
-  try {
-    console.log("waiting for db on port", port);
-    const child = spawn("npx", ["wait-on", `tcp:${port}`], {
-      stdio: "inherit",
-      shell: true,
-    });
-
-    const code = await new Promise<number | null>((resolve) => {
-      child.on("close", (code, _sig) => resolve(code));
-    });
-
-    if (code === 0) {
-      console.log("✅ Database is ready on port 5432");
-    } else {
-      console.error("❌ Failed to connect to database on port 5432");
-      exit(code ?? 1);
+async function waitForDb(
+  targetPort = port,
+  host = "127.0.0.1",
+  timeoutMs = 10_000,
+): Promise<void> {
+  console.log(`waiting for db on ${host}:${targetPort}`);
+  const deadline = Date.now() + timeoutMs;
+  let lastError: unknown;
+  while (Date.now() < deadline) {
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const socket = net.connect({ host, port: targetPort });
+        socket.once("connect", () => {
+          socket.destroy();
+          resolve();
+        });
+        socket.once("error", reject);
+      });
+      console.log(`✅ Database is ready on ${host}:${targetPort}`);
+      return;
+    } catch (error) {
+      lastError = error;
+      await new Promise((resolve) => setTimeout(resolve, 100));
     }
-  } catch (error) {
-    console.error("❌ Error waiting for database:", error);
-    exit(1);
   }
+  throw new Error(`Failed to connect to database at ${host}:${targetPort}.`, {
+    cause: lastError,
+  });
 }
 
 export { waitForDb };

--- a/packages/node-sdk/db/test/fixtures/pglite-close/01-sentinel.test.ts
+++ b/packages/node-sdk/db/test/fixtures/pglite-close/01-sentinel.test.ts
@@ -1,0 +1,10 @@
+import { expect, test } from "bun:test";
+
+if (process.env.EFFECTSTREAM_PGLITE_MULTIFILE_FIXTURE !== "1") {
+  test.skip("multi-file sentinel fixture runs only through its parent", () => {});
+} else {
+  console.info("PGLITE_SENTINEL_REGISTERED");
+  test("the following file still registers", () => {
+    expect(true).toBe(true);
+  });
+}

--- a/packages/node-sdk/db/test/fixtures/pglite-close/02-live-client.test.ts
+++ b/packages/node-sdk/db/test/fixtures/pglite-close/02-live-client.test.ts
@@ -1,0 +1,27 @@
+import { afterAll, expect, test } from "bun:test";
+import { Client } from "pg";
+import { startPglite } from "../../../scripts/start-pglite.ts";
+
+const enabled = process.env.EFFECTSTREAM_PGLITE_MULTIFILE_FIXTURE === "1";
+
+if (!enabled) {
+  test.skip("multi-file retained-client fixture runs only through its parent", () => {});
+} else {
+  const handle = await startPglite(0);
+  const client = new Client({
+    host: "127.0.0.1",
+    port: handle.port,
+    user: "postgres",
+    database: "postgres",
+  });
+
+  test("leaves a raw client connected during default close", async () => {
+    await client.connect();
+    expect((await client.query("SELECT 1 AS value")).rows).toEqual([{ value: 1 }]);
+  });
+
+  afterAll(async () => {
+    await handle.close();
+    console.info("PGLITE_LIVE_CLIENT_CLOSED_DEFAULT");
+  });
+}

--- a/packages/node-sdk/db/test/fixtures/pglite-close/process-exit.ts
+++ b/packages/node-sdk/db/test/fixtures/pglite-close/process-exit.ts
@@ -1,0 +1,10 @@
+import { startPglite } from "../../../scripts/start-pglite.ts";
+
+const handle = await startPglite(0);
+console.info(`PGLITE_PROCESS_EXIT_PORT:${handle.port}`);
+
+await new Promise<void>((resolve) => {
+  handle.server.once("connection", () => resolve());
+});
+await handle.close();
+console.info("PGLITE_PROCESS_EXIT_DEFAULT_CLOSED");

--- a/packages/node-sdk/db/test/fixtures/pgtyped/failure.mjs
+++ b/packages/node-sdk/db/test/fixtures/pgtyped/failure.mjs
@@ -1,0 +1,17 @@
+import { readFileSync } from "node:fs";
+
+const configIndex = process.argv.indexOf("-c");
+const configPath = configIndex === -1 ? undefined : process.argv[configIndex + 1];
+const config = JSON.parse(readFileSync(configPath, "utf8"));
+if (config.db.host !== "127.0.0.1") {
+  console.error(`unexpected pgtyped host: ${String(config.db.host)}`);
+  process.exit(2);
+}
+const port = Number(config.db.port);
+if (!Number.isInteger(port) || port <= 0 || port === 5432) {
+  console.error(`pgtyped did not receive the reported ephemeral port: ${port}`);
+  process.exit(3);
+}
+console.log(`PGTYPED_CONFIG_PATH:${configPath}`);
+console.error("PGTYPED_INJECTED_FAILURE");
+process.exit(23);

--- a/packages/node-sdk/db/test/fixtures/pgtyped/hang.mjs
+++ b/packages/node-sdk/db/test/fixtures/pgtyped/hang.mjs
@@ -1,0 +1,12 @@
+import { readFileSync } from "node:fs";
+
+const configIndex = process.argv.indexOf("-c");
+const configPath = configIndex === -1 ? undefined : process.argv[configIndex + 1];
+const config = JSON.parse(readFileSync(configPath, "utf8"));
+if (config.db.host !== "127.0.0.1" || !Number.isInteger(config.db.port)) {
+  console.error("unexpected pgtyped connection config");
+  process.exit(2);
+}
+console.log(`PGTYPED_CONFIG_PATH:${configPath}`);
+console.log("PGTYPED_INJECTED_HANG");
+setInterval(() => {}, 1_000);

--- a/packages/node-sdk/db/test/fixtures/pgtyped/success.mjs
+++ b/packages/node-sdk/db/test/fixtures/pgtyped/success.mjs
@@ -1,0 +1,30 @@
+import { readFileSync } from "node:fs";
+
+const configIndex = process.argv.indexOf("-c");
+const configPath = configIndex === -1 ? undefined : process.argv[configIndex + 1];
+const config = JSON.parse(readFileSync(configPath, "utf8"));
+if (config.db.host !== "127.0.0.1") {
+  console.error(`unexpected pgtyped host: ${String(config.db.host)}`);
+  process.exit(2);
+}
+const port = Number(config.db.port);
+if (!Number.isInteger(port) || port <= 0 || port === 5432) {
+  console.error(`pgtyped did not receive the reported ephemeral port: ${port}`);
+  process.exit(3);
+}
+if (config.db.user !== "postgres" || config.db.dbName !== "postgres") {
+  console.error("unexpected pgtyped user or database");
+  process.exit(4);
+}
+if (
+  config.customMarker !== "quoted \"value\" with newline\nand unicode ✓" ||
+  config.db.password !== "special ✓ password" ||
+  config.db.ssl !== false ||
+  "dbUrl" in config
+) {
+  console.error("derived pgtyped config did not preserve its shape safely");
+  process.exit(5);
+}
+console.log(`PGTYPED_CONNECTION_OK:${port}`);
+console.log("PGTYPED_CONFIG_SHAPE_OK");
+console.log(`PGTYPED_CONFIG_PATH:${configPath}`);

--- a/packages/node-sdk/db/test/pgtyped-update.test.ts
+++ b/packages/node-sdk/db/test/pgtyped-update.test.ts
@@ -1,0 +1,132 @@
+import { expect, test } from "bun:test";
+import { PGlite } from "@electric-sql/pglite";
+import { existsSync } from "node:fs";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import net from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { main } from "../scripts/pgtyped-update.ts";
+
+const configMarker = "quoted \"value\" with newline\nand unicode ✓";
+
+async function expectPortClosed(port: number): Promise<void> {
+  await expect(new Promise<void>((resolve, reject) => {
+    const socket = net.connect({ host: "127.0.0.1", port });
+    socket.once("connect", () => {
+      socket.destroy();
+      resolve();
+    });
+    socket.once("error", reject);
+  })).rejects.toMatchObject({ code: "ECONNREFUSED" });
+}
+
+async function runAndCapture(
+  pgtypedBin: URL,
+  pgtypedTimeoutMs = 30_000,
+): Promise<{
+  closeCount: number;
+  derivedConfigPath: string;
+  output: string;
+  port: number;
+  error?: unknown;
+}> {
+  const configDirectory = await mkdtemp(join(tmpdir(), "effectstream-pgtyped-test-"));
+  const configPath = join(configDirectory, "pgtypedconfig.json");
+  await writeFile(configPath, JSON.stringify({
+    customMarker: configMarker,
+    db: {
+      dbName: "wrong-db",
+      host: "wrong-host",
+      password: "special ✓ password",
+      port: 1,
+      ssl: false,
+      user: "wrong-user",
+    },
+    dbUrl: "postgresql://must-not-be-used",
+    failOnError: false,
+    maxWorkerThreads: 1,
+    srcDir: "./sql",
+    transforms: [],
+  }));
+
+  const originalClose = PGlite.prototype.close;
+  const originalInfo = console.info;
+  const originalLog = console.log;
+  const originalError = console.error;
+  let closeCount = 0;
+  const output: string[] = [];
+
+  PGlite.prototype.close = async function () {
+    closeCount += 1;
+    return await originalClose.call(this);
+  };
+  console.info = (...args: unknown[]) => output.push(args.join(" "));
+  console.log = (...args: unknown[]) => output.push(args.join(" "));
+  console.error = (...args: unknown[]) => output.push(args.join(" "));
+
+  let error: unknown;
+  try {
+    await main({
+      userMigrations: [],
+      pgtypedConfigPath: configPath,
+      pgtypedBin: pgtypedBin.pathname,
+      pgtypedTimeoutMs,
+    });
+  } catch (caught) {
+    error = caught;
+  } finally {
+    PGlite.prototype.close = originalClose;
+    console.info = originalInfo;
+    console.log = originalLog;
+    console.error = originalError;
+    await rm(configDirectory, { force: true, recursive: true });
+  }
+
+  const text = output.join("\n");
+  const match = text.match(/database: server listening on port (\d+)/);
+  if (!match) throw new Error(`No reported PGlite port in output:\n${text}`);
+  const configMatch = text.match(/PGTYPED_CONFIG_PATH:(.+)/);
+  if (!configMatch) throw new Error(`No derived pgtyped config path in output:\n${text}`);
+  return {
+    closeCount,
+    derivedConfigPath: configMatch[1],
+    output: text,
+    port: Number(match[1]),
+    error,
+  };
+}
+
+test("pgtyped update uses the reported IPv4 connection and closes every resource on success", async () => {
+  const result = await runAndCapture(new URL("./fixtures/pgtyped/success.mjs", import.meta.url));
+
+  expect(result.error).toBeUndefined();
+  expect(result.output).toContain(`PGTYPED_CONNECTION_OK:${result.port}`);
+  expect(result.output).toContain("PGTYPED_CONFIG_SHAPE_OK");
+  expect(result.port).not.toBe(5432);
+  expect(result.closeCount).toBe(1);
+  expect(existsSync(result.derivedConfigPath)).toBe(false);
+  await expectPortClosed(result.port);
+}, 30_000);
+
+test("pgtyped update closes every resource when its child fails", async () => {
+  const result = await runAndCapture(new URL("./fixtures/pgtyped/failure.mjs", import.meta.url));
+
+  expect(result.error).toEqual(new Error("pgtyped failed with exit code 23"));
+  expect(result.output).toContain("PGTYPED_INJECTED_FAILURE");
+  expect(result.closeCount).toBe(1);
+  expect(existsSync(result.derivedConfigPath)).toBe(false);
+  await expectPortClosed(result.port);
+}, 30_000);
+
+test("pgtyped update times out its child and removes the derived config", async () => {
+  const result = await runAndCapture(
+    new URL("./fixtures/pgtyped/hang.mjs", import.meta.url),
+    100,
+  );
+
+  expect(result.error).toEqual(new Error("pgtyped timed out after 100ms"));
+  expect(result.output).toContain("PGTYPED_INJECTED_HANG");
+  expect(result.closeCount).toBe(1);
+  expect(existsSync(result.derivedConfigPath)).toBe(false);
+  await expectPortClosed(result.port);
+}, 30_000);

--- a/packages/node-sdk/db/test/start-pglite-multifile.test.ts
+++ b/packages/node-sdk/db/test/start-pglite-multifile.test.ts
@@ -1,0 +1,33 @@
+import { expect, test } from "bun:test";
+
+test("default close with a retained raw client does not poison the next test file", async () => {
+  const fixtures = new URL("./fixtures/pglite-close/", import.meta.url);
+  const child = Bun.spawn([
+    process.execPath,
+    "test",
+    "--max-concurrency=1",
+    new URL("01-sentinel.test.ts", fixtures).pathname,
+    new URL("02-live-client.test.ts", fixtures).pathname,
+  ], {
+    cwd: new URL("../../../..", import.meta.url).pathname,
+    env: {
+      ...process.env,
+      EFFECTSTREAM_PGLITE_MULTIFILE_FIXTURE: "1",
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+    child.exited,
+  ]);
+  const output = `${stdout}\n${stderr}`;
+
+  expect(exitCode, output).toBe(0);
+  expect(output).toContain("PGLITE_LIVE_CLIENT_CLOSED_DEFAULT");
+  expect(output).toContain("PGLITE_SENTINEL_REGISTERED");
+  expect(output).not.toContain("Unhandled error between tests");
+  expect(output).not.toContain("Connection terminated unexpectedly");
+}, 30_000);

--- a/packages/node-sdk/db/test/start-pglite.test.ts
+++ b/packages/node-sdk/db/test/start-pglite.test.ts
@@ -1,0 +1,520 @@
+import { expect, test } from "bun:test";
+import { PGlite } from "@electric-sql/pglite";
+import net from "node:net";
+import { Client } from "pg";
+import {
+  startPglite,
+  type PgliteHandle,
+} from "../scripts/start-pglite.ts";
+
+const connection = (handle: PgliteHandle) => ({
+  host: "127.0.0.1",
+  port: handle.port,
+  user: "postgres",
+  database: "postgres",
+  connectionTimeoutMillis: 500,
+});
+
+async function connect(handle: PgliteHandle): Promise<Client> {
+  const client = new Client(connection(handle));
+  await client.connect();
+  return client;
+}
+
+async function expectRefused(handle: PgliteHandle): Promise<void> {
+  const probe = new Client(connection(handle));
+  await expect(probe.connect()).rejects.toMatchObject({ code: "ECONNREFUSED" });
+}
+
+const clientSocket = (client: Client): net.Socket =>
+  (client as unknown as { connection: { stream: net.Socket } }).connection.stream;
+
+async function destroyHandled(client: Client): Promise<Error[]> {
+  const errors: Error[] = [];
+  client.on("error", (error) => errors.push(error));
+  clientSocket(client).destroy();
+  await Bun.sleep(20);
+  return errors;
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  description: string,
+  timeoutMs = 2_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() >= deadline) throw new Error(`Timed out waiting for ${description}.`);
+    await Bun.sleep(10);
+  }
+}
+
+test("default and forced close are bounded without clients", async () => {
+  const graceful = await startPglite(0);
+  const forced = await startPglite(0);
+
+  await Promise.race([
+    graceful.close(),
+    Bun.sleep(2_000).then(() => Promise.reject(new Error("default close timed out"))),
+  ]);
+  await Promise.race([
+    forced.close({ force: true }),
+    Bun.sleep(2_000).then(() => Promise.reject(new Error("forced close timed out"))),
+  ]);
+
+  expect(graceful.server.listening).toBe(false);
+  expect(forced.server.listening).toBe(false);
+});
+
+test("a client that drains first closes without a client error", async () => {
+  const handle = await startPglite(0);
+  const client = await connect(handle);
+  const errors: Error[] = [];
+  client.on("error", (error) => errors.push(error));
+
+  await client.end();
+  await handle.close();
+
+  expect(errors).toEqual([]);
+  expect(handle.server.listening).toBe(false);
+});
+
+test("default close preserves multiple retained sockets and rejects new clients", async () => {
+  const handle = await startPglite(0);
+  const clients = await Promise.all([connect(handle), connect(handle)]);
+  const errors: Error[] = [];
+  for (const client of clients) client.on("error", (error) => errors.push(error));
+
+  await Promise.race([
+    handle.close(),
+    Bun.sleep(2_000).then(() => Promise.reject(new Error("default close timed out"))),
+  ]);
+  await expectRefused(handle);
+  await Bun.sleep(20);
+
+  expect(errors).toEqual([]);
+  expect(clients.every((client) => !clientSocket(client).destroyed)).toBe(true);
+  for (const client of clients) clientSocket(client).destroy();
+  await Bun.sleep(20);
+});
+
+test("default close unrefs retained sockets and defers cleanup until the last drains", async () => {
+  const handle = await startPglite(0);
+  const acceptedSockets: net.Socket[] = [];
+  handle.server.on("connection", (socket) => acceptedSockets.push(socket));
+  const clients = await Promise.all([connect(handle), connect(handle)]);
+  const errors: Error[] = [];
+  for (const client of clients) client.on("error", (error) => errors.push(error));
+  const unrefCounts = acceptedSockets.map(() => 0);
+  acceptedSockets.forEach((socket, index) => {
+    const originalUnref = socket.unref.bind(socket);
+    socket.unref = () => {
+      unrefCounts[index] += 1;
+      return originalUnref();
+    };
+  });
+
+  const originalDbClose = handle.db.close.bind(handle.db);
+  let dbCloseCount = 0;
+  let dbCloseComplete = false;
+  handle.db.close = async () => {
+    dbCloseCount += 1;
+    await originalDbClose();
+    dbCloseComplete = true;
+  };
+
+  await handle.close();
+  expect(acceptedSockets).toHaveLength(2);
+  expect(unrefCounts).toEqual([1, 1]);
+  expect(dbCloseCount).toBe(0);
+  expect((await clients[0].query("SELECT 1 AS value")).rows).toEqual([{ value: 1 }]);
+  expect(errors).toEqual([]);
+
+  clientSocket(clients[0]).destroy();
+  await waitFor(() => acceptedSockets[0].destroyed, "the first accepted socket to drain");
+  expect(dbCloseCount).toBe(0);
+
+  clientSocket(clients[1]).destroy();
+  await waitFor(() => dbCloseComplete, "deferred PGlite cleanup");
+  expect(dbCloseCount).toBe(1);
+  expect(errors).toHaveLength(2);
+  expect(errors.every((error) => error.message === "Connection terminated unexpectedly")).toBe(true);
+});
+
+test("an unrefed retained server socket does not keep its owner process alive", async () => {
+  const child = Bun.spawn([
+    process.execPath,
+    new URL("./fixtures/pglite-close/process-exit.ts", import.meta.url).pathname,
+  ], {
+    cwd: new URL("../../../..", import.meta.url).pathname,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const decoder = new TextDecoder();
+  let stdout = "";
+  let reportPort: ((port: number) => void) | undefined;
+  const portReported = new Promise<number>((resolve) => {
+    reportPort = resolve;
+  });
+  const stdoutComplete = (async () => {
+    for await (const chunk of child.stdout) {
+      stdout += decoder.decode(chunk, { stream: true });
+      const match = stdout.match(/PGLITE_PROCESS_EXIT_PORT:(\d+)/);
+      if (match && reportPort) {
+        reportPort(Number(match[1]));
+        reportPort = undefined;
+      }
+    }
+    stdout += decoder.decode();
+    return stdout;
+  })();
+  const stderrComplete = new Response(child.stderr).text();
+
+  let socket: net.Socket | undefined;
+  try {
+    const port = await Promise.race([
+      portReported,
+      Bun.sleep(5_000).then(() => Promise.reject(new Error("child did not report its port"))),
+    ]);
+    socket = net.createConnection({ host: "127.0.0.1", port });
+    socket.on("error", () => {});
+    await new Promise<void>((resolve) => socket?.once("connect", resolve));
+
+    const exitCode = await Promise.race([
+      child.exited,
+      Bun.sleep(5_000).then(() => Promise.reject(
+        new Error(`retained socket kept child alive; stdout so far: ${stdout}`),
+      )),
+    ]);
+    const [childStdout, childStderr] = await Promise.all([stdoutComplete, stderrComplete]);
+    const output = `${childStdout}\n${childStderr}`;
+    expect(exitCode, output).toBe(0);
+    expect(output).toContain("PGLITE_PROCESS_EXIT_DEFAULT_CLOSED");
+  } finally {
+    socket?.destroy();
+    if (child.exitCode === null) child.kill();
+    await child.exited;
+  }
+}, 15_000);
+
+test("forced close destroys every retained socket before settling", async () => {
+  const handle = await startPglite(0);
+  const clients = await Promise.all([connect(handle), connect(handle)]);
+  const errors: Error[] = [];
+  for (const client of clients) client.on("error", (error) => errors.push(error));
+
+  await handle.close({ force: true });
+  await Bun.sleep(20);
+
+  expect(clients.every((client) => clientSocket(client).destroyed)).toBe(true);
+  expect(errors).toHaveLength(2);
+  expect(errors.every((error) => error.message === "Connection terminated unexpectedly")).toBe(true);
+  expect(handle.server.listening).toBe(false);
+});
+
+test("repeated and concurrent close calls share the first default operation", async () => {
+  const handle = await startPglite(0);
+  const client = await connect(handle);
+  const errors: Error[] = [];
+  client.on("error", (error) => errors.push(error));
+
+  const first = handle.close();
+  const sameMode = handle.close();
+  const attemptedEscalation = handle.close({ force: true });
+
+  expect(sameMode).toBe(first);
+  expect(attemptedEscalation).toBe(first);
+  await Promise.all([first, sameMode, attemptedEscalation]);
+  await Bun.sleep(20);
+  expect(errors).toEqual([]);
+  expect(clientSocket(client).destroyed).toBe(false);
+  expect(handle.close({ force: true })).toBe(first);
+
+  clientSocket(client).destroy();
+  await Bun.sleep(20);
+});
+
+test("repeated and concurrent close calls share the first forced operation", async () => {
+  const handle = await startPglite(0);
+  const client = await connect(handle);
+  client.on("error", () => {});
+
+  const first = handle.close({ force: true });
+  const sameMode = handle.close({ force: true });
+  const attemptedDowngrade = handle.close();
+
+  expect(sameMode).toBe(first);
+  expect(attemptedDowngrade).toBe(first);
+  await Promise.all([first, sameMode, attemptedDowngrade]);
+  await Bun.sleep(20);
+  expect(clientSocket(client).destroyed).toBe(true);
+  expect(handle.close()).toBe(first);
+});
+
+test("port zero reports the actual IPv4 loopback listener", async () => {
+  const handle = await startPglite(0);
+  try {
+    const address = handle.server.address();
+    expect(address).not.toBeNull();
+    expect(typeof address).not.toBe("string");
+    if (!address || typeof address === "string") return;
+    expect(handle.port).toBe(address.port);
+    expect(handle.port).toBeGreaterThan(0);
+    expect(address.address).toBe("127.0.0.1");
+    expect(address.family).toBe("IPv4");
+  } finally {
+    await handle.close({ force: true });
+  }
+});
+
+test("occupied-port startup rejects and closes the created PGlite instance", async () => {
+  const blocker = net.createServer();
+  await new Promise<void>((resolve) => blocker.listen(0, "127.0.0.1", resolve));
+  const address = blocker.address();
+  if (!address || typeof address === "string") throw new Error("Unable to reserve a port.");
+
+  const originalClose = PGlite.prototype.close;
+  let dbCloseCount = 0;
+  PGlite.prototype.close = async function () {
+    dbCloseCount += 1;
+    return await originalClose.call(this);
+  };
+
+  try {
+    await expect(startPglite(address.port)).rejects.toMatchObject({ code: "EADDRINUSE" });
+    expect(dbCloseCount).toBe(1);
+  } finally {
+    PGlite.prototype.close = originalClose;
+    await new Promise<void>((resolve, reject) => {
+      blocker.close((error) => error ? reject(error) : resolve());
+    });
+  }
+});
+
+test("startup reports both listen and database-cleanup failures deterministically", async () => {
+  const blocker = net.createServer();
+  await new Promise<void>((resolve) => blocker.listen(0, "127.0.0.1", resolve));
+  const address = blocker.address();
+  if (!address || typeof address === "string") throw new Error("Unable to reserve a port.");
+
+  const originalClose = PGlite.prototype.close;
+  const databaseError = new Error("injected startup database close failure");
+  PGlite.prototype.close = async function () {
+    await originalClose.call(this);
+    throw databaseError;
+  };
+
+  try {
+    try {
+      await startPglite(address.port);
+      throw new Error("startup unexpectedly succeeded");
+    } catch (error) {
+      expect(error).toBeInstanceOf(AggregateError);
+      const errors = (error as AggregateError).errors;
+      expect(errors).toHaveLength(2);
+      expect(errors[0]).toMatchObject({ code: "EADDRINUSE" });
+      expect(errors[1]).toBe(databaseError);
+    }
+  } finally {
+    PGlite.prototype.close = originalClose;
+    await new Promise<void>((resolve, reject) => {
+      blocker.close((error) => error ? reject(error) : resolve());
+    });
+  }
+});
+
+test("listener close failure still closes the database and remains shared", async () => {
+  const handle = await startPglite(0);
+  const originalServerClose = handle.server.close.bind(handle.server);
+  const originalDbClose = handle.db.close.bind(handle.db);
+  const listenerError = new Error("injected listener close failure");
+  let dbCloseCount = 0;
+
+  handle.server.close = ((callback?: (error?: Error) => void) => {
+    callback?.(listenerError);
+    return handle.server;
+  }) as typeof handle.server.close;
+  handle.db.close = async () => {
+    dbCloseCount += 1;
+    await originalDbClose();
+  };
+
+  const first = handle.close();
+  const repeated = handle.close({ force: true });
+  expect(repeated).toBe(first);
+  await expect(first).rejects.toBe(listenerError);
+  await expect(repeated).rejects.toBe(listenerError);
+  expect(dbCloseCount).toBe(1);
+
+  handle.server.close = originalServerClose as typeof handle.server.close;
+  await new Promise<void>((resolve, reject) => {
+    originalServerClose((error) => error ? reject(error) : resolve());
+  });
+});
+
+test("multiple cleanup failures are deterministic and database cleanup is attempted once", async () => {
+  const handle = await startPglite(0);
+  const originalServerClose = handle.server.close.bind(handle.server);
+  const originalDbClose = handle.db.close.bind(handle.db);
+  const listenerError = new Error("injected listener close failure");
+  const databaseError = new Error("injected database close failure");
+  let dbCloseCount = 0;
+
+  handle.server.close = ((callback?: (error?: Error) => void) => {
+    callback?.(listenerError);
+    return handle.server;
+  }) as typeof handle.server.close;
+  handle.db.close = async () => {
+    dbCloseCount += 1;
+    throw databaseError;
+  };
+
+  const cleanup = handle.close({ force: true });
+  try {
+    await cleanup;
+    throw new Error("cleanup unexpectedly succeeded");
+  } catch (error) {
+    expect(error).toBeInstanceOf(AggregateError);
+    expect((error as AggregateError).errors).toEqual([listenerError, databaseError]);
+  }
+  expect(handle.close()).toBe(cleanup);
+  await expect(handle.close()).rejects.toBeInstanceOf(AggregateError);
+  expect(dbCloseCount).toBe(1);
+
+  handle.server.close = originalServerClose as typeof handle.server.close;
+  handle.db.close = originalDbClose;
+  await new Promise<void>((resolve, reject) => {
+    originalServerClose((error) => error ? reject(error) : resolve());
+  });
+  await originalDbClose();
+});
+
+test("an externally stopped listener still permits database cleanup", async () => {
+  const handle = await startPglite(0);
+  await new Promise<void>((resolve, reject) => {
+    handle.server.close((error) => error ? reject(error) : resolve());
+  });
+
+  await handle.close({ force: true });
+  expect(handle.server.listening).toBe(false);
+});
+
+test("a genuine PostgreSQL query error remains visible", async () => {
+  const handle = await startPglite(0);
+  const client = await connect(handle);
+  client.on("error", () => {});
+  try {
+    await expect(client.query("SELECT * FROM table_that_does_not_exist")).rejects.toMatchObject({
+      code: "42P01",
+    });
+  } finally {
+    await handle.close({ force: true });
+  }
+});
+
+test("default close settles while an in-flight query completes on its retained socket", async () => {
+  const handle = await startPglite(0);
+  const client = await connect(handle);
+  const errors: Error[] = [];
+  client.on("error", (error) => errors.push(error));
+
+  const query = client.query("SELECT pg_sleep(0.05), 1 AS value");
+  await Bun.sleep(10);
+  const cleanup = handle.close();
+  await cleanup;
+  const result = await query;
+
+  expect(result.rows).toHaveLength(1);
+  expect(errors).toEqual([]);
+  await destroyHandled(client);
+});
+
+test("default close drains a query submitted by an accepted client as close begins", async () => {
+  const handle = await startPglite(0);
+  const client = await connect(handle);
+  const errors: Error[] = [];
+  client.on("error", (error) => errors.push(error));
+
+  const cleanup = handle.close();
+  const result = await client.query("SELECT 1 AS value");
+  await cleanup;
+
+  expect(result.rows).toEqual([{ value: 1 }]);
+  expect(errors).toEqual([]);
+  await destroyHandled(client);
+});
+
+test("last socket close waits for final serialized work before deferred database cleanup", async () => {
+  const handle = await startPglite(0);
+  let acceptedSocket: net.Socket | undefined;
+  handle.server.once("connection", (socket) => {
+    acceptedSocket = socket;
+  });
+  const client = await connect(handle);
+  client.on("error", () => {});
+
+  const originalExec = handle.db.execProtocolRaw.bind(handle.db);
+  const originalDbClose = handle.db.close.bind(handle.db);
+  let releaseQuery!: () => void;
+  let queryEntered!: () => void;
+  const queryGate = new Promise<void>((resolve) => {
+    releaseQuery = resolve;
+  });
+  const queryStarted = new Promise<void>((resolve) => {
+    queryEntered = resolve;
+  });
+  let dbCloseCount = 0;
+  let dbCloseComplete = false;
+  handle.db.execProtocolRaw = async (...args) => {
+    queryEntered();
+    await queryGate;
+    return await originalExec(...args);
+  };
+  handle.db.close = async () => {
+    dbCloseCount += 1;
+    await originalDbClose();
+    dbCloseComplete = true;
+  };
+
+  const query = client.query("SELECT 1 AS value").catch(() => undefined);
+  await queryStarted;
+  clientSocket(client).destroy();
+  await waitFor(() => acceptedSocket?.destroyed === true, "the final accepted socket to close");
+  const cleanup = handle.close();
+  await Bun.sleep(20);
+  expect(dbCloseCount).toBe(0);
+
+  releaseQuery();
+  await cleanup;
+  await query;
+  await waitFor(() => dbCloseComplete, "database cleanup after final serialized work");
+  expect(dbCloseCount).toBe(1);
+});
+
+test("a late deferred database-cleanup failure is observed without rejecting settled close", async () => {
+  const handle = await startPglite(0);
+  const client = await connect(handle);
+  client.on("error", () => {});
+  const originalDbClose = handle.db.close.bind(handle.db);
+  const originalConsoleError = console.error;
+  const databaseError = new Error("injected deferred database close failure");
+  const observed: unknown[][] = [];
+  handle.db.close = async () => {
+    throw databaseError;
+  };
+  console.error = (...args: unknown[]) => observed.push(args);
+
+  try {
+    await handle.close();
+    clientSocket(client).destroy();
+    await waitFor(() => observed.length === 1, "the deferred cleanup failure to be observed");
+    expect(observed[0][0]).toBe("database: deferred PGlite cleanup failed");
+    expect(observed[0][1]).toBe(databaseError);
+    expect(handle.close({ force: true })).toBe(handle.close());
+  } finally {
+    console.error = originalConsoleError;
+    handle.db.close = originalDbClose;
+    await originalDbClose();
+  }
+});

--- a/packages/node-sdk/db/test/start-pglite.test.ts
+++ b/packages/node-sdk/db/test/start-pglite.test.ts
@@ -400,6 +400,58 @@ test("an externally stopped listener still permits database cleanup", async () =
   expect(handle.server.listening).toBe(false);
 });
 
+test("forced close awaits a live socket and an externally closing listener", async () => {
+  const handle = await startPglite(0);
+  let acceptedSocket: net.Socket | undefined;
+  handle.server.once("connection", (socket) => {
+    acceptedSocket = socket;
+  });
+  const client = await connect(handle);
+  client.on("error", () => {});
+  if (!acceptedSocket) throw new Error("The gateway did not track the accepted socket.");
+
+  const order: string[] = [];
+  let acceptedSocketClosed = false;
+  let listenerCloseComplete = false;
+  acceptedSocket.once("close", () => {
+    acceptedSocketClosed = true;
+    order.push("socket-close");
+  });
+
+  const originalDbClose = handle.db.close.bind(handle.db);
+  handle.db.close = async () => {
+    order.push("db-close");
+  };
+
+  const externalListenerClose = new Promise<void>((resolve, reject) => {
+    handle.server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      listenerCloseComplete = true;
+      order.push("listener-close");
+      resolve();
+    });
+  });
+
+  try {
+    await handle.close({ force: true });
+    order.push("handle-close-resolved");
+
+    expect(acceptedSocketClosed).toBe(true);
+    expect(listenerCloseComplete).toBe(true);
+    expect(order.indexOf("socket-close")).toBeLessThan(order.indexOf("db-close"));
+    expect(order.indexOf("listener-close")).toBeLessThan(order.indexOf("db-close"));
+    expect(order.at(-1)).toBe("handle-close-resolved");
+  } finally {
+    await externalListenerClose;
+    handle.db.close = originalDbClose;
+    await originalDbClose();
+    clientSocket(client).destroy();
+  }
+});
+
 test("a genuine PostgreSQL query error remains visible", async () => {
   const handle = await startPglite(0);
   const client = await connect(handle);

--- a/packages/node-sdk/node/README.md
+++ b/packages/node-sdk/node/README.md
@@ -64,6 +64,13 @@ instead of jumping to a new tip.
 The subpaths are thin re-exports - semantics are identical to importing
 from the underlying packages.
 
+The re-exported `db/start-pglite` handle uses a bounded, non-destructive
+`close()` by default and an explicit owner-only `close({ force: true })` mode.
+Default close defers PGlite cleanup until the last accepted client socket drains.
+Concurrent calls share the first cleanup promise and the first requested mode
+wins. See the `@effectstream/db` PgLite gateway lifecycle section for the full
+client-ownership, failure, and `0.104.0`→`0.200.1` migration contract.
+
 ## Inside EffectStream
 
 A namespace seam, not a runtime piece. Each subpath simply re-exports

--- a/packages/node-sdk/node/src/single-file.ts
+++ b/packages/node-sdk/node/src/single-file.ts
@@ -218,7 +218,7 @@ export async function runNode<
 
     task = run(function* () {
       yield* ensure(function* () {
-        yield* call(() => ownedDatabase.close());
+        yield* call(() => ownedDatabase.close({ force: true }));
       });
       yield* init();
       yield* withEffectstreamStaticConfig(staticConfig, function* () {
@@ -252,7 +252,7 @@ export async function runNode<
       process.off("SIGINT", signalHandler);
       process.off("SIGTERM", signalHandler);
     }
-    if (!task && database) await database.close();
+    if (!task && database) await database.close({ force: true });
     restoreEnvironment();
   }
 }

--- a/packages/node-sdk/node/test/fixtures/single-file-sigterm.ts
+++ b/packages/node-sdk/node/test/fixtures/single-file-sigterm.ts
@@ -1,0 +1,50 @@
+import pg from "../../../db/node_modules/pg";
+import net from "node:net";
+import {
+  midnightContract,
+  pglite,
+  runNode,
+} from "../../src/single-file.ts";
+
+const originalPoolEnd = pg.Pool.prototype.end;
+const originalServerClose = net.Server.prototype.close;
+pg.Pool.prototype.end = async function () {
+  console.info("SINGLE_FILE_POOL_END");
+  return await originalPoolEnd.call(this);
+};
+net.Server.prototype.close = function (...args: Parameters<net.Server["close"]>) {
+  const address = this.address();
+  if (address && typeof address !== "string") {
+    console.info(`SINGLE_FILE_SERVER_CLOSE:${address.port}`);
+  }
+  return originalServerClose.apply(this, args);
+};
+
+const initialSignalListeners = process.listenerCount("SIGTERM");
+const signalPoll = setInterval(() => {
+  if (process.listenerCount("SIGTERM") > initialSignalListeners) {
+    clearInterval(signalPoll);
+    console.info("SINGLE_FILE_SEND_SIGTERM");
+    process.kill(process.pid, "SIGTERM");
+  }
+}, 10);
+
+await runNode({
+  appName: "single-file-sigterm-fixture",
+  apiPort: 18999,
+  database: pglite({ port: 0 }),
+  sources: {
+    counter: midnightContract({
+      network: "preview",
+      address: "a".repeat(64),
+      startBlockHeight: 0,
+      ledger: { round: "uint128" },
+      indexer: "http://127.0.0.1:18998/graphql",
+    }),
+  },
+  transitions: {
+    counter: () => {},
+  },
+});
+
+console.info("SINGLE_FILE_EXIT_ZERO");

--- a/packages/node-sdk/node/test/single-file-lifecycle.test.ts
+++ b/packages/node-sdk/node/test/single-file-lifecycle.test.ts
@@ -1,0 +1,46 @@
+import { expect, test } from "bun:test";
+import net from "node:net";
+
+async function expectPortClosed(port: number): Promise<void> {
+  await expect(new Promise<void>((resolve, reject) => {
+    const socket = net.connect({ host: "127.0.0.1", port });
+    socket.once("connect", () => {
+      socket.destroy();
+      resolve();
+    });
+    socket.once("error", reject);
+  })).rejects.toMatchObject({ code: "ECONNREFUSED" });
+}
+
+test("single-file SIGTERM drains the runtime pool before explicit forced PGlite close", async () => {
+  const child = Bun.spawn([
+    process.execPath,
+    new URL("./fixtures/single-file-sigterm.ts", import.meta.url).pathname,
+  ], {
+    cwd: new URL("../../../..", import.meta.url).pathname,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+    child.exited,
+  ]);
+  const output = `${stdout}\n${stderr}`;
+
+  expect(exitCode, output).toBe(0);
+  expect(output).toContain("SINGLE_FILE_SEND_SIGTERM");
+  expect(output).toContain("SINGLE_FILE_POOL_END");
+  expect(output).toContain("SINGLE_FILE_EXIT_ZERO");
+
+  const match = output.match(/database: server listening on port (\d+)/);
+  if (!match) throw new Error(`No reported PGlite port in output:\n${output}`);
+  const port = Number(match[1]);
+  const gatewayCloseMarker = `SINGLE_FILE_SERVER_CLOSE:${port}`;
+  expect(output).toContain(gatewayCloseMarker);
+  expect(output.indexOf("SINGLE_FILE_POOL_END")).toBeLessThan(
+    output.indexOf(gatewayCloseMarker),
+  );
+  await expectPortClosed(port);
+}, 30_000);


### PR DESCRIPTION
## Summary

- restore the compatible default `startPglite().close()` behavior without hard-disconnecting consumer-owned PostgreSQL clients
- add explicit `close({ force: true })` teardown for framework-owned clients and use it from the single-file and pgtyped owners
- defer default PGlite cleanup until retained sockets drain, while unrefing the listener and sockets so shutdown remains bounded
- make cleanup idempotent and first-call-wins, preserve listener/startup errors, and aggregate synchronous cleanup failures
- make pgtyped use the returned IPv4 loopback port and clean up its owned clients, pool, subprocess, listener, and database on every exit path
- document the lifecycle contract and add a focused Docker CI gate

## Root cause

The forced socket teardown was introduced in `@effectstream/db@0.104.0` by commit `0f8351e4` in PR #865 and then carried unchanged into `0.104.1` and `0.200.1`. The downstream Ledger-v9 migration jumped from `0.103.1` to `0.200.1`, exposing the older lifecycle change.

The affected no-argument close path tracked every accepted socket and called `socket.destroy()` before closing the listener. A retained `pg.Client` consequently emitted an asynchronous `Connection terminated unexpectedly` error. In Bun multi-file suites that error escaped between files and prevented later tests from registering.

## Behavioral change and migration warning

Consumers that intentionally rely on no-argument `close()` to forcibly disconnect accepted clients must now call:

```ts
await handle.close({ force: true });
```

The default call stops new accepts, unrefs and preserves retained sockets, and settles without waiting for them. PGlite cleanup is deferred until the final retained socket and serialized operation drain. A socket retained forever can therefore defer database cleanup forever.

The first close call selects the mode for all concurrent and subsequent callers; a later call cannot silently escalate a default close to force mode.

## Verification

All integration gates ran in disposable Docker environments:

- focused PGlite lifecycle and multi-file regression: 21 passed, 0 failed, 73 expectations
- impacted upstream suites: 69 passed, 2 environment-gated fixture skips, 0 failed, 172 expectations
- pgtyped lifecycle: 3 passed, 0 failed, 17 expectations
- single-file SIGTERM lifecycle: 1 passed, 0 failed, 7 expectations
- narrow CI assertions: 13 passed, 0 failed, 27 expectations
- changed TypeScript entrypoints: 55 modules built successfully
- downstream workaround-free kernel suite: all 313 tests registered; 311 passed, 2 reconciled missing-generated-asset skips, 0 failed, and 0 asynchronous teardown errors
- independent audit: PASS; the initial force-ordering finding was remediated and re-audited with no remaining findings

## Release note

PGlite gateway teardown no longer force-disconnects consumer-owned clients by default. Forced socket teardown was introduced in 0.104.0 and observed downstream during an upgrade to 0.200.1. `await handle.close()` is compatible again; frameworks that own every client can request deterministic teardown with `await handle.close({ force: true })`.
