### PR TITLE
fix(batcher): key the tracking queue on request_id, not the payload (00017 Q-1)

### DIFF
--- a/packages/batcher/README.md
+++ b/packages/batcher/README.md
@@ -302,6 +302,16 @@ therefore:
   requests, because `target` is part of the key.
 - **Not a secret.** Everything it hashes is public on chain. Statuses are not
   private data; the id is not a capability token.
+- **What the queue is keyed on.** `pending_inputs` has `PRIMARY KEY
+  (request_id, seq)`. The id is what gets indexed, never the content key it
+  hashes — the content key embeds the whole submitted payload, and a btree
+  tuple may not exceed 2704 bytes, so a real Midnight transaction (~3.3 KB,
+  a ~6.7 KB key) could not be indexed at all: acceptance failed with
+  `index row size … exceeds btree version 4 maximum 2704` and the caller got a
+  500 rather than an id. A 64-character hash has no such ceiling. `content_key`
+  is still stored, unindexed, for diagnostics. `seq` orders the queue and lets
+  one id own several rows, which is what a resubmission without a replay key
+  legitimately produces.
 
 ### Polling
 

--- a/packages/batcher/core/database-storage.ts
+++ b/packages/batcher/core/database-storage.ts
@@ -28,14 +28,12 @@ import batcherStorageMigration from "./sql/migrations/00001-batcher-storage.sql"
   type: "text",
 };
 import {
-  backfillPendingRequestId,
   clearPendingInputs,
   countOrphanedStatuses,
   countPendingInputs,
-  deletePendingByContentKeys,
   deletePendingByIdentity,
+  deletePendingByRequestIds,
   deleteReplayKeysByRequestIds,
-  findPendingWithoutRequestId,
   getAllPendingPayloads,
   getPendingForRetry,
   getPendingInputCountAndSize,
@@ -572,6 +570,20 @@ function contentKeyOf(input: DefaultBatcherInput, target: string): string {
 }
 
 /**
+ * Row identity: sha256 of the content key — what `pending_inputs` is keyed on.
+ *
+ * The identity is the SAME identity the content key expressed; only its width
+ * changed. Equal content keys hash equal and different ones do not, so every
+ * operation that used to say "the rows whose content key is this" says "the
+ * rows whose request id is this" and selects the same rows — including the
+ * several rows a duplicate submission legitimately leaves behind. What it no
+ * longer does is compare, or index, several kilobytes of transaction.
+ */
+function requestIdOf(input: DefaultBatcherInput, target: string): string {
+  return requestIdFromKey(contentKeyOf(input, target));
+}
+
+/**
  * The target a row belongs to: its own, or the one the caller routed it to.
  *
  * Throws rather than storing a targetless row — such a row is adopted by
@@ -810,35 +822,23 @@ export class DatabaseStorage<
     return this.driver;
   }
 
-  /** Apply the reviewed immutable schema/function migration as one asset. */
+  /**
+   * Apply the reviewed immutable schema/function migration as one asset.
+   *
+   * There is no request-id backfill step any more, and its absence is the
+   * point. `request_id` is now the queue's PRIMARY KEY, so it is supplied by
+   * both write paths (`insertRow` and `batcher_record_accepted`) and no
+   * statement in this tree can produce a row without one — the column it used
+   * to repair cannot go unfilled. The only rows it could ever have found are
+   * rows written by a deployment that predates the column, and such a
+   * deployment's table would keep its old `(content_key, seq)` primary key
+   * regardless (this migration is `CREATE TABLE IF NOT EXISTS`), so stamping
+   * its rows would not have fixed the size defect anyway. Nothing is deployed
+   * (project 00020, user ruling), so this migration describes a fresh database
+   * and carries no legacy-data machinery.
+   */
   private async migrate(): Promise<void> {
     await this.db.migrate(batcherStorageMigration);
-    await this.backfillRequestIds();
-  }
-
-  /**
-   * Give rows written before the column existed the id they always had.
-   *
-   * Done in TypeScript rather than in SQL on purpose: the hash has exactly one
-   * implementation (`request-id.ts`), and a second one written in Postgres —
-   * even a correct one — is a second thing to keep correct. Bounded by the
-   * pending queue, which is small by construction.
-   */
-  private async backfillRequestIds(): Promise<void> {
-    const stale = await findPendingWithoutRequestId.run(undefined, this.db);
-    if (stale.length === 0) return;
-    await this.db.transaction(async (tx) => {
-      for (const row of stale) {
-        await backfillPendingRequestId.run({
-          request_id: requestIdFromKey(row.content_key),
-          content_key: row.content_key,
-          seq: row.seq,
-        }, tx);
-      }
-    });
-    console.log(
-      `[Storage] Stamped ${stale.length} queue row(s) with their request id.`,
-    );
   }
 
   /**
@@ -1033,13 +1033,17 @@ export class DatabaseStorage<
   ): Promise<void> {
     if (processedInputs.length === 0) return;
     try {
-      const keys = [
-        ...new Set(processedInputs.map((input) => contentKeyOf(input, target))),
+      // Hashed, not compared: the row is FOUND by its request id, which is what
+      // the table is keyed on. The de-duplicated set is the same set either way
+      // — equal content keys hash equal — so "remove every row matching these
+      // inputs" still removes every duplicate row, as it always has.
+      const requestIds = [
+        ...new Set(processedInputs.map((input) => requestIdOf(input, target))),
       ];
       const { removed, total } = await this.db.transaction(async (tx) => {
         const [{ count }] = await countPendingInputs.run(undefined, tx);
-        const deleted = await deletePendingByContentKeys.run({
-          content_keys: keys,
+        const deleted = await deletePendingByRequestIds.run({
+          request_ids: requestIds,
         }, tx);
         return { removed: deleted.length, total: Number(count) };
       });
@@ -1083,12 +1087,14 @@ export class DatabaseStorage<
   ): Promise<T[]> {
     if (inputs.length === 0) return [];
     try {
-      const keys = [
-        ...new Set(inputs.map((input) => contentKeyOf(input, target))),
+      const requestIds = [
+        ...new Set(inputs.map((input) => requestIdOf(input, target))),
       ];
       const dropped: T[] = [];
       await this.db.transaction(async (tx) => {
-        const rows = await getPendingForRetry.run({ content_keys: keys }, tx);
+        const rows = await getPendingForRetry.run({
+          request_ids: requestIds,
+        }, tx);
 
         for (const row of rows) {
           // The charge is against the STORED count, not whatever the caller's
@@ -1097,14 +1103,18 @@ export class DatabaseStorage<
           if (newRetryCount >= maxRetries) {
             const parsed = JSON.parse(row.payload) as DefaultBatcherInput;
             // Always-visible: deleting a user's input must never be silent.
+            // Identified by request id rather than by a slice of the payload:
+            // it is the id the caller was handed and the one every other log
+            // line, `/input-status` answer and status row already uses, so an
+            // operator can join them. The truncated content key it replaces
+            // could not be joined to anything.
             console.warn(
               `[Storage] DROPPING input after ${newRetryCount} failed retries ` +
-                `(address=${parsed.address}, target=${target}): ${
-                  row.content_key.substring(0, 100)
-                }...`,
+                `(address=${parsed.address}, target=${target}, ` +
+                `request=${row.request_id.substring(0, 12)}…).`,
             );
             await deletePendingByIdentity.run({
-              content_key: row.content_key,
+              request_id: row.request_id,
               seq: row.seq,
             }, tx);
             // Reported, not just logged: the caller waiting on this input can
@@ -1120,7 +1130,7 @@ export class DatabaseStorage<
           await updatePendingRetry.run({
             retry_count: newRetryCount,
             payload,
-            content_key: row.content_key,
+            request_id: row.request_id,
             seq: row.seq,
           }, tx);
         }

--- a/packages/batcher/core/sql/migrations/00001-batcher-storage.sql
+++ b/packages/batcher/core/sql/migrations/00001-batcher-storage.sql
@@ -1,6 +1,34 @@
+-- The queue is keyed on the request id, NEVER on the content key.
+--
+-- `request_id` is sha256(content_key) — 64 hex characters whatever the payload
+-- weighs. `content_key` is the payload itself: `addressType|target|address|
+-- timestamp|signature|input`, where `input` is the entire submitted
+-- transaction. Indexing that column is not a size risk, it is a size CEILING:
+-- a btree tuple may not exceed 2704 bytes (one third of an 8 KB page), and a
+-- minimal real Midnight contract call is ~3.3 KB, so its content key is ~6.7 KB.
+-- With `PRIMARY KEY (content_key, seq)` — which is what this table used to
+-- declare — every such submission failed the index write with
+-- `index row size 6880 exceeds btree version 4 maximum 2704`, rolled the
+-- acceptance transaction back, and returned a 500 to the caller instead of the
+-- request id that request tracking exists to hand out. Measured on BOTH rungs:
+-- the ceiling is PostgreSQL's and PgLite is PostgreSQL, so the embedded engine
+-- fails at the identical byte count.
+--
+-- Hashing changes nothing about what a row IS. Same uniqueness class (equal
+-- content keys hash equal, different ones do not), same duplicate grouping
+-- under `seq`, same remove-all-matching and retry-charging behaviour — the
+-- callers all hold the content key already and hash it with the one
+-- implementation in `core/request-id.ts`.
+--
+-- `seq` stays. Inputs without a replay key are allowed to queue twice, so two
+-- rows may legally share a request id, and the queue is read in insertion
+-- order.
+--
+-- `content_key` stays as an UNINDEXED column: it is diagnostic, and it is what
+-- a legacy `pending-inputs.jsonl` import writes alongside the id it derives.
 CREATE TABLE IF NOT EXISTS pending_inputs (
   content_key  text      NOT NULL,
-  request_id   text      NOT NULL DEFAULT '',
+  request_id   text      NOT NULL,
   seq          bigserial NOT NULL,
   row_target   text      NOT NULL,
   address      text      NOT NULL,
@@ -11,17 +39,11 @@ CREATE TABLE IF NOT EXISTS pending_inputs (
   retry_count  integer   NOT NULL DEFAULT 0,
   payload      text      NOT NULL,
   created_at   timestamptz NOT NULL DEFAULT now(),
-  PRIMARY KEY (content_key, seq)
+  PRIMARY KEY (request_id, seq)
 );
 
 CREATE INDEX IF NOT EXISTS pending_inputs_target_seq_idx
   ON pending_inputs (row_target, seq);
-
-ALTER TABLE pending_inputs
-  ADD COLUMN IF NOT EXISTS request_id text NOT NULL DEFAULT '';
-
-CREATE INDEX IF NOT EXISTS pending_inputs_request_idx
-  ON pending_inputs (request_id);
 
 CREATE TABLE IF NOT EXISTS request_status (
   request_id       text PRIMARY KEY,

--- a/packages/batcher/core/sql/queries/database-storage.queries.ts
+++ b/packages/batcher/core/sql/queries/database-storage.queries.ts
@@ -5,64 +5,6 @@ export type Json = null | boolean | number | string | Json[] | { [key: string]: 
 
 export type NumberOrString = number | string;
 
-/** 'FindPendingWithoutRequestId' parameters type */
-export type IFindPendingWithoutRequestIdParams = void;
-
-/** 'FindPendingWithoutRequestId' return type */
-export interface IFindPendingWithoutRequestIdResult {
-  content_key: string;
-  seq: string;
-}
-
-/** 'FindPendingWithoutRequestId' query type */
-export interface IFindPendingWithoutRequestIdQuery {
-  params: IFindPendingWithoutRequestIdParams;
-  result: IFindPendingWithoutRequestIdResult;
-}
-
-const findPendingWithoutRequestIdIR: any = {"usedParamSet":{},"params":[],"statement":"SELECT content_key, seq\nFROM pending_inputs\nWHERE request_id = ''"};
-
-/**
- * Query generated from SQL:
- * ```
- * SELECT content_key, seq
- * FROM pending_inputs
- * WHERE request_id = ''
- * ```
- */
-export const findPendingWithoutRequestId = new PreparedQuery<IFindPendingWithoutRequestIdParams,IFindPendingWithoutRequestIdResult>(findPendingWithoutRequestIdIR);
-
-
-/** 'BackfillPendingRequestId' parameters type */
-export interface IBackfillPendingRequestIdParams {
-  content_key: string;
-  request_id: string;
-  seq: NumberOrString;
-}
-
-/** 'BackfillPendingRequestId' return type */
-export type IBackfillPendingRequestIdResult = void;
-
-/** 'BackfillPendingRequestId' query type */
-export interface IBackfillPendingRequestIdQuery {
-  params: IBackfillPendingRequestIdParams;
-  result: IBackfillPendingRequestIdResult;
-}
-
-const backfillPendingRequestIdIR: any = {"usedParamSet":{"request_id":true,"content_key":true,"seq":true},"params":[{"name":"request_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":39,"b":50}]},{"name":"content_key","required":true,"transform":{"type":"scalar"},"locs":[{"a":72,"b":84}]},{"name":"seq","required":true,"transform":{"type":"scalar"},"locs":[{"a":98,"b":102}]}],"statement":"UPDATE pending_inputs\nSET request_id = :request_id!\nWHERE content_key = :content_key!\n  AND seq = :seq!"};
-
-/**
- * Query generated from SQL:
- * ```
- * UPDATE pending_inputs
- * SET request_id = :request_id!
- * WHERE content_key = :content_key!
- *   AND seq = :seq!
- * ```
- */
-export const backfillPendingRequestId = new PreparedQuery<IBackfillPendingRequestIdParams,IBackfillPendingRequestIdResult>(backfillPendingRequestIdIR);
-
-
 /** 'CountPendingInputs' parameters type */
 export type ICountPendingInputsParams = void;
 
@@ -262,33 +204,33 @@ const getPendingPayloadsByTargetIR: any = {"usedParamSet":{"default_target":true
 export const getPendingPayloadsByTarget = new PreparedQuery<IGetPendingPayloadsByTargetParams,IGetPendingPayloadsByTargetResult>(getPendingPayloadsByTargetIR);
 
 
-/** 'DeletePendingByContentKeys' parameters type */
-export interface IDeletePendingByContentKeysParams {
-  content_keys: readonly (string)[];
+/** 'DeletePendingByRequestIds' parameters type */
+export interface IDeletePendingByRequestIdsParams {
+  request_ids: readonly (string)[];
 }
 
-/** 'DeletePendingByContentKeys' return type */
-export interface IDeletePendingByContentKeysResult {
+/** 'DeletePendingByRequestIds' return type */
+export interface IDeletePendingByRequestIdsResult {
   one: number | null;
 }
 
-/** 'DeletePendingByContentKeys' query type */
-export interface IDeletePendingByContentKeysQuery {
-  params: IDeletePendingByContentKeysParams;
-  result: IDeletePendingByContentKeysResult;
+/** 'DeletePendingByRequestIds' query type */
+export interface IDeletePendingByRequestIdsQuery {
+  params: IDeletePendingByRequestIdsParams;
+  result: IDeletePendingByRequestIdsResult;
 }
 
-const deletePendingByContentKeysIR: any = {"usedParamSet":{"content_keys":true},"params":[{"name":"content_keys","required":true,"transform":{"type":"array_spread"},"locs":[{"a":48,"b":61}]}],"statement":"DELETE FROM pending_inputs\nWHERE content_key IN :content_keys!\nRETURNING 1::int AS one"};
+const deletePendingByRequestIdsIR: any = {"usedParamSet":{"request_ids":true},"params":[{"name":"request_ids","required":true,"transform":{"type":"array_spread"},"locs":[{"a":47,"b":59}]}],"statement":"DELETE FROM pending_inputs\nWHERE request_id IN :request_ids!\nRETURNING 1::int AS one"};
 
 /**
  * Query generated from SQL:
  * ```
  * DELETE FROM pending_inputs
- * WHERE content_key IN :content_keys!
+ * WHERE request_id IN :request_ids!
  * RETURNING 1::int AS one
  * ```
  */
-export const deletePendingByContentKeys = new PreparedQuery<IDeletePendingByContentKeysParams,IDeletePendingByContentKeysResult>(deletePendingByContentKeysIR);
+export const deletePendingByRequestIds = new PreparedQuery<IDeletePendingByRequestIdsParams,IDeletePendingByRequestIdsResult>(deletePendingByRequestIdsIR);
 
 
 /** 'GetPendingInputCountAndSize' parameters type */
@@ -321,13 +263,13 @@ export const getPendingInputCountAndSize = new PreparedQuery<IGetPendingInputCou
 
 /** 'GetPendingForRetry' parameters type */
 export interface IGetPendingForRetryParams {
-  content_keys: readonly (string)[];
+  request_ids: readonly (string)[];
 }
 
 /** 'GetPendingForRetry' return type */
 export interface IGetPendingForRetryResult {
-  content_key: string;
   payload: string;
+  request_id: string;
   retry_count: number;
   seq: string;
 }
@@ -338,14 +280,14 @@ export interface IGetPendingForRetryQuery {
   result: IGetPendingForRetryResult;
 }
 
-const getPendingForRetryIR: any = {"usedParamSet":{"content_keys":true},"params":[{"name":"content_keys","required":true,"transform":{"type":"array_spread"},"locs":[{"a":87,"b":100}]}],"statement":"SELECT content_key, seq, retry_count, payload\nFROM pending_inputs\nWHERE content_key IN :content_keys!\nORDER BY seq\nFOR UPDATE"};
+const getPendingForRetryIR: any = {"usedParamSet":{"request_ids":true},"params":[{"name":"request_ids","required":true,"transform":{"type":"array_spread"},"locs":[{"a":85,"b":97}]}],"statement":"SELECT request_id, seq, retry_count, payload\nFROM pending_inputs\nWHERE request_id IN :request_ids!\nORDER BY seq\nFOR UPDATE"};
 
 /**
  * Query generated from SQL:
  * ```
- * SELECT content_key, seq, retry_count, payload
+ * SELECT request_id, seq, retry_count, payload
  * FROM pending_inputs
- * WHERE content_key IN :content_keys!
+ * WHERE request_id IN :request_ids!
  * ORDER BY seq
  * FOR UPDATE
  * ```
@@ -355,7 +297,7 @@ export const getPendingForRetry = new PreparedQuery<IGetPendingForRetryParams,IG
 
 /** 'DeletePendingByIdentity' parameters type */
 export interface IDeletePendingByIdentityParams {
-  content_key: string;
+  request_id: string;
   seq: NumberOrString;
 }
 
@@ -368,13 +310,13 @@ export interface IDeletePendingByIdentityQuery {
   result: IDeletePendingByIdentityResult;
 }
 
-const deletePendingByIdentityIR: any = {"usedParamSet":{"content_key":true,"seq":true},"params":[{"name":"content_key","required":true,"transform":{"type":"scalar"},"locs":[{"a":47,"b":59}]},{"name":"seq","required":true,"transform":{"type":"scalar"},"locs":[{"a":73,"b":77}]}],"statement":"DELETE FROM pending_inputs\nWHERE content_key = :content_key!\n  AND seq = :seq!"};
+const deletePendingByIdentityIR: any = {"usedParamSet":{"request_id":true,"seq":true},"params":[{"name":"request_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":46,"b":57}]},{"name":"seq","required":true,"transform":{"type":"scalar"},"locs":[{"a":71,"b":75}]}],"statement":"DELETE FROM pending_inputs\nWHERE request_id = :request_id!\n  AND seq = :seq!"};
 
 /**
  * Query generated from SQL:
  * ```
  * DELETE FROM pending_inputs
- * WHERE content_key = :content_key!
+ * WHERE request_id = :request_id!
  *   AND seq = :seq!
  * ```
  */
@@ -383,8 +325,8 @@ export const deletePendingByIdentity = new PreparedQuery<IDeletePendingByIdentit
 
 /** 'UpdatePendingRetry' parameters type */
 export interface IUpdatePendingRetryParams {
-  content_key: string;
   payload: string;
+  request_id: string;
   retry_count: number;
   seq: NumberOrString;
 }
@@ -398,7 +340,7 @@ export interface IUpdatePendingRetryQuery {
   result: IUpdatePendingRetryResult;
 }
 
-const updatePendingRetryIR: any = {"usedParamSet":{"retry_count":true,"payload":true,"content_key":true,"seq":true},"params":[{"name":"retry_count","required":true,"transform":{"type":"scalar"},"locs":[{"a":40,"b":52}]},{"name":"payload","required":true,"transform":{"type":"scalar"},"locs":[{"a":69,"b":77}]},{"name":"content_key","required":true,"transform":{"type":"scalar"},"locs":[{"a":99,"b":111}]},{"name":"seq","required":true,"transform":{"type":"scalar"},"locs":[{"a":125,"b":129}]}],"statement":"UPDATE pending_inputs\nSET retry_count = :retry_count!,\n    payload = :payload!\nWHERE content_key = :content_key!\n  AND seq = :seq!"};
+const updatePendingRetryIR: any = {"usedParamSet":{"retry_count":true,"payload":true,"request_id":true,"seq":true},"params":[{"name":"retry_count","required":true,"transform":{"type":"scalar"},"locs":[{"a":40,"b":52}]},{"name":"payload","required":true,"transform":{"type":"scalar"},"locs":[{"a":69,"b":77}]},{"name":"request_id","required":true,"transform":{"type":"scalar"},"locs":[{"a":98,"b":109}]},{"name":"seq","required":true,"transform":{"type":"scalar"},"locs":[{"a":123,"b":127}]}],"statement":"UPDATE pending_inputs\nSET retry_count = :retry_count!,\n    payload = :payload!\nWHERE request_id = :request_id!\n  AND seq = :seq!"};
 
 /**
  * Query generated from SQL:
@@ -406,7 +348,7 @@ const updatePendingRetryIR: any = {"usedParamSet":{"retry_count":true,"payload":
  * UPDATE pending_inputs
  * SET retry_count = :retry_count!,
  *     payload = :payload!
- * WHERE content_key = :content_key!
+ * WHERE request_id = :request_id!
  *   AND seq = :seq!
  * ```
  */

--- a/packages/batcher/core/sql/queries/database-storage.sql
+++ b/packages/batcher/core/sql/queries/database-storage.sql
@@ -1,14 +1,3 @@
-/* @name findPendingWithoutRequestId */
-SELECT content_key, seq
-FROM pending_inputs
-WHERE request_id = '';
-
-/* @name backfillPendingRequestId */
-UPDATE pending_inputs
-SET request_id = :request_id!
-WHERE content_key = :content_key!
-  AND seq = :seq!;
-
 /* @name countPendingInputs */
 SELECT count(*)::int AS count
 FROM pending_inputs;
@@ -65,11 +54,11 @@ WHERE (
 ORDER BY seq;
 
 /*
- @name deletePendingByContentKeys
- @param content_keys -> (...)
+ @name deletePendingByRequestIds
+ @param request_ids -> (...)
 */
 DELETE FROM pending_inputs
-WHERE content_key IN :content_keys!
+WHERE request_id IN :request_ids!
 RETURNING 1::int AS one;
 
 /* @name getPendingInputCountAndSize */
@@ -79,24 +68,24 @@ FROM pending_inputs;
 
 /*
  @name getPendingForRetry
- @param content_keys -> (...)
+ @param request_ids -> (...)
 */
-SELECT content_key, seq, retry_count, payload
+SELECT request_id, seq, retry_count, payload
 FROM pending_inputs
-WHERE content_key IN :content_keys!
+WHERE request_id IN :request_ids!
 ORDER BY seq
 FOR UPDATE;
 
 /* @name deletePendingByIdentity */
 DELETE FROM pending_inputs
-WHERE content_key = :content_key!
+WHERE request_id = :request_id!
   AND seq = :seq!;
 
 /* @name updatePendingRetry */
 UPDATE pending_inputs
 SET retry_count = :retry_count!,
     payload = :payload!
-WHERE content_key = :content_key!
+WHERE request_id = :request_id!
   AND seq = :seq!;
 
 /* @name clearPendingInputs */

--- a/packages/batcher/test/large-payload-storage.test.ts
+++ b/packages/batcher/test/large-payload-storage.test.ts
@@ -1,0 +1,283 @@
+// Payload size is not a storage-failure class (project 00020, spec FR-4).
+//
+// The defect this suite exists for: `pending_inputs` used to be keyed on
+// `content_key`, and `content_key` embeds the ENTIRE submitted payload
+// (`addressType|target|address|timestamp|signature|input`). PostgreSQL's btree
+// tuple ceiling is 2704 bytes — one third of an 8 KB page — so any input whose
+// content key crossed it could not be indexed at all. The insert failed, the
+// acceptance transaction rolled back, and the caller got a 500 instead of the
+// `requestId` the whole tracking feature exists to hand out.
+//
+// That is not a corner case for this batcher: 00017's deep suite measured a
+// MINIMAL real Midnight contract call at 3307 bytes, which yields a ~6.7 KB
+// content key. Every real transaction the flagship adapter submits was over the
+// line, on both the embedded and the connected rung — the limit is
+// PostgreSQL's and the DDL is shared, so PgLite fails identically.
+//
+// The fix re-keys the table on `request_id` (sha256 of the content key), which
+// is 64 hex characters no matter how large the payload is. These tests
+// therefore assert the WHOLE path at chain-sized payloads, not just the insert:
+// accept, poll, list in order, retry-charge, and remove. Every one of them used
+// to reach `pending_inputs` through the oversized key.
+//
+// Runs against the embedded engine, and against a real Postgres when one is
+// pointed at it (`BATCHER_TEST_POSTGRES_URL`) — same statements, same ceiling,
+// so both are held to the same result rather than one being taken on trust.
+
+import { describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { DatabaseStorage } from "../core/database-storage.ts";
+import { buildRequestKey, computeRequestId } from "../core/request-id.ts";
+import type { DefaultBatcherInput } from "../core/types.ts";
+
+const POSTGRES_URL = process.env.BATCHER_TEST_POSTGRES_URL;
+
+/** PostgreSQL's btree tuple ceiling: one third of an 8 KB page. */
+const BTREE_MAX_BYTES = 2704;
+
+interface Backend {
+  readonly name: string;
+  make(dataDirectory: string): DatabaseStorage;
+  reset?(storage: DatabaseStorage): Promise<void>;
+}
+
+async function rawExec(storage: DatabaseStorage, sql: string): Promise<void> {
+  const db = (storage as unknown as {
+    db: { query(sql: string, params?: unknown[]): Promise<unknown> };
+  }).db;
+  await db.query(sql, []);
+}
+
+const BACKENDS: Backend[] = [
+  {
+    name: "DatabaseStorage",
+    make: (dir) => new DatabaseStorage({ dataDirectory: dir }),
+  },
+];
+
+if (POSTGRES_URL) {
+  BACKENDS.push({
+    name: "DatabaseStorage(postgres)",
+    make: (dir) =>
+      new DatabaseStorage({ dataDirectory: dir, connectionString: POSTGRES_URL }),
+    reset: (storage) =>
+      rawExec(
+        storage,
+        "TRUNCATE pending_inputs, request_status, replay_keys RESTART IDENTITY",
+      ),
+  });
+}
+
+/**
+ * Deterministic HIGH-ENTROPY hex, `bytes` bytes' worth (2 chars each).
+ *
+ * Entropy is load-bearing, not decoration. A btree index tuple is PGLZ
+ * -compressed before the size check, so a fixture built from `"ab".repeat(n)`
+ * shrinks to nothing and the oversized key sails straight in — measured: the
+ * first version of this suite passed 7/7 against the OLD schema for exactly
+ * that reason. A serialized Midnight transaction is ciphertext and proofs; it
+ * does not compress, which is why the real thing overflowed and a repetitive
+ * stand-in does not. A sha256 chain reproduces that property and stays
+ * byte-identical between runs, engines and machines, so the request id it
+ * hashes to is stable.
+ */
+function entropyHex(bytes: number, seed: string): string {
+  let out = "";
+  let block = createHash("sha256").update(seed, "utf8").digest();
+  while (out.length < bytes * 2) {
+    out += block.toString("hex");
+    block = createHash("sha256").update(block).digest();
+  }
+  return out.slice(0, bytes * 2);
+}
+
+/**
+ * A submission shaped like the ones that broke: a serialized Midnight
+ * transaction carried as hex inside a small JSON envelope.
+ *
+ * `txBytes` is the size of the transaction itself; the hex doubles it and the
+ * envelope plus the five other content-key fields add a little more.
+ */
+const chainSizedInput = (
+  txBytes: number,
+  overrides: Partial<DefaultBatcherInput> = {},
+): DefaultBatcherInput => ({
+  addressType: 5,
+  address: "mn_shield-addr_test1abcdefghijklmnopqrstuvwxyz0123456789",
+  input: JSON.stringify({
+    tx: entropyHex(txBytes, `tx-${txBytes}`),
+    txStage: "balanced",
+  }),
+  timestamp: "1754350000000",
+  signature: "0x" + entropyHex(64, `sig-${txBytes}`),
+  target: "product-a",
+  ...overrides,
+});
+
+async function withStorage(
+  backend: Backend,
+  fn: (storage: DatabaseStorage) => Promise<void>,
+): Promise<void> {
+  const dir = mkdtempSync(path.join(tmpdir(), "batcher-large-payload-"));
+  const storage = backend.make(dir);
+  try {
+    await storage.init("product-a");
+    await backend.reset?.(storage);
+    await fn(storage);
+  } finally {
+    await storage.close().catch(() => {});
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+describe("content key size is not an identity", () => {
+  test("the fixture really is over the btree ceiling", () => {
+    // Guards the guard: a fixture that quietly shrank would turn this whole
+    // suite green without proving anything.
+    const key = buildRequestKey(chainSizedInput(3307), "product-a");
+    expect(Buffer.byteLength(key, "utf8")).toBeGreaterThan(BTREE_MAX_BYTES);
+    // The request id is fixed width no matter how big the key is.
+    expect(computeRequestId(chainSizedInput(3307), "product-a")).toHaveLength(64);
+  });
+});
+
+for (const backend of BACKENDS) {
+  describe(`${backend.name}: chain-sized payloads`, () => {
+    test("accepts and tracks a real-sized Midnight transaction end to end", async () => {
+      await withStorage(backend, async (storage) => {
+        // 3307 bytes is 00017's measured MINIMUM real contract call.
+        const input = chainSizedInput(3307);
+        const requestId = computeRequestId(input, "product-a");
+
+        const outcome = await storage.recordAccepted(
+          requestId,
+          input,
+          "product-a",
+        );
+        expect(outcome.requestId).toBe(requestId);
+        expect(outcome.created).toBe(true);
+        expect(outcome.record.state).toBe("queued");
+
+        // Pollable: the promise a 200 makes.
+        const status = await storage.getStatus(requestId);
+        expect(status?.requestId).toBe(requestId);
+        expect(status?.state).toBe("queued");
+
+        // Queued: the batch will actually pick it up, byte-for-byte.
+        const queued = await storage.getAllInputs();
+        expect(queued).toHaveLength(1);
+        expect(queued[0]!.input).toBe(input.input);
+
+        // Removable at the new key: `removeProcessedInputs` takes the caller's
+        // input, not a row id, so this is the path that used to compare the
+        // whole payload.
+        await storage.removeProcessedInputs([input], "product-a");
+        expect(await storage.getAllInputs()).toHaveLength(0);
+      });
+    });
+
+    test("accepts a content key well past 8 KB (FR-4)", async () => {
+      await withStorage(backend, async (storage) => {
+        const input = chainSizedInput(6000);
+        const key = buildRequestKey(input, "product-a");
+        expect(Buffer.byteLength(key, "utf8")).toBeGreaterThan(8 * 1024);
+
+        const requestId = computeRequestId(input, "product-a");
+        const outcome = await storage.recordAccepted(
+          requestId,
+          input,
+          "product-a",
+        );
+        expect(outcome.created).toBe(true);
+        expect((await storage.getAllInputs())[0]!.input).toBe(input.input);
+      });
+    });
+
+    test("untracked addInput takes an oversized payload too", async () => {
+      await withStorage(backend, async (storage) => {
+        // The queue-only write path has no status record behind it and reaches
+        // `pending_inputs` on its own; it overflowed the old key just as hard.
+        await storage.addInput(chainSizedInput(4000));
+        const { count, size } = await storage.getInputCountAndSize();
+        expect(count).toBe(1);
+        expect(size).toBeGreaterThan(8 * 1024);
+      });
+    });
+
+    test("duplicate oversized rows stay two rows, one identity, and are removed together", async () => {
+      await withStorage(backend, async (storage) => {
+        // No replay key: `FileStorage` has always taken the second row, and the
+        // re-key must not turn "two rows sharing an identity" into a primary
+        // key collision.
+        const input = chainSizedInput(3307);
+        const requestId = computeRequestId(input, "product-a");
+
+        const first = await storage.recordAccepted(requestId, input, "product-a");
+        const second = await storage.recordAccepted(requestId, input, "product-a");
+        expect(first.created).toBe(true);
+        expect(second.created).toBe(false);
+        expect(second.requestId).toBe(requestId);
+        expect(await storage.getAllInputs()).toHaveLength(2);
+
+        await storage.removeProcessedInputs([input], "product-a");
+        expect(await storage.getAllInputs()).toHaveLength(0);
+      });
+    });
+
+    test("insertion order survives at chain size", async () => {
+      await withStorage(backend, async (storage) => {
+        // `seq` is what orders the queue; re-keying the table must not reorder
+        // it. Distinct payloads, so distinct request ids.
+        const inputs = [3307, 3400, 3500].map((size) =>
+          chainSizedInput(size, { timestamp: `17543500000${size}` })
+        );
+        for (const input of inputs) {
+          await storage.recordAccepted(
+            computeRequestId(input, "product-a"),
+            input,
+            "product-a",
+          );
+        }
+        const queued = await storage.getAllInputs();
+        expect(queued.map((row) => row.input)).toEqual(
+          inputs.map((row) => row.input),
+        );
+        expect(
+          (await storage.getInputsByTarget("product-a", "product-a"))
+            .map((row) => row.input),
+        ).toEqual(inputs.map((row) => row.input));
+      });
+    });
+
+    test("retry charging and dropping reach an oversized row", async () => {
+      await withStorage(backend, async (storage) => {
+        const input = chainSizedInput(3307);
+        await storage.recordAccepted(
+          computeRequestId(input, "product-a"),
+          input,
+          "product-a",
+        );
+
+        // Charged, not dropped: the stored count goes 0 → 1 under a limit of 2.
+        expect(await storage.incrementRetryCount([input], "product-a", 2))
+          .toHaveLength(0);
+        expect(await storage.getAllInputs()).toHaveLength(1);
+
+        // Charged again, now at the limit: dropped and REPORTED, so the caller
+        // waiting on it can be told.
+        const dropped = await storage.incrementRetryCount(
+          [input],
+          "product-a",
+          2,
+        );
+        expect(dropped).toHaveLength(1);
+        expect(dropped[0]!.input).toBe(input.input);
+        expect(await storage.getAllInputs()).toHaveLength(0);
+      });
+    });
+  });
+}


### PR DESCRIPTION
## The defect

Project [00017's deep suite](https://github.com/effectstream/effectstream/pull/856) measured (its **Q-1**) that request tracking **500s on every real Midnight transaction**. `packages/batcher/core/sql/migrations/00001-batcher-storage.sql:14` declared

```sql
PRIMARY KEY (content_key, seq)
```

and `content_key` is the FULL content key — `addressType|target|address|timestamp|signature|input`, where `input` is the entire submitted payload. A btree tuple may not exceed **2704 bytes** (one third of an 8 KB page). 00017 measured a *minimal* real contract call at **3307 bytes**, which yields a ~6.7 KB key, so acceptance failed with

```
Failed to record accepted request: error: index row size 6880 exceeds
btree version 4 maximum 2704 for index "pending_inputs_pkey"
```

the transaction rolled back, and the caller got a 500 instead of the `requestId` the whole tracking feature exists to hand out. **Not PgLite-specific**: the ceiling is PostgreSQL's and the DDL is shared, so the connected `BATCHER_DB_SCHEMA` rung failed identically — reproduced here at the *identical byte count* on PgLite and on PostgreSQL 16.14. `FileStorage` was unaffected, which is why nothing before 00017 surfaced it.

00011's own plan (task 1.2) had specified "PK = content-key **hash** + a monotonic seq". The implementation deviated to the raw key. **This PR delivers what the plan said.**

## The fix

`PRIMARY KEY (request_id, seq)`. `request_id` is `sha256(content_key)` — the existing `computeRequestId`, the id that is already computed, already stored, already the public identity, and 64 characters no matter how large the payload is.

**Identity is unchanged by construction.** Equal content keys hash equal and different ones do not, so the uniqueness class, the duplicate grouping under `seq`, remove-all-matching and retry-charging select exactly the rows they selected before. `seq` stays — an input without a replay key may legally queue twice, and the queue is read in insertion order. `content_key` stays as an UNINDEXED column for diagnostics and the legacy-JSONL import.

Every operational statement moved with the key: `deletePendingByContentKeys` → `deletePendingByRequestIds`, and `getPendingForRetry` / `deletePendingByIdentity` / `updatePendingRetry` now key on the id — turning two former full-payload comparisons into exact primary-key lookups. Call sites hash through the single implementation in `core/request-id.ts` (new one-line `requestIdOf` helper), so no second serialization exists. pgtyped bindings regenerated with the committed config: **21 queries**, exit 0.

### ⚠️ The migration carries no backfill, and describes a FRESH database

Per the approving decision ("this is all new, so nothing to backfill"), the migration has no legacy-data machinery. Removed with it: the `request_id` compatibility `ALTER`, its `DEFAULT ''`, the now-redundant `pending_inputs_request_idx` (the primary key's own unique index leads with `request_id`), and the boot-time stamping step plus its two queries.

This is deliberate rather than merely convenient: this migration is `CREATE TABLE IF NOT EXISTS`, so **a table that already existed would keep its old `(content_key, seq)` primary key** — stamping its rows would not have fixed the size defect anyway. An existing deployment would need the table dropped. Nothing is deployed. *(Observed live during acceptance: 00017's leftover PgLite directory, created under the old schema, survived the new migration with the old primary key intact — exactly this behaviour.)*

There is no migration-immutability guard to amend: the only static guard shipped with #878 (`test/database-storage-sql-source.test.ts`) reads `core/database-storage.ts` and never hashes or mentions the migration asset, so the file was edited in place rather than stacked with a pointless `00002`.

Minor visible change: the DROPPING warning now identifies the input by `request=<id>…` instead of the first 100 bytes of its payload — the id the caller was handed, and the one `/input-status` and the status rows already use.

## Evidence

**Red first.** `packages/batcher/test/large-payload-storage.test.ts` drives chain-sized payloads through accept, poll, ordered listing, duplicate rows, retry-charge/drop and removal.

| | PgLite only | + PostgreSQL 16.14 (Docker, port 19064) |
|---|---|---|
| old schema | **1 pass / 6 fail** | **1 pass / 12 fail** — every failure the verbatim `index row size 6880 exceeds btree version 4 maximum 2704` |
| new schema | — | **13 pass / 0 fail**, 52 assertions, exit 0 |

The fixture is deliberately **high-entropy**: btree index tuples are PGLZ-compressed before the size check, so a `"ab".repeat(n)` payload passes on the *broken* schema (measured — the first draft of this suite did exactly that). A serialized Midnight transaction is ciphertext and proof material and does not compress.

**No regressions.** Base `6df033d7` was re-measured in the same session by stashing the change:

| run | base `6df033d7` | this branch |
|---|---|---|
| `bun test packages/batcher` (no database) | 602 pass / 9 skip / **0 fail** | 609 pass / 9 skip / **0 fail** |
| same, with `BATCHER_TEST_POSTGRES_URL` | 663 pass / **0 fail** | 676 pass / **0 fail** |
| `bun test packages/effectstream-sdk/utils` | 18 / 0 | 18 / 0 |

The deltas (+7, +13) are exactly this PR's new cases. The pre-existing-failure set is EMPTY on both sides. Typecheck (house command) exits 1 with exactly the two documented pre-existing errors — `core/batcher.ts(2072,15) TS2339 Property 'reason' does not exist on type 'Event'` and the `.sql` asset import `TS2307`, the latter re-verified byte-identical at base. `bun.lock` diff is empty.

**Semantics re-proven at the new key.** Targeted rerun across both backends of dedup-gate, replay-key, database-storage-crash, accept-atomicity-crash, restart-reconciliation, storage-contract, request-status, request-id and processor-real-storage: **180 pass / 0 fail / 876 assertions** — the replay-key claim gate and its eight-way one-owner race, staggered `SIGKILL` during acceptance and during confirmation/removal, restart reconciliation and the shared storage contract.

## Acceptance against 00017's M13/M14 — the blocker is gone, two other defects are now visible

00017's M13 and M14 were run **from that clone with zero edits to it**, against this branch's batcher (mounted read-only over the clone's `packages/batcher/core` by a compose overlay kept outside it; the clone was left byte-identical, `TESTING-RESULTS.md` restored to the same sha256).

Both stop reporting `observed`. **The Q-1 blocker is fixed**: M13 gets `ids=4/4 preRestart200=4 postureHeld=true zero404s=true counterDelta=4` — four real contract calls accepted, tracked, surviving a `docker compose restart`, and landing on chain. M14 gets `first=200 sameId=true pollable=200` — the byte-identical resubmission is recognised as the same request.

Neither reaches `pass`, and neither remaining failure is reachable from the primary key:

- **M13 `complete=0 withHash=0`** — the restart straddles an in-flight submission, so the batcher never sees the receipt for a transaction the node already accepted, re-picks the rows, charges three retries, drops them and records **`failed` for work that confirmed**. This is 00017's own **Q-2**, in its restart flavour; that suite's `TESTING.md` already describes the same phenomenon for M8.
- **M14 `dup=false`** — the batcher says why itself: *"Target "product-b" produced no replay key for an input (no signature, and its adapter supplies none) … Implement getReplayKey() on the adapter to close this."* `duplicate: true` comes only from the replay-key claim; with no key the store correctly keeps the existing record and takes the legally-permitted second row.

Both were unreachable while every submission 500'd at acceptance — they are visible *because* the fix works. Each deserves its own project; neither is a regression from this change.

## Scope

Changes are confined to `packages/batcher/**` (+ its README). `FileStorage`, the explicit-constructor rule and the env ladder are untouched. **Do not merge** — opened for review.
