### PR TITLE
fix(batcher): park node outages uncharged, and never report RETRIES_EXHAUSTED for a transaction that landed

### DIFF
--- a/packages/batcher/README.md
+++ b/packages/batcher/README.md
@@ -710,6 +710,63 @@ Worked example: [`templates/multi-batcher`](https://github.com/effectstream/effe
 — three products (contract calls, transfers, custom-filtered swaps) on one
 batcher, with fast and deep test suites.
 
+### Outages don't spend a caller's retry budget
+
+A retry budget exists to bound bad *inputs*. When the batcher's own environment
+is what failed, the input was never judged, so charging it would eventually
+delete a perfectly valid transaction because a node was down. Two mechanisms
+keep that promise, and both are opt-in additions to `BatchOutcome` — an adapter
+that sets neither behaves exactly as it always did.
+
+**Park an outage, don't charge it.** Mark a deferral `infra: true` and the
+batcher leaves the row untouched *and* rests the target, instead of rebuilding
+and re-proving the same doomed batch on every poll round:
+
+```ts
+return {
+  retryable: [{ input, reason: "node unreachable", infra: true }],
+  // Optional. Omit it and the batcher backs off by itself: 1s, 2s, 4s …
+  // capped at 60s, reset the moment the input is carried.
+  cooldownMs: 30_000,
+};
+```
+
+Decide it by **asking the node**, not by reading the error. Chain SDKs wrap an
+unreachable node, a dead socket and an already-spent input in the same generic
+message, so a message test cannot separate an outage from a verdict. The
+Midnight balancing adapter probes the node's JSON-RPC endpoint once per batch
+(only when a batch actually contains an unrecognized failure) and classifies on
+the answer. A node that replies — even with a JSON-RPC error — counts as
+reachable, so an unexpected RPC surface degrades to charging, never to parking
+everything.
+
+Parking is bounded: after 50 consecutive parks an input is charged anyway, so a
+misclassification cannot hold a doomed input uncharged forever. With the
+backoff above, that is upwards of 45 minutes of continuous downtime.
+
+**Never report `RETRIES_EXHAUSTED` for a transaction that is on chain.** A
+batcher restarted mid-flight loses receipts but not rows: the transactions land,
+the rows are re-picked, the resubmission is refused because the spends are
+already used, and the request used to go terminal `failed` while being
+*confirmed* on chain. Implement `findLandedTransaction` and the batcher asks
+before it charges:
+
+```ts
+async findLandedTransaction(input, { target, transactionHash }) {
+  // Return a transaction ONLY if THIS input is on chain. A batch-level answer
+  // would confirm every input in the batch as soon as any one was found.
+  // When in doubt return undefined — the input is then charged as before.
+  return await myIndexer.find(input) ?? undefined;
+}
+```
+
+A hit is recorded `confirmed` with its hash and block, the row is removed and
+the caller is resolved — the ordinary confirmation path, just later than the
+batcher noticed. Anything else (no hook, a throw, an unreachable indexer) falls
+back to today's behaviour. `transactionHash` is what the request's last
+`submitted` transition recorded, which is now always that input's **own** hash
+rather than the batch's comma-joined one.
+
 ## Customising the batcher
 
 The four interfaces you'd implement, in order of frequency:

--- a/packages/batcher/adapters/adapter.ts
+++ b/packages/batcher/adapters/adapter.ts
@@ -75,6 +75,21 @@ export interface BatchInputDeferral<TInput = DefaultBatcherInput> {
   input: TInput;
   /** Why this input could not be carried right now. */
   reason: string;
+  /**
+   * This deferral is OUR INFRASTRUCTURE failing — an unreachable node, a dead
+   * indexer — rather than a queue of ours that happened to be full.
+   *
+   * The difference is what the batcher should do next. A saturated validation
+   * queue frees up on its own and the target should keep polling; an
+   * unreachable node will refuse the identical work on the identical schedule
+   * for as long as it is down, so the target is RESTED (see
+   * {@link BatchOutcome.cooldownMs}) instead of rebuilding and re-proving the
+   * same doomed batch every poll round.
+   *
+   * Optional and additive: an adapter that never sets it behaves exactly as
+   * adapters did before this field existed.
+   */
+  infra?: boolean;
 }
 
 /**
@@ -145,6 +160,35 @@ export interface BatchOutcome<TInput = DefaultBatcherInput> {
    * its verdicts because the batcher cannot know which input is at fault.
    */
   invariantFailure?: BatchInvariantFailure<TInput>;
+  /**
+   * Rest this target for at least this many milliseconds before the next round.
+   *
+   * The batcher has always been able to park a target on a cooldown, but only
+   * for a failure THROWN out of `submitBatch`. An adapter that runs its workers
+   * under `Promise.allSettled` and reports per-input fates cannot throw, so its
+   * outages had no way to ask for a rest and every poll round re-ran a full
+   * balance/prove pipeline against a dead node. This is that channel.
+   *
+   * Advisory, and additive: omit it and the processor decides for itself from
+   * the `infra` deferrals in this outcome, exactly as an adapter written before
+   * this field would behave.
+   */
+  cooldownMs?: number;
+}
+
+/**
+ * A transaction the batcher may already have put on chain, as the chain sees it.
+ *
+ * The answer to {@link BlockchainAdapter.findLandedTransaction} — see there for
+ * why a batcher has to be able to ask.
+ */
+export interface LandedTransaction {
+  /** The hash the chain knows it by; recorded verbatim for the caller. */
+  hash: BlockchainHash;
+  /** Block it was included in, when the chain will say. */
+  blockNumber?: bigint;
+  /** 1 = mined and succeeded (the default), 0 = mined and failed. */
+  status?: number;
 }
 
 /**
@@ -323,6 +367,43 @@ export interface BlockchainAdapter<TOutput> {
    * already did, cache it there rather than repeating it here.
    */
   getReplayKey?(input: DefaultBatcherInput): string | undefined;
+
+  /**
+   * (Optional) Did an EARLIER submission of this input already reach the chain?
+   *
+   * Asked before the batcher charges a retry, and it exists because of a
+   * measured lie. A batcher restarted while a batch is in flight loses the
+   * receipts but not the rows: the transactions land, the surviving rows are
+   * re-picked, the resubmission is refused because the spends are already
+   * used, three retries are charged, the rows are dropped — and the request is
+   * published as `failed / RETRIES_EXHAUSTED` for work the chain CONFIRMED.
+   * (00017's Q-2; observed verbatim as 00020's M13, with an on-chain counter
+   * proving all four transactions landed.)
+   *
+   * The adapter is asked rather than the batcher deciding, because only the
+   * adapter knows what its payloads mean — Midnight watches the transaction's
+   * own ledger identifiers, which survive the re-proving and re-serialization
+   * a hash does not.
+   *
+   * Contract, and it is a strict one: return a transaction ONLY when this
+   * SPECIFIC input is on chain. A batch-level answer would confirm every input
+   * in the batch the moment any one of them was found, which reports a chain
+   * verdict for a request the chain never saw — the same class of lie as the
+   * defect this closes. When in doubt, return `undefined`: the input is then
+   * charged exactly as it is today, which is the pre-existing behaviour.
+   *
+   * `context.transactionHash` is what the request's own status record kept from
+   * its last `submitted` transition, when there is a record and it got that
+   * far. Absent means the batcher died before it could write one down — the
+   * adapter's own identifiers are then the only evidence there is.
+   *
+   * Failures are swallowed by the batcher and treated as `undefined`: an
+   * unreachable indexer must never be the reason a batch loop stops.
+   */
+  findLandedTransaction?(
+    input: DefaultBatcherInput,
+    context: { target: string; transactionHash?: string },
+  ): Promise<LandedTransaction | undefined>;
 
   /**
    * (Optional) Operational snapshot for `/queue-stats`, e.g. fee capacity,

--- a/packages/batcher/adapters/midnight-balancing-adapter.ts
+++ b/packages/batcher/adapters/midnight-balancing-adapter.ts
@@ -31,6 +31,7 @@ import type {
   BlockchainAdapter,
   BlockchainHash,
   BlockchainTransactionReceipt,
+  LandedTransaction,
   ValidationResult,
 } from "./adapter.ts";
 import type { DefaultBatcherInput } from "../core/types.ts";
@@ -101,6 +102,7 @@ import {
 } from "./validation-executor.ts";
 import {
   midnightReplayKey,
+  midnightTxIdentifiers,
   type ReplayIdentifiableTx,
 } from "./midnight-replay-key.ts";
 import { createHash } from "node:crypto";
@@ -310,6 +312,89 @@ export class PreSubmitInvariant extends Error {
   }
 }
 
+/** How long the node gets to answer a liveness probe before it counts as down. */
+const NODE_PROBE_TIMEOUT_MS = 5_000;
+
+/**
+ * The node's JSON-RPC endpoint, derived from the URL the adapter already has.
+ *
+ * A Midnight node serves JSON-RPC over HTTP on the SAME port as its WebSocket —
+ * the multi-batcher template's own compose healthcheck curls
+ * `http://localhost:9944` while the adapter is configured with
+ * `ws://node:9944`. So the probe needs no new configuration and there is
+ * nothing that can drift out of sync with the endpoint actually in use.
+ */
+export function nodeProbeUrl(nodeUrl: string): string {
+  const url = new URL(nodeUrl);
+  if (url.protocol === "ws:") url.protocol = "http:";
+  else if (url.protocol === "wss:") url.protocol = "https:";
+  return url.toString();
+}
+
+/**
+ * Can we still reach the node at all?
+ *
+ * This is the whole of FR-1's evidence, and it is deliberately not the error's
+ * message. The failure 00017's Q-2 and 00020's M13 both recorded arrives as
+ * `"Transaction submission error"` — a generic wrapper the SDK puts around a
+ * node that is gone, a socket that died and a spend that was already used
+ * alike. Charging a retry for the first two spends a user's budget on our
+ * outage; refusing to charge for the third lets a doomed input loop. The
+ * message cannot separate them. One round-trip can.
+ *
+ * "Reachable" means the node ANSWERED — including answering with a JSON-RPC
+ * error. That is the honest reading of the question, and it is also the safe
+ * default: a node whose RPC surface is configured differently than expected
+ * then classifies exactly as it does today (charged) rather than parking every
+ * failure it ever sees. A real outage produces no answer at all.
+ *
+ * Never throws, and never outlives its own timeout: a probe that could hang is
+ * a probe that has become the outage.
+ */
+export async function probeNodeReachable(
+  nodeUrl: string,
+  timeoutMs: number = NODE_PROBE_TIMEOUT_MS,
+): Promise<boolean> {
+  let url: string;
+  try {
+    url = nodeProbeUrl(nodeUrl);
+  } catch {
+    return false;
+  }
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        id: 1,
+        jsonrpc: "2.0",
+        method: "system_health",
+        params: [],
+      }),
+      signal: controller.signal,
+    });
+    if (!response.ok) return false;
+    const body = await response.json() as { jsonrpc?: string } | null;
+    // A JSON-RPC envelope came back, so something on the other end is alive
+    // and speaking the protocol. Whether it liked the method is a different
+    // question from whether it is there.
+    return body !== null && typeof body === "object" && "jsonrpc" in body;
+  } catch {
+    return false;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/** Does this rejection already carry its own verdict? */
+function isTypedWorkerFailure(error: unknown): boolean {
+  return error instanceof PreSpendPermanent ||
+    error instanceof PreSpendDefer ||
+    error instanceof PreSubmitInvariant;
+}
+
 export type WorkerFailureClassification<TInput extends DefaultBatcherInput> =
   | { category: "permanentRejected"; value: BatchInputRejection<TInput> }
   | { category: "retryable"; value: BatchInputDeferral<TInput> }
@@ -319,10 +404,19 @@ export type WorkerFailureClassification<TInput extends DefaultBatcherInput> =
   }
   | { category: "failed"; value: BatchInputFailure<TInput> };
 
-/** Keep permanent, deferral and legacy retry-charged failures disjoint. */
+/**
+ * Keep permanent, deferral and legacy retry-charged failures disjoint.
+ *
+ * `nodeReachable` is the FR-1 probe's verdict for THIS batch, and it only ever
+ * reaches the default branch: the three typed channels are the adapter's own
+ * verdicts and are not up for reinterpretation because a node blinked. Omit it
+ * — as every caller predating the probe does — and the default branch behaves
+ * exactly as it always has.
+ */
 export function classifyWorkerFailure<TInput extends DefaultBatcherInput>(
   input: TInput,
   error: unknown,
+  nodeReachable?: boolean,
 ): WorkerFailureClassification<TInput> {
   if (error instanceof PreSpendPermanent) {
     return {
@@ -352,20 +446,40 @@ export function classifyWorkerFailure<TInput extends DefaultBatcherInput>(
       },
     };
   }
-  return {
-    category: "failed",
-    value: {
-      input,
-      error: error instanceof Error ? error.message : String(error),
-    },
-  };
+  const message = error instanceof Error ? error.message : String(error);
+  if (nodeReachable === false) {
+    // The node did not answer, so nothing it "said" about this transaction can
+    // be believed — including the refusal that just arrived. The input has not
+    // been judged, so its budget is not touched, and the marker tells the
+    // processor to rest the target instead of rebuilding this batch a second
+    // later against the same dead node.
+    return {
+      category: "retryable",
+      value: {
+        input,
+        reason:
+          `node unreachable — not charging a retry for our own outage: ${message}`,
+        infra: true,
+      },
+    };
+  }
+  return { category: "failed", value: { input, error: message } };
 }
 
-/** Build the adapter's explicit mixed-fate outcome without splice-diff state. */
+/**
+ * Build the adapter's explicit mixed-fate outcome without splice-diff state.
+ *
+ * `nodeReachable` is passed straight through to {@link classifyWorkerFailure};
+ * note that the deserialize failures in `invalidInputs` are NOT subject to it.
+ * A row whose bytes are not a transaction is doomed whatever the node is doing,
+ * and excusing it from its budget for the duration of an outage would leave it
+ * in the queue for the outage and then some.
+ */
 export function buildWorkerBatchOutcome<TInput extends DefaultBatcherInput>(
   invalidInputs: TInput[],
   workerInputs: TInput[],
   results: PromiseSettledResult<string>[],
+  nodeReachable?: boolean,
 ): BatchOutcome<TInput> {
   const hashes: string[] = [];
   const submitted: TInput[] = [];
@@ -389,7 +503,7 @@ export function buildWorkerBatchOutcome<TInput extends DefaultBatcherInput>(
       continue;
     }
 
-    const classified = classifyWorkerFailure(input, result.reason);
+    const classified = classifyWorkerFailure(input, result.reason, nodeReachable);
     if (classified.category === "permanentRejected") {
       permanentRejected.push(classified.value);
     } else if (classified.category === "retryable") {
@@ -419,6 +533,139 @@ export function buildWorkerBatchOutcome<TInput extends DefaultBatcherInput>(
       }
       : undefined,
   };
+}
+
+/** Normalize a Midnight transaction hash to the 64-char hex the indexer takes. */
+export function normalizeMidnightHash(hash: string): string {
+  let normalized = hash.trim().toLowerCase().replace(/^0x/, "");
+  if (normalized.length > 64) normalized = normalized.slice(-64);
+  else if (normalized.length < 64) normalized = normalized.padStart(64, "0");
+  return normalized;
+}
+
+/**
+ * The indexer query behind FR-3's "did this input's spend already land?".
+ *
+ * `TransactionOffset` accepts a hash OR an identifier — introspected from
+ * `midnightntwrk/indexer-standalone:4.3.2`, not assumed — and `block` is
+ * non-nullable on the result, so a transaction coming back from this query is
+ * by construction one the chain included.
+ */
+const LANDED_TX_QUERY = `query ($offset: TransactionOffset!) {
+  transactions(offset: $offset) {
+    hash
+    block { height }
+    ... on RegularTransaction { transactionResult { status } }
+  }
+}`;
+
+interface LandedTxArgs {
+  indexer: string;
+  /** Watchable identifiers for THIS input's spend; the exact, per-input answer. */
+  identifiers?: readonly string[];
+  /**
+   * The hash a previous `submitted` transition recorded, when there was one.
+   * A comma-joined batch hash is REFUSED: it identifies a batch, and answering
+   * a per-input question with it would confirm every input in that batch the
+   * moment any one of them was found.
+   */
+  transactionHash?: string;
+  timeoutMs?: number;
+  log?: { log: (message: string) => void; warn: (message: string) => void };
+}
+
+/**
+ * Ask the indexer whether one specific spend is on chain.
+ *
+ * Identifiers are tried first and are the answer that actually matters: they
+ * name THIS input's spend, and they survive the re-proving and merging that
+ * change a transaction's hash. The recorded hash is a fallback for the case
+ * where the transaction carries no usable identifiers.
+ *
+ * Returns `undefined` for "no evidence" — not landed, unreachable indexer,
+ * malformed response, all of it. The caller must treat that as "charge it as
+ * usual", so an ambiguous answer can only ever preserve today's behaviour.
+ */
+export async function findLandedMidnightTransaction(
+  args: LandedTxArgs,
+): Promise<LandedTransaction | undefined> {
+  const offsets: Array<Record<string, string>> = [];
+  for (const identifier of args.identifiers ?? []) {
+    offsets.push({ identifier });
+  }
+  const hash = args.transactionHash?.trim();
+  if (hash && !hash.includes(",")) {
+    offsets.push({ hash: normalizeMidnightHash(hash) });
+  } else if (hash) {
+    args.log?.log(
+      `Landed-transaction check ignoring the recorded hash "${hash}": a ` +
+        `comma-joined batch hash is not evidence about an individual input.`,
+    );
+  }
+
+  for (const offset of offsets) {
+    const found = await queryLandedTransaction(args, offset);
+    if (found) return found;
+  }
+  return undefined;
+}
+
+async function queryLandedTransaction(
+  args: LandedTxArgs,
+  offset: Record<string, string>,
+): Promise<LandedTransaction | undefined> {
+  const controller = new AbortController();
+  const timer = setTimeout(
+    () => controller.abort(),
+    args.timeoutMs ?? NODE_PROBE_TIMEOUT_MS,
+  );
+  try {
+    const response = await fetch(args.indexer, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        query: LANDED_TX_QUERY,
+        variables: { offset },
+      }),
+      signal: controller.signal,
+    });
+    if (!response.ok) return undefined;
+    const body = await response.json() as {
+      data?: {
+        transactions?: Array<
+          {
+            hash?: string;
+            block?: { height?: number | string };
+            transactionResult?: { status?: string };
+          } | null
+        >;
+      };
+    };
+    const tx = body?.data?.transactions?.find((entry) =>
+      entry && typeof entry.hash === "string" && entry.block != null
+    );
+    if (!tx?.hash) return undefined;
+    const height = tx.block?.height;
+    return {
+      hash: tx.hash,
+      blockNumber: height === undefined || height === null
+        ? undefined
+        : BigInt(height),
+      // Only an outright FAILURE is reported as an on-chain failure. The
+      // existing receipt path calls anything it finds in a block `status: 1`,
+      // so this is strictly more informative than what confirmation already
+      // does — and PARTIAL_SUCCESS is not a claim this layer can safely turn
+      // into "your transaction failed".
+      status: tx.transactionResult?.status === "FAILURE" ? 0 : 1,
+    };
+  } catch (error) {
+    args.log?.log(
+      `Landed-transaction query failed for ${JSON.stringify(offset)}: ${error}`,
+    );
+    return undefined;
+  } finally {
+    clearTimeout(timer);
+  }
 }
 
 /** Outcome returned before touching a wallet once manual recovery is required. */
@@ -1771,6 +2018,54 @@ export class MidnightBalancingAdapter
     return key;
   }
 
+  /**
+   * Is an earlier submission of this input already on chain? (spec 00021 FR-3.)
+   *
+   * The batcher asks this before it charges a retry, because of a measured lie:
+   * a restart straddling an in-flight batch loses the receipts but not the
+   * rows, the re-submission is refused because the spends are used, and a
+   * request the chain CONFIRMED is published as `failed / RETRIES_EXHAUSTED`.
+   *
+   * This adapter can answer because it already knows what to watch for — the
+   * transaction's ledger identifiers, the same ones `getReplayKey` hashes.
+   * Failure of any kind returns `undefined`, which means "charge it as usual":
+   * an indexer that is down must never be able to turn into a false confirmation.
+   */
+  async findLandedTransaction(
+    input: DefaultBatcherInput,
+    context: { target: string; transactionHash?: string },
+  ): Promise<LandedTransaction | undefined> {
+    const identifiers = this.watchableIdentifiers(input);
+    const found = await findLandedMidnightTransaction({
+      indexer: this.config.indexer,
+      identifiers,
+      transactionHash: context.transactionHash,
+      log: this.log,
+    });
+    if (!found && identifiers.length === 0 && !context.transactionHash) {
+      this.log.warn(
+        `Cannot tell whether an input for target ${context.target} already ` +
+          `landed: it yielded no watchable identifiers and no earlier ` +
+          `transaction hash was recorded. It will be charged a retry, which ` +
+          `is the pre-existing behaviour.`,
+      );
+    }
+    return found;
+  }
+
+  /** The indexer-watchable identifiers of this input's own transaction. */
+  private watchableIdentifiers(input: DefaultBatcherInput): string[] {
+    try {
+      return midnightTxIdentifiers(
+        this.deserializeTxEntry(input).tx as unknown as ReplayIdentifiableTx,
+      );
+    } catch {
+      // Undeserializable payloads are refused at intake; one that reaches here
+      // simply has no identifiers to offer.
+      return [];
+    }
+  }
+
   private replayMemoKey(payload: string): string {
     return createHash("sha256").update(payload, "utf8").digest("hex");
   }
@@ -2587,15 +2882,36 @@ export class MidnightBalancingAdapter
       }),
     );
 
+    // FR-1: ONE probe for the whole batch, and only when there is an
+    // unrecognized failure to explain. A batch that succeeded, or that failed
+    // only on its own typed verdicts, never touches the network here.
+    const nodeReachable = results.some((r) =>
+        r.status === "rejected" && !isTypedWorkerFailure(r.reason)
+      )
+      ? await probeNodeReachable(this.config.node)
+      : undefined;
+    if (nodeReachable === false) {
+      this.log.warn(
+        `[${bTag}] node ${this.config.node} did not answer a liveness probe — ` +
+          `treating unrecognized worker failures as OUR outage: parking those ` +
+          `inputs uncharged rather than spending their retry budgets`,
+      );
+    }
+
     const outcome = buildWorkerBatchOutcome(
       batchData.invalidInputs,
       traceInfos.map((trace) => trace.input),
       results,
+      nodeReachable,
     );
     for (let i = 0; i < results.length; i++) {
       const r = results[i];
       if (r.status === "rejected") {
-        const classified = classifyWorkerFailure(traceInfos[i].input, r.reason);
+        const classified = classifyWorkerFailure(
+          traceInfos[i].input,
+          r.reason,
+          nodeReachable,
+        );
         this.log.warn(
           `  ${traceInfos[i].label} #${traceInfos[i].contentHash} ` +
             `[${classified.category}]: ${

--- a/packages/batcher/adapters/midnight-replay-key.ts
+++ b/packages/batcher/adapters/midnight-replay-key.ts
@@ -64,6 +64,44 @@ function attempt<R>(fn: (() => R) | undefined): R | undefined {
   }
 }
 
+/** The transaction's own identifier list, however the WASM boundary hands it over. */
+function identifierList(tx: ReplayIdentifiableTx): unknown[] {
+  const raw = attempt(tx.identifiers);
+  return Array.isArray(raw)
+    ? raw
+    : raw !== null && raw !== undefined && typeof raw !== "string" &&
+        typeof (raw as Iterable<unknown>)[Symbol.iterator] === "function"
+    ? Array.from(raw as Iterable<unknown>)
+    : [];
+}
+
+/**
+ * The identifiers a chain indexer can be asked to WATCH for, as plain hex.
+ *
+ * The same list the replay key is derived from, exposed unhashed because it has
+ * a second job: answering "did this spend already land?" after a restart lost
+ * the receipt (spec 00021 FR-3). The ledger's own documentation for these is
+ * literally that any of them may be used to watch for a specific transaction,
+ * and — unlike the transaction hash — they survive the re-proving and merging
+ * a balancing batcher does, which is the entire reason they are usable here.
+ *
+ * Normalized to bare lowercase hex with no `0x`, which is the `HexEncoded`
+ * scalar the Midnight indexer's `transactions(offset: { identifier })` takes.
+ * Entries that are not hex are dropped rather than guessed at: a malformed
+ * offset is a query that answers nothing, and answering nothing is exactly what
+ * the caller must not mistake for "it did not land".
+ */
+export function midnightTxIdentifiers(tx: ReplayIdentifiableTx): string[] {
+  const seen = new Set<string>();
+  for (const value of identifierList(tx)) {
+    const encoded = encodePart(value).trim().toLowerCase().replace(/^0x/, "");
+    if (encoded.length === 0 || encoded.length % 2 !== 0) continue;
+    if (!/^[0-9a-f]+$/.test(encoded)) continue;
+    seen.add(encoded);
+  }
+  return [...seen];
+}
+
 /**
  * The key that answers "have we already paid to put this spend on chain?".
  *
@@ -78,13 +116,7 @@ function attempt<R>(fn: (() => R) | undefined): R | undefined {
 export function midnightReplayKey(
   tx: ReplayIdentifiableTx,
 ): string | undefined {
-  const raw = attempt(tx.identifiers);
-  const list: unknown[] = Array.isArray(raw)
-    ? raw
-    : raw !== null && raw !== undefined && typeof raw !== "string" &&
-        typeof (raw as Iterable<unknown>)[Symbol.iterator] === "function"
-    ? Array.from(raw as Iterable<unknown>)
-    : [];
+  const list = identifierList(tx);
 
   if (list.length > 0) {
     const parts = list.map(encodePart).sort();

--- a/packages/batcher/core/batch-processor.test.ts
+++ b/packages/batcher/core/batch-processor.test.ts
@@ -1,5 +1,9 @@
 import { expect, test } from "bun:test";
-import { BatchProcessor, normalizeBatchOutcome } from "./batch-processor.ts";
+import {
+  BatchProcessor,
+  MAX_CONSECUTIVE_INFRA_PARKS,
+  normalizeBatchOutcome,
+} from "./batch-processor.ts";
 import { InputTerminalError, InputValidationError } from "./errors.ts";
 import { computeRequestId } from "./request-id.ts";
 import type { DefaultBatcherInput } from "./types.ts";
@@ -41,7 +45,13 @@ interface Harness {
   waitOn: (input: DefaultBatcherInput) => void;
 }
 
-function makeHarness(options: { removeError?: Error } = {}): Harness {
+function makeHarness(
+  options: {
+    removeError?: Error;
+    /** Which inputs storage DROPS when charged — the retry limit biting. */
+    dropOnRetry?: (inputs: DefaultBatcherInput[]) => DefaultBatcherInput[];
+  } = {},
+): Harness {
   const removed: DefaultBatcherInput[] = [];
   const retried: DefaultBatcherInput[] = [];
   const cooldowns: number[] = [];
@@ -57,9 +67,9 @@ function makeHarness(options: { removeError?: Error } = {}): Harness {
       },
       incrementRetryCount: async (inputs) => {
         retried.push(...inputs);
-        // Nothing hits its limit in these cases; exhaustion is covered in
-        // `batch-processor-status.test.ts`.
-        return [];
+        // Nothing hits its limit in these cases unless a case asks for it;
+        // exhaustion is covered in `batch-processor-status.test.ts`.
+        return options.dropOnRetry?.(inputs) ?? [];
       },
     },
     submissionCallbacks: callbacks,
@@ -621,4 +631,193 @@ test("a bare-hash adapter that splices inputs still charges them a retry", async
   expect(h.removed).toEqual([kept]);
   expect(h.settled.get("kept")?.status).toEqual("resolved");
   expect(h.settled.has("dropped")).toBe(false);
+});
+
+// --- FR-2: infra parking through the OUTCOME channel -------------------
+//
+// The processor could already park an infra failure — but only one that was
+// THROWN out of `submitBatch`. An adapter that runs its workers under
+// `Promise.allSettled` and reports per-input fates can never throw, so it could
+// never park: every outage arrived on the returned-outcome channel, where a
+// deferral was logged and forgotten and a failure was charged. These cases are
+// the other half of the pair the thrown channel has had since 00011.
+
+test("an infra deferral rests the target instead of merely logging it", async () => {
+  const h = makeHarness();
+  const parked = makeInput("parked");
+  h.waitOn(parked);
+
+  const adapter = makeAdapter([parked], async () => ({
+    retryable: [{
+      input: parked,
+      reason: "node unreachable: Transaction submission error",
+      infra: true,
+    }],
+  }));
+
+  await h.processor.processBatchForTarget(adapter, TARGET, [parked]);
+
+  // Uncharged, as every deferral is...
+  expect(h.retried).toEqual([]);
+  expect(h.removed).toEqual([]);
+  expect(h.settled.has("parked")).toBe(false);
+  // ...but now the target rests, instead of re-running the whole
+  // balance/prove/submit pipeline against a dead node every poll round.
+  expect(h.cooldowns.length).toBe(1);
+  expect(h.cooldowns[0]).toBeGreaterThanOrEqual(1000);
+});
+
+test("a plain deferral still rests nothing at all", async () => {
+  const h = makeHarness();
+  const deferred = makeInput("deferred");
+
+  const adapter = makeAdapter([deferred], async () => ({
+    retryable: [{ input: deferred, reason: "validation queue saturated" }],
+  }));
+
+  await h.processor.processBatchForTarget(adapter, TARGET, [deferred]);
+
+  // Back-compat, and correctness: a saturated queue of ours says nothing about
+  // the target, and pausing it would idle capacity that is about to free up.
+  expect(h.cooldowns).toEqual([]);
+  expect(h.retried).toEqual([]);
+});
+
+test("a batch-level cooldownMs is honored on its own", async () => {
+  const h = makeHarness();
+  const parked = makeInput("parked");
+
+  const adapter = makeAdapter([parked], async () => ({
+    retryable: [{ input: parked, reason: "node unreachable", infra: true }],
+    cooldownMs: 30_000,
+  }));
+
+  await h.processor.processBatchForTarget(adapter, TARGET, [parked]);
+
+  // The adapter knows more than the processor about how long its chain takes
+  // to come back, so an explicit request wins over the default.
+  expect(h.cooldowns).toEqual([30_000]);
+});
+
+test("an adapter that sets no signal behaves exactly as it did before", async () => {
+  const h = makeHarness();
+  const failed = makeInput("failed");
+
+  const adapter = makeAdapter([failed], async () => ({
+    failed: [{ input: failed, error: "balance failed" }],
+  }));
+
+  await h.processor.processBatchForTarget(adapter, TARGET, [failed]);
+
+  expect(h.retried).toEqual([failed]);
+  expect(h.cooldowns).toEqual([]);
+});
+
+test("consecutive parks of the same input rest the target for longer", async () => {
+  const h = makeHarness();
+  const parked = makeInput("parked");
+
+  const adapter = makeAdapter([parked], async () => ({
+    retryable: [{ input: parked, reason: "node unreachable", infra: true }],
+  }));
+
+  for (let round = 0; round < 4; round++) {
+    await h.processor.processBatchForTarget(adapter, TARGET, [parked]);
+  }
+
+  // A flat cooldown makes a long outage a busy-loop: the same doomed batch is
+  // rebuilt every second for the whole outage. Backoff makes the cost of an
+  // outage bounded instead of proportional to its length.
+  expect(h.cooldowns.length).toBe(4);
+  for (let i = 1; i < h.cooldowns.length; i++) {
+    expect(h.cooldowns[i]).toBeGreaterThan(h.cooldowns[i - 1]);
+  }
+  expect(h.retried).toEqual([]);
+});
+
+test("a park counter resets once the input is carried", async () => {
+  const h = makeHarness();
+  const flaky = makeInput("flaky");
+  let outage = true;
+
+  const adapter = makeAdapter([flaky], async () =>
+    outage
+      ? {
+        retryable: [{ input: flaky, reason: "node unreachable", infra: true }],
+      }
+      : { hash: "0xhash", submitted: [flaky] });
+
+  await h.processor.processBatchForTarget(adapter, TARGET, [flaky]);
+  await h.processor.processBatchForTarget(adapter, TARGET, [flaky]);
+  const duringOutage = [...h.cooldowns];
+  outage = false;
+  await h.processor.processBatchForTarget(adapter, TARGET, [flaky]);
+  outage = true;
+  await h.processor.processBatchForTarget(adapter, TARGET, [flaky]);
+
+  // Otherwise a batcher that has been up for a month would treat its first
+  // blip of the month as if the outage had been running all along.
+  expect(h.cooldowns[h.cooldowns.length - 1]).toBe(duringOutage[0]);
+});
+
+// --- FR-4: the masking backstop ---------------------------------------
+
+test("an input that parks forever is charged once its park budget is spent", async () => {
+  // The risk the probe introduces. A misclassification — or an adapter that
+  // simply always says "infra" — would otherwise let a deterministically
+  // doomed input sit in the queue uncharged for the rest of time, which is the
+  // silent-hang failure mode traded for the silent-drop one.
+  const dropped: DefaultBatcherInput[] = [];
+  let charges = 0;
+  const h = makeHarness({
+    dropOnRetry: (inputs) => {
+      // Three charges is the default `maxRetries`; the third one drops.
+      if (++charges < 3) return [];
+      dropped.push(...inputs);
+      return inputs;
+    },
+  });
+  const doomed = makeInput("doomed");
+
+  const adapter = makeAdapter([doomed], async () => ({
+    retryable: [{ input: doomed, reason: "node unreachable", infra: true }],
+  }));
+
+  let firstCharge = -1;
+  for (let round = 0; round < MAX_CONSECUTIVE_INFRA_PARKS + 10; round++) {
+    await h.processor.processBatchForTarget(adapter, TARGET, [doomed]);
+    if (firstCharge < 0 && h.retried.length > 0) firstCharge = round;
+  }
+
+  // Bounded, and bounded by the documented constant rather than by luck.
+  expect(firstCharge).toBe(MAX_CONSECUTIVE_INFRA_PARKS);
+  expect(h.retried.length).toBeGreaterThanOrEqual(3);
+  expect(dropped.length).toBeGreaterThan(0);
+});
+
+test("the park budget bites per input, not per batch", async () => {
+  const h = makeHarness();
+  const old = makeInput("old");
+  const fresh = makeInput("fresh");
+
+  const parkBoth = makeAdapter([old, fresh], async () => ({
+    retryable: [
+      { input: old, reason: "node unreachable", infra: true },
+      { input: fresh, reason: "node unreachable", infra: true },
+    ],
+  }));
+  const parkOld = makeAdapter([old], async () => ({
+    retryable: [{ input: old, reason: "node unreachable", infra: true }],
+  }));
+
+  for (let round = 0; round < MAX_CONSECUTIVE_INFRA_PARKS; round++) {
+    await h.processor.processBatchForTarget(parkOld, TARGET, [old]);
+  }
+  expect(h.retried).toEqual([]);
+
+  await h.processor.processBatchForTarget(parkBoth, TARGET, [old, fresh]);
+
+  // `old` has spent its budget; `fresh` joined the same batch this round and
+  // must not inherit someone else's history.
+  expect(h.retried).toEqual([old]);
 });

--- a/packages/batcher/core/batch-processor.ts
+++ b/packages/batcher/core/batch-processor.ts
@@ -1,4 +1,5 @@
 import type {
+  BatchInputDeferral,
   BatchInputRejection,
   BatchOutcome,
   BatchSubmitResult,
@@ -8,6 +9,7 @@ import type {
 import type { DefaultBatcherInput } from "./types.ts";
 import type {
   RequestState,
+  RequestStatusRecord,
   RequestTransition,
   RequestTransitionDetail,
   TransitionOutcome,
@@ -28,6 +30,44 @@ export const RETRIES_EXHAUSTED = "RETRIES_EXHAUSTED";
 
 /** The transaction was mined and the chain reported it failed (`status: 0`). */
 export const ONCHAIN_FAILED = "ONCHAIN_FAILED";
+
+/** Shortest rest a target gets for an infrastructure failure. */
+const INFRA_COOLDOWN_FLOOR_MS = 1000;
+
+/** Longest rest the escalation reaches; a chain that is back should be noticed. */
+const INFRA_COOLDOWN_CEILING_MS = 60_000;
+
+/**
+ * How many times in a row ONE input may be parked uncharged before the batcher
+ * stops believing the diagnosis and charges it anyway (spec FR-4).
+ *
+ * The bound exists because parking is a judgement, and a judgement can be
+ * wrong. Without it, an adapter that answers "infrastructure" for an input that
+ * is in fact deterministically doomed would keep that input queued, uncharged
+ * and unanswerable for the rest of the process's life — trading the silent-drop
+ * failure this project fixes for a silent-hang one, which is not a trade.
+ *
+ * 50 is chosen against the escalation, not out of the air: parks rest the
+ * target for 1s, 2s, 4s … capped at 60s, so spending a whole park budget takes
+ * upwards of **45 minutes of continuous outage**. That is far longer than any
+ * outage a per-input retry budget was ever meant to absorb, and still finite.
+ */
+export const MAX_CONSECUTIVE_INFRA_PARKS = 50;
+
+/**
+ * Ceiling on the park ledger, so a batcher that has seen a great many distinct
+ * inputs cannot accumulate one counter per input forever. Entries are evicted
+ * oldest-first; an evicted input simply starts its count again, which is the
+ * safe direction — it gets MORE patience, never less.
+ */
+const INFRA_PARK_LEDGER_LIMIT = 10_000;
+
+/** The rest a target earns after `parks` consecutive infrastructure failures. */
+export function infraCooldownMs(parks: number, retryDelayMs: number): number {
+  const floor = Math.max(retryDelayMs, INFRA_COOLDOWN_FLOOR_MS);
+  const escalated = floor * 2 ** Math.max(0, parks - 1);
+  return Math.min(escalated, INFRA_COOLDOWN_CEILING_MS);
+}
 
 // Custom logger for debugging
 // File logging is opt-in: appendFileSync blocks the event loop on every line,
@@ -89,6 +129,15 @@ export class BatchProcessor<T extends DefaultBatcherInput> {
         recordTransitions?: (
           transitions: readonly RequestTransition[],
         ) => Promise<TransitionOutcome[]>;
+        /**
+         * Optional: the record for one request. Feature-detected like the rest
+         * of tracking — the reconciliation below uses it to hand the adapter
+         * the hash an earlier submission recorded, and does without when the
+         * backend has no statuses to read.
+         */
+        getStatus?: (
+          requestId: string,
+        ) => Promise<RequestStatusRecord | undefined>;
       };
       submissionCallbacks: Map<
         string,
@@ -108,6 +157,42 @@ export class BatchProcessor<T extends DefaultBatcherInput> {
       setTargetCooldown: (target: string, ms: number) => void;
     },
   ) {}
+
+  /**
+   * How many rounds in a row each input has been parked uncharged for an
+   * infrastructure failure (spec FR-4). Keyed by target and request id, and
+   * reset the moment the input is carried, judged or charged — a batcher that
+   * has been up for a month must treat its first blip of the month as the first
+   * blip, not as the continuation of one.
+   */
+  private readonly infraParks = new Map<string, number>();
+
+  private parkLedgerKey(input: T, target: string): string {
+    return `${target}\u0000${computeRequestId(input, target)}`;
+  }
+
+  /** Count one more consecutive park for this input and return the new total. */
+  private recordInfraPark(input: T, target: string): number {
+    const key = this.parkLedgerKey(input, target);
+    const parks = (this.infraParks.get(key) ?? 0) + 1;
+    // Re-inserting moves the entry to the back of the insertion order, which is
+    // what makes the eviction below oldest-first.
+    this.infraParks.delete(key);
+    this.infraParks.set(key, parks);
+    while (this.infraParks.size > INFRA_PARK_LEDGER_LIMIT) {
+      const oldest = this.infraParks.keys().next();
+      if (oldest.done) break;
+      this.infraParks.delete(oldest.value);
+    }
+    return parks;
+  }
+
+  /** This input's streak is over: it was carried, judged or charged. */
+  private clearInfraParks(inputs: readonly T[], target: string): void {
+    for (const input of inputs) {
+      this.infraParks.delete(this.parkLedgerKey(input, target));
+    }
+  }
 
   /**
    * Classify a batch-wide failure. INFRASTRUCTURE failures (no spendable
@@ -346,6 +431,191 @@ export class BatchProcessor<T extends DefaultBatcherInput> {
     }
   }
 
+  /**
+   * Split this round's deferrals into the ones still within their park budget
+   * and the ones that have spent it (spec FR-4).
+   *
+   * Only `infra` deferrals are counted. A plain deferral — a validation queue
+   * of ours that was full — is not a claim about the environment, so it does
+   * not rest the target and it does not consume a budget; that channel behaves
+   * exactly as it did before this existed.
+   */
+  private splitParkBudget(
+    deferrals: BatchInputDeferral<T>[],
+    target: string,
+  ): { parked: Array<{ deferral: BatchInputDeferral<T>; parks: number }>;
+    exhausted: BatchInputDeferral<T>[] } {
+    const parked: Array<{ deferral: BatchInputDeferral<T>; parks: number }> = [];
+    const exhausted: BatchInputDeferral<T>[] = [];
+    for (const deferral of deferrals) {
+      if (deferral.infra !== true) continue;
+      const parks = this.recordInfraPark(deferral.input, target);
+      if (parks > MAX_CONSECUTIVE_INFRA_PARKS) exhausted.push(deferral);
+      else parked.push({ deferral, parks });
+    }
+    return { parked, exhausted };
+  }
+
+  /**
+   * How long to rest this target, or `undefined` for "do not rest it".
+   *
+   * An explicit `cooldownMs` from the adapter wins: it knows how long its own
+   * chain takes to come back. Otherwise the rest escalates with the longest
+   * park streak in the batch, so a five-second blip costs a second and a
+   * two-hour outage does not cost two hours of rebuilt batches.
+   */
+  private infraCooldownRequest(
+    outcome: BatchOutcome<T>,
+    parked: Array<{ deferral: BatchInputDeferral<T>; parks: number }>,
+    retryDelayMs: number,
+    invariantCooldownMs: number | undefined,
+  ): number | undefined {
+    let requested: number | undefined;
+    if (typeof outcome.cooldownMs === "number" && outcome.cooldownMs > 0) {
+      requested = outcome.cooldownMs;
+    } else if (parked.length > 0) {
+      const longestStreak = Math.max(...parked.map((entry) => entry.parks));
+      requested = infraCooldownMs(longestStreak, retryDelayMs);
+    }
+    if (requested === undefined) return undefined;
+    // Never shorten a rest something more serious already asked for.
+    if (invariantCooldownMs !== undefined && invariantCooldownMs >= requested) {
+      return undefined;
+    }
+    return requested;
+  }
+
+  /**
+   * Ask the chain before charging: which of these inputs are already ON it?
+   *
+   * The defect this closes (spec FR-3, 00017's Q-2, measured verbatim as
+   * 00020's M13): a batcher restarted while a batch is in flight loses the
+   * receipts but keeps the rows. The transactions land, the surviving rows are
+   * re-picked, the resubmission is refused because the spends are used, three
+   * retries are charged, the rows are dropped — and the store publishes
+   * `failed / RETRIES_EXHAUSTED` for requests the chain CONFIRMED. A poller is
+   * then told the exact opposite of what happened, which is worse than being
+   * told nothing.
+   *
+   * Returns the inputs that are NOT on chain and must still be charged. The
+   * ones that are get the ordinary confirmation treatment — the same verdict,
+   * the same removal, the same resolution, in the same order — because that is
+   * what genuinely happened to them, just later than the batcher noticed.
+   *
+   * Everything here is best-effort by construction: no hook, a hook that
+   * throws, a status store that will not answer, a removal that fails — each
+   * degrades to "charge it, exactly as before". An outage in the check must
+   * never be a reason a batch loop stops.
+   */
+  private async reconcileLandedInputs(
+    adapter: BlockchainAdapter<any>,
+    target: string,
+    inputs: T[],
+  ): Promise<T[]> {
+    if (inputs.length === 0) return inputs;
+    if (typeof adapter.findLandedTransaction !== "function") return inputs;
+
+    const unresolved: T[] = [];
+    for (const input of inputs) {
+      let landed;
+      try {
+        landed = await adapter.findLandedTransaction(input, {
+          target,
+          transactionHash: await this.recordedTransactionHash(input, target),
+        });
+      } catch (error) {
+        debugLog(
+          `[BatchProcessor] Landed-transaction check failed for target ` +
+            `${target}; charging as usual: ${error}`,
+        );
+        landed = undefined;
+      }
+      if (!landed) {
+        unresolved.push(input);
+        continue;
+      }
+
+      const receipt: BlockchainTransactionReceipt = {
+        hash: landed.hash,
+        blockNumber: landed.blockNumber ?? 0n,
+        status: landed.status ?? 1,
+      };
+      console.warn(
+        `🔎 [BatchProcessor] Request ` +
+          `${computeRequestId(input, target).substring(0, 12)}… for target ` +
+          `${target} failed to submit, but its earlier transaction IS on ` +
+          `chain (${landed.hash}${
+            landed.blockNumber === undefined
+              ? ""
+              : ` at block ${landed.blockNumber}`
+          }). Recording the chain's verdict instead of charging a retry.`,
+      );
+
+      // Verdict BEFORE removal (00011 F-P3.14). Under kill -9 this ordering is
+      // the safe one: a terminal record with a surviving row is repaired by the
+      // append-only guard when the row is re-picked, whereas removing first can
+      // leave an in-flight record with no row behind it.
+      await this.recordChainOutcome([input], target, receipt);
+      try {
+        await this.batcher.storage.removeProcessedInputs([input], target);
+      } catch (error) {
+        // The row survives and will be re-picked — and reconciled again, which
+        // is self-healing. What must not happen is that it gets charged, and
+        // it will not: it is out of the charge set for good.
+        console.error(
+          `🛑 [BatchProcessor] Could not remove the row for a request that IS ` +
+            `on chain (target ${target}, ${landed.hash}); its record is ` +
+            `already terminal, so the re-picked row will be reconciled ` +
+            `again: ${error}`,
+        );
+      }
+      this.resolveInputCallbacks([input], target, receipt);
+      this.clearInfraParks([input], target);
+    }
+    return unresolved;
+  }
+
+  /** The hash this request's last `submitted` transition wrote down, if any. */
+  private async recordedTransactionHash(
+    input: T,
+    target: string,
+  ): Promise<string | undefined> {
+    const storage = this.batcher.storage;
+    if (typeof storage.getStatus !== "function") return undefined;
+    try {
+      const record = await storage.getStatus(computeRequestId(input, target));
+      return record?.transactionHash;
+    } catch (error) {
+      debugLog(
+        `[BatchProcessor] Could not read the status record before the ` +
+          `landed-transaction check for target ${target}: ${error}`,
+      );
+      return undefined;
+    }
+  }
+
+  /**
+   * Reconcile, then charge whatever the chain has never heard of.
+   *
+   * Every charge path in this class goes through here, so there is exactly one
+   * answer to "did we check before we charged?" rather than three.
+   */
+  private async reconcileThenCharge(
+    adapter: BlockchainAdapter<any>,
+    inputs: T[],
+    target: string,
+    maxRetries: number,
+    reasons?: Map<string, string>,
+  ): Promise<void> {
+    const unresolved = await this.reconcileLandedInputs(
+      adapter,
+      target,
+      inputs,
+    );
+    if (unresolved.length === 0) return;
+    await this.chargeRetries(unresolved, target, maxRetries, reasons);
+  }
+
   async processBatchForTarget(
     adapter: BlockchainAdapter<any>,
     target: string,
@@ -434,7 +704,9 @@ export class BatchProcessor<T extends DefaultBatcherInput> {
         const thrownMessage = error instanceof Error
           ? error.message
           : String(error);
-        await this.chargeRetries(
+        this.clearInfraParks(inputsSnapshot, target);
+        await this.reconcileThenCharge(
+          adapter,
           inputsSnapshot,
           target,
           maxRetries,
@@ -464,10 +736,15 @@ export class BatchProcessor<T extends DefaultBatcherInput> {
       const invariantInputs = invariant?.inputs ?? [];
       const invariantInputSet = new Set<T>(invariantInputs);
       let invariantError: Error | undefined;
+      // Remembered so the infra cooldown below can never SHORTEN it: the
+      // batcher's cooldown is an absolute deadline, so a 1s infra rest applied
+      // after an infinite hard pause would silently cancel the hard pause.
+      let invariantCooldownMs: number | undefined;
       if (invariant) {
         const cooldownMs = invariant.hardPause
           ? Number.POSITIVE_INFINITY
-          : Math.max(retryDelayMs, 1000);
+          : Math.max(retryDelayMs, INFRA_COOLDOWN_FLOOR_MS);
+        invariantCooldownMs = cooldownMs;
         this.batcher.setTargetCooldown(target, cooldownMs);
         invariantError = new Error(
           `Batch invariant failure for target ${target}: ` +
@@ -503,9 +780,29 @@ export class BatchProcessor<T extends DefaultBatcherInput> {
       );
 
       if (permanentRejected.length > 0) {
+        this.clearInfraParks(
+          permanentRejected.map((rejection) => rejection.input),
+          target,
+        );
         await this.rejectInputsPermanently(permanentRejected, target);
       }
 
+      // An infra deferral is the outage the retry budget was never meant to
+      // absorb. It is left uncharged like any deferral, but unlike any other
+      // deferral it also RESTS the target: the same doomed balance/prove
+      // pipeline re-run every poll round is how a node outage used to cost a
+      // batcher its whole worker pool.
+      const { parked, exhausted } = this.splitParkBudget(retryable, target);
+      if (exhausted.length > 0) {
+        console.warn(
+          `[BatchProcessor] ${exhausted.length} input(s) for target ${target} ` +
+            `have now been parked ${MAX_CONSECUTIVE_INFRA_PARKS} times in a ` +
+            `row without ever being carried; charging them a retry rather ` +
+            `than parking uncharged forever: ${
+              exhausted.map((d) => d.reason).join("; ")
+            }`,
+        );
+      }
       if (retryable.length > 0) {
         // Left in storage with retry counts untouched: these inputs were never
         // judged, so charging them for our own trouble would eventually drop a
@@ -518,20 +815,50 @@ export class BatchProcessor<T extends DefaultBatcherInput> {
         );
       }
 
-      if (failed.length > 0) {
+      const cooldownRequest = this.infraCooldownRequest(
+        outcome,
+        parked,
+        retryDelayMs,
+        invariantCooldownMs,
+      );
+      if (cooldownRequest !== undefined) {
+        console.warn(
+          `[BatchProcessor] Infra failure reported for target ${target} — ` +
+            `parking ${parked.length} input(s) untouched, cooldown ` +
+            `${cooldownRequest}ms`,
+        );
+        this.batcher.setTargetCooldown(target, cooldownRequest);
+      }
+
+      // A judged failure ends the streak — the adapter reached a verdict, so
+      // whatever the previous rounds suspected about the environment, this
+      // round was not about the environment. A budget-exhausted park does NOT
+      // end it: its counter is the only thing keeping the input from parking
+      // for another full budget, and resetting it here would triple the bound
+      // FR-4 exists to impose.
+      this.clearInfraParks(failed.map((failure) => failure.input), target);
+      const chargeable = [
+        ...failed,
+        ...exhausted.map((deferral) => ({
+          input: deferral.input,
+          error: deferral.reason,
+        })),
+      ];
+      if (chargeable.length > 0) {
         debugLog(
-          `[BatchProcessor] Charging one retry to ${failed.length} ` +
+          `[BatchProcessor] Charging one retry to ${chargeable.length} ` +
             `adapter-judged failed input(s) for target ${target} ` +
             `(maxRetries=${maxRetries}): ${
-              failed.map((failure) => failure.error).join("; ")
+              chargeable.map((failure) => failure.error).join("; ")
             }`,
         );
-        await this.chargeRetries(
-          failed.map((failure) => failure.input),
+        await this.reconcileThenCharge(
+          adapter,
+          chargeable.map((failure) => failure.input),
           target,
           maxRetries,
           new Map(
-            failed.map((
+            chargeable.map((
               failure,
             ) => [computeRequestId(failure.input, target), failure.error]),
           ),
@@ -591,7 +918,13 @@ export class BatchProcessor<T extends DefaultBatcherInput> {
             );
             // The legacy protocol says nothing about WHY an input was spliced
             // out, so the exhaustion report carries no diagnostic here.
-            await this.chargeRetries(failedInputs, target, maxRetries);
+            this.clearInfraParks(failedInputs, target);
+            await this.reconcileThenCharge(
+              adapter,
+              failedInputs,
+              target,
+              maxRetries,
+            );
           }
         }
       }
@@ -600,14 +933,34 @@ export class BatchProcessor<T extends DefaultBatcherInput> {
         `[BatchProcessor] Submitting ${finalSelectedInputs.length} inputs for target ${target} with hash ${hash}`,
       );
 
+      // Carried at last: whatever the previous rounds thought of these inputs,
+      // the environment worked this time.
+      this.clearInfraParks(finalSelectedInputs, target);
+
       // Recorded before the receipt wait, which can take a minute: a poll in
       // that window should say "submitted, here is the hash" rather than
       // "batching", so the caller can watch the chain themselves.
+      //
+      // Each input gets its OWN hash, by the same rule the receipt already uses
+      // (`splitReceiptHashes`). An adapter that submits one transaction per
+      // input reports them comma-joined, and recording the joined string here
+      // would hand every caller a hash that matches nothing on chain — and
+      // would give `reconcileLandedInputs` a batch-level answer to a per-input
+      // question, confirming everyone the moment anyone was found.
+      const submitHashes = this.splitReceiptHashes(finalSelectedInputs, {
+        hash,
+        blockNumber: 0n,
+        status: 1,
+      });
       await this.transitionAll(
         finalSelectedInputs,
         target,
         "submitted",
-        () => ({ transactionHash: hash }),
+        (input) => ({
+          transactionHash: submitHashes.isMultiHash
+            ? submitHashes.hashes[finalSelectedInputs.indexOf(input)]
+            : hash,
+        }),
       );
 
       // Wait for confirmation and EffectStream processing

--- a/packages/batcher/test/infra-classification.test.ts
+++ b/packages/batcher/test/infra-classification.test.ts
@@ -1,0 +1,306 @@
+// FR-1 / FR-6: an unrecognized worker failure is classified by PROBING THE
+// NODE, not by reading the error's message.
+//
+// The message is not evidence. The failure 00017's Q-2 and 00020's M13 both
+// observed arrives as the string `"Transaction submission error"` — a generic
+// wrapper the Midnight SDK puts around a node refusal, a socket that went away
+// and an already-spent input alike. Charging a retry for the second of those
+// spends a user's budget on our outage; refusing to charge for the third lets a
+// doomed input loop forever. Only asking the node which world we are in can
+// tell them apart, so that is what the classifier is given.
+
+import { describe, expect, test } from "bun:test";
+import type { DefaultBatcherInput } from "../core/types.ts";
+import {
+  buildWorkerBatchOutcome,
+  classifyWorkerFailure,
+  nodeProbeUrl,
+  PreSpendDefer,
+  PreSpendPermanent,
+  probeNodeReachable,
+  PreSubmitInvariant,
+} from "../adapters/midnight-balancing-adapter.ts";
+
+const input: DefaultBatcherInput = {
+  addressType: 1 as DefaultBatcherInput["addressType"],
+  input: "0102",
+  address: "caller",
+  timestamp: "2026-08-14T00:00:00.000Z",
+  target: "product-a",
+};
+
+const other: DefaultBatcherInput = { ...input, address: "other-caller" };
+
+/** The exact wrapper both 00017's Q-2 and 00020's M13 captured. */
+const OBSERVED = new Error("Transaction submission error");
+
+describe("FR-1 — the probe, not the message, decides who pays", () => {
+  test("an unrecognized failure is CHARGED when the node answered the probe", () => {
+    const classified = classifyWorkerFailure(input, OBSERVED, true);
+
+    // The node is up, so it gave a verdict about this transaction. That is
+    // exactly what a retry budget is for.
+    expect(classified.category).toBe("failed");
+    expect(classified.value).toEqual({
+      input,
+      error: "Transaction submission error",
+    });
+  });
+
+  test("the same failure becomes an UNCHARGED deferral when the node did not", () => {
+    const classified = classifyWorkerFailure(input, OBSERVED, false);
+
+    expect(classified.category).toBe("retryable");
+    if (classified.category !== "retryable") throw new Error("unreachable");
+    expect(classified.value.input).toBe(input);
+    // The FR-2 signal: this deferral is our environment, so the processor
+    // must rest the target rather than merely log it.
+    expect(classified.value.infra).toBe(true);
+    // The original diagnostic survives — a deferral that hid the SDK's own
+    // words would make the next outage unreadable.
+    expect(classified.value.reason).toContain("Transaction submission error");
+    expect(classified.value.reason).toContain("unreachable");
+  });
+
+  test("the identical message lands in BOTH channels — so nothing was sniffed", () => {
+    const charged = classifyWorkerFailure(input, OBSERVED, true);
+    const parked = classifyWorkerFailure(input, OBSERVED, false);
+
+    expect(charged.category).toBe("failed");
+    expect(parked.category).toBe("retryable");
+  });
+
+  test("an unprobed classification behaves EXACTLY as it did before", () => {
+    // Back-compat: every existing caller passes two arguments.
+    expect(classifyWorkerFailure(input, OBSERVED).category).toBe("failed");
+    expect(classifyWorkerFailure(input, OBSERVED, undefined).category)
+      .toBe("failed");
+  });
+
+  test("a non-Error rejection is still readable in the deferral reason", () => {
+    const classified = classifyWorkerFailure(input, "socket hang up", false);
+    if (classified.category !== "retryable") {
+      throw new Error(`expected retryable, got ${classified.category}`);
+    }
+    expect(classified.value.reason).toContain("socket hang up");
+  });
+});
+
+describe("FR-1 — the typed channels are untouched by the probe", () => {
+  for (const reachable of [true, false, undefined]) {
+    test(`a permanent verdict stays permanent (probe=${reachable})`, () => {
+      const classified = classifyWorkerFailure(
+        input,
+        new PreSpendPermanent("bad network", "NOT_WELL_FORMED", 400),
+        reachable,
+      );
+      expect(classified.category).toBe("permanentRejected");
+    });
+
+    test(`a typed deferral stays a plain deferral (probe=${reachable})`, () => {
+      const classified = classifyWorkerFailure(
+        input,
+        new PreSpendDefer("validation queue saturated"),
+        reachable,
+      );
+      expect(classified.category).toBe("retryable");
+      if (classified.category !== "retryable") throw new Error("unreachable");
+      expect(classified.value.reason).toBe("validation queue saturated");
+      // A saturated queue of ours is not an unreachable node: it must NOT
+      // acquire the infra marker and rest the whole target.
+      expect(classified.value.infra).toBeUndefined();
+    });
+
+    test(`an invariant stays an invariant (probe=${reachable})`, () => {
+      const classified = classifyWorkerFailure(
+        input,
+        new PreSubmitInvariant("finalized tx failed revalidation"),
+        reachable,
+      );
+      expect(classified.category).toBe("invariantFailure");
+    });
+  }
+});
+
+describe("FR-1/FR-2 — the outcome the adapter hands the processor", () => {
+  test("an unreachable node defers every untyped failure and asks for a rest", () => {
+    const outcome = buildWorkerBatchOutcome(
+      [],
+      [input, other],
+      [
+        { status: "rejected", reason: OBSERVED },
+        { status: "rejected", reason: new Error("fetch failed") },
+      ],
+      false,
+    );
+
+    expect(outcome.failed).toEqual([]);
+    expect(outcome.retryable?.length).toBe(2);
+    // FR-2's signal, carried per deferral. The adapter says WHAT happened and
+    // leaves the schedule to the processor, which is the only party that knows
+    // how many rounds in a row this target has already been failing — and so
+    // the only one that can back the retries off instead of asking for the
+    // same flat rest for a five-second blip and a two-hour outage.
+    expect(outcome.retryable?.every((d) => d.infra === true)).toBe(true);
+    expect(outcome.cooldownMs).toBeUndefined();
+    expect(outcome.hash).toBeUndefined();
+  });
+
+  test("a reachable node keeps charging, and asks for no rest at all", () => {
+    const outcome = buildWorkerBatchOutcome(
+      [],
+      [input, other],
+      [
+        { status: "rejected", reason: OBSERVED },
+        { status: "rejected", reason: new Error("already spent") },
+      ],
+      true,
+    );
+
+    expect(outcome.failed?.length).toBe(2);
+    expect(outcome.retryable).toEqual([]);
+    expect(outcome.cooldownMs).toBeUndefined();
+  });
+
+  test("FR-4 anchor: a payload that cannot deserialize is charged EVEN during an outage", () => {
+    // The masking risk in one case. A row whose bytes are not a transaction is
+    // deterministically doomed; if an outage excused it from its budget it
+    // would sit in the queue for as long as the outage lasted and then some.
+    const outcome = buildWorkerBatchOutcome([other], [input], [
+      { status: "rejected", reason: OBSERVED },
+    ], false);
+
+    expect(outcome.failed).toEqual([{
+      input: other,
+      error: "transaction failed to deserialize",
+    }]);
+    expect(outcome.retryable?.length).toBe(1);
+  });
+
+  test("an unprobed batch is byte-for-byte what it was before", () => {
+    const outcome = buildWorkerBatchOutcome([], [input], [
+      { status: "rejected", reason: OBSERVED },
+    ]);
+
+    expect(outcome.failed?.length).toBe(1);
+    expect(outcome.retryable).toEqual([]);
+    expect(outcome.cooldownMs).toBeUndefined();
+  });
+});
+
+describe("FR-1 — the probe itself", () => {
+  test("the probe URL is the node's own, on the scheme HTTP JSON-RPC uses", () => {
+    // The node serves JSON-RPC over HTTP on the SAME port as its WebSocket —
+    // the 00017 template's compose healthcheck curls `http://localhost:9944`.
+    // So there is nothing new to configure and nothing to keep in sync.
+    expect(nodeProbeUrl("ws://node:9944")).toBe("http://node:9944/");
+    expect(nodeProbeUrl("wss://rpc.example.com/chain")).toBe(
+      "https://rpc.example.com/chain",
+    );
+    expect(nodeProbeUrl("http://node:9944/")).toBe("http://node:9944/");
+    expect(nodeProbeUrl("https://node/rpc")).toBe("https://node/rpc");
+  });
+
+  test("a node that answers JSON-RPC is reachable, and is asked politely", async () => {
+    let seenMethod: string | undefined;
+    const seenContentTypes: Array<string | null> = [];
+    const node = Bun.serve({
+      port: 0,
+      fetch: async (request) => {
+        seenContentTypes.push(request.headers.get("content-type"));
+        const body = await request.json() as { method?: string; id?: unknown };
+        seenMethod = body.method;
+        return Response.json({ jsonrpc: "2.0", id: body.id, result: {} });
+      },
+    });
+    try {
+      expect(await probeNodeReachable(`ws://127.0.0.1:${node.port}`, 5_000))
+        .toBe(true);
+      expect(seenMethod).toBe("system_health");
+      expect(seenContentTypes).toEqual(["application/json"]);
+    } finally {
+      await node.stop(true);
+    }
+  });
+
+  test("a port with nothing behind it is unreachable", async () => {
+    // Bind, read the port, release it: a port that WAS free a moment ago is
+    // the closest thing to a guaranteed-closed port a test can have.
+    const scratch = Bun.serve({ port: 0, fetch: () => new Response("x") });
+    const closedPort = scratch.port;
+    await scratch.stop(true);
+
+    expect(await probeNodeReachable(`ws://127.0.0.1:${closedPort}`, 5_000))
+      .toBe(false);
+  });
+
+  test("a node that answers with an error status is unreachable", async () => {
+    const node = Bun.serve({
+      port: 0,
+      fetch: () => new Response("service unavailable", { status: 503 }),
+    });
+    try {
+      expect(await probeNodeReachable(`ws://127.0.0.1:${node.port}`, 5_000))
+        .toBe(false);
+    } finally {
+      await node.stop(true);
+    }
+  });
+
+  test("a node that answers a JSON-RPC ERROR is still reachable — it answered", async () => {
+    // The probe asks "is the node there", not "does it like this method". A
+    // deployment whose RPC surface is configured differently than expected must
+    // fall back to today's behaviour (charge), not park every failure it sees.
+    const node = Bun.serve({
+      port: 0,
+      fetch: () =>
+        Response.json({ jsonrpc: "2.0", id: 1, error: { code: -32601 } }),
+    });
+    try {
+      expect(await probeNodeReachable(`ws://127.0.0.1:${node.port}`, 5_000))
+        .toBe(true);
+    } finally {
+      await node.stop(true);
+    }
+  });
+
+  test("a 200 that is not JSON-RPC at all is unreachable", async () => {
+    // A proxy or captive portal answering 200 with HTML is not a node.
+    const node = Bun.serve({
+      port: 0,
+      fetch: () => new Response("<html>gateway</html>"),
+    });
+    try {
+      expect(await probeNodeReachable(`ws://127.0.0.1:${node.port}`, 5_000))
+        .toBe(false);
+    } finally {
+      await node.stop(true);
+    }
+  });
+
+  test("a node that never answers is unreachable, and BOUNDED", async () => {
+    // The whole point of a cheap probe is that it cannot itself become the
+    // outage. A hung socket must expire on our clock, not the peer's.
+    let release: (response: Response) => void = () => {};
+    const node = Bun.serve({
+      port: 0,
+      fetch: () => new Promise<Response>((resolve) => { release = resolve; }),
+    });
+    try {
+      const started = Date.now();
+      expect(await probeNodeReachable(`ws://127.0.0.1:${node.port}`, 250))
+        .toBe(false);
+      expect(Date.now() - started).toBeLessThan(3_000);
+    } finally {
+      // Let the stuck handler go before shutting down, or the server has an
+      // in-flight request it will wait on forever and the TEST hangs instead.
+      release(new Response("late"));
+      await node.stop(true);
+    }
+  });
+
+  test("an unusable URL is unreachable rather than an exception", async () => {
+    expect(await probeNodeReachable("not a url", 250)).toBe(false);
+    expect(await probeNodeReachable("", 250)).toBe(false);
+  });
+});

--- a/packages/batcher/test/landed-transaction.test.ts
+++ b/packages/batcher/test/landed-transaction.test.ts
@@ -1,0 +1,298 @@
+// FR-3, adapter half: "is this input's spend already on chain?"
+//
+// The batcher asks; only the adapter can answer, because only it knows what its
+// payloads mean. For Midnight the answer is the transaction's own ledger
+// identifiers — the ones `getReplayKey` already hashes — because those survive
+// the re-proving and merging that change a transaction's hash, and because the
+// indexer will take them as a query offset.
+//
+// The GraphQL in `findLandedMidnightTransaction` was validated against the real
+// `midnightntwrk/indexer-standalone:4.3.2` schema: `TransactionOffset` accepts
+// `hash` and `identifier`, `RegularTransaction.transactionResult.status` is one
+// of SUCCESS | PARTIAL_SUCCESS | FAILURE, and `Transaction.block` is
+// non-nullable, so anything the query returns is by construction in a block.
+
+import { describe, expect, test } from "bun:test";
+import {
+  findLandedMidnightTransaction,
+  normalizeMidnightHash,
+} from "../adapters/midnight-balancing-adapter.ts";
+import { midnightTxIdentifiers } from "../adapters/midnight-replay-key.ts";
+
+interface Seen {
+  offset: Record<string, string>;
+  query: string;
+}
+
+/**
+ * A stand-in indexer that answers for the offsets it is told about and returns
+ * an empty list for anything else — which is what the real one does.
+ */
+function fakeIndexer(
+  landed: Record<string, unknown>,
+  options: { status?: number; body?: unknown; seen?: Seen[] } = {},
+) {
+  const server = Bun.serve({
+    port: 0,
+    fetch: async (request) => {
+      const body = await request.json() as {
+        query: string;
+        variables: { offset: Record<string, string> };
+      };
+      options.seen?.push({ offset: body.variables.offset, query: body.query });
+      if (options.status && options.status !== 200) {
+        return new Response("no", { status: options.status });
+      }
+      if (options.body !== undefined) return Response.json(options.body);
+      const key = Object.values(body.variables.offset)[0];
+      const hit = landed[key];
+      return Response.json({ data: { transactions: hit ? [hit] : [] } });
+    },
+  });
+  return { url: `http://127.0.0.1:${server.port}`, server };
+}
+
+const CONFIRMED = {
+  hash: "aa".repeat(32),
+  block: { height: 4242 },
+  transactionResult: { status: "SUCCESS" },
+};
+
+describe("findLandedMidnightTransaction", () => {
+  test("an identifier the chain knows resolves to its transaction", async () => {
+    const seen: Seen[] = [];
+    const { url, server } = fakeIndexer({ deadbeef: CONFIRMED }, { seen });
+    try {
+      const found = await findLandedMidnightTransaction({
+        indexer: url,
+        identifiers: ["deadbeef"],
+      });
+
+      expect(found).toEqual({
+        hash: "aa".repeat(32),
+        blockNumber: 4242n,
+        status: 1,
+      });
+      expect(seen[0].offset).toEqual({ identifier: "deadbeef" });
+      // The exact query text that the real indexer accepted.
+      expect(seen[0].query).toContain("TransactionOffset!");
+      expect(seen[0].query).toContain("transactionResult");
+    } finally {
+      await server.stop(true);
+    }
+  });
+
+  test("identifiers are tried before the recorded hash", async () => {
+    const seen: Seen[] = [];
+    const { url, server } = fakeIndexer({}, { seen });
+    try {
+      await findLandedMidnightTransaction({
+        indexer: url,
+        identifiers: ["1111", "2222"],
+        transactionHash: "cc".repeat(32),
+      });
+
+      // Identifiers name THIS input's spend; a hash is what is left when they
+      // are unavailable.
+      expect(seen.map((s) => s.offset)).toEqual([
+        { identifier: "1111" },
+        { identifier: "2222" },
+        { hash: "cc".repeat(32) },
+      ]);
+    } finally {
+      await server.stop(true);
+    }
+  });
+
+  test("the recorded hash answers when there are no identifiers", async () => {
+    const { url, server } = fakeIndexer({ ["bb".repeat(32)]: CONFIRMED });
+    try {
+      const found = await findLandedMidnightTransaction({
+        indexer: url,
+        identifiers: [],
+        transactionHash: `0x${"bb".repeat(32)}`,
+      });
+      expect(found?.blockNumber).toBe(4242n);
+    } finally {
+      await server.stop(true);
+    }
+  });
+
+  test("a COMMA-joined batch hash is refused outright", async () => {
+    const seen: Seen[] = [];
+    const { url, server } = fakeIndexer({ ["bb".repeat(32)]: CONFIRMED }, {
+      seen,
+    });
+    try {
+      const found = await findLandedMidnightTransaction({
+        indexer: url,
+        identifiers: [],
+        transactionHash: `${"bb".repeat(32)},${"cc".repeat(32)}`,
+      });
+
+      // This is the soundness rule of the whole feature. A batch hash is shared
+      // by every input in the batch, so answering a per-input question with it
+      // would confirm all of them the moment ANY of them was found — recording
+      // a chain verdict for a request the chain never saw.
+      expect(found).toBeUndefined();
+      expect(seen).toEqual([]);
+    } finally {
+      await server.stop(true);
+    }
+  });
+
+  test("a transaction the chain FAILED is reported as failed, not confirmed", async () => {
+    const { url, server } = fakeIndexer({
+      abcd: { ...CONFIRMED, transactionResult: { status: "FAILURE" } },
+    });
+    try {
+      const found = await findLandedMidnightTransaction({
+        indexer: url,
+        identifiers: ["abcd"],
+      });
+      expect(found?.status).toBe(0);
+    } finally {
+      await server.stop(true);
+    }
+  });
+
+  test("PARTIAL_SUCCESS is not turned into a failure verdict", async () => {
+    const { url, server } = fakeIndexer({
+      abcd: { ...CONFIRMED, transactionResult: { status: "PARTIAL_SUCCESS" } },
+    });
+    try {
+      const found = await findLandedMidnightTransaction({
+        indexer: url,
+        identifiers: ["abcd"],
+      });
+      // The chain included it. Which segment did what is not something this
+      // layer can safely collapse into "your transaction failed".
+      expect(found?.status).toBe(1);
+    } finally {
+      await server.stop(true);
+    }
+  });
+
+  test("nothing on chain is `undefined`, which means charge as usual", async () => {
+    const { url, server } = fakeIndexer({});
+    try {
+      expect(
+        await findLandedMidnightTransaction({
+          indexer: url,
+          identifiers: ["abcd"],
+        }),
+      ).toBeUndefined();
+    } finally {
+      await server.stop(true);
+    }
+  });
+
+  test("an indexer that errors, or lies, is `undefined` too", async () => {
+    const failing = fakeIndexer({}, { status: 503 });
+    const garbage = fakeIndexer({}, { body: { data: { transactions: null } } });
+    const nonsense = fakeIndexer({}, { body: { errors: [{ message: "no" }] } });
+    try {
+      for (const indexer of [failing.url, garbage.url, nonsense.url]) {
+        expect(
+          await findLandedMidnightTransaction({
+            indexer,
+            identifiers: ["abcd"],
+          }),
+        ).toBeUndefined();
+      }
+      // An unreachable indexer is the case that matters most: during the very
+      // outage this feature exists for, the check must degrade to today's
+      // behaviour rather than to a false confirmation.
+      expect(
+        await findLandedMidnightTransaction({
+          indexer: "http://127.0.0.1:1/graphql",
+          identifiers: ["abcd"],
+          timeoutMs: 500,
+        }),
+      ).toBeUndefined();
+    } finally {
+      await failing.server.stop(true);
+      await garbage.server.stop(true);
+      await nonsense.server.stop(true);
+    }
+  });
+
+  test("a transaction with no block is not evidence of anything", async () => {
+    const { url, server } = fakeIndexer({
+      abcd: { hash: "aa".repeat(32), block: null },
+    });
+    try {
+      expect(
+        await findLandedMidnightTransaction({
+          indexer: url,
+          identifiers: ["abcd"],
+        }),
+      ).toBeUndefined();
+    } finally {
+      await server.stop(true);
+    }
+  });
+
+  test("with nothing to ask about, the indexer is not called at all", async () => {
+    const seen: Seen[] = [];
+    const { url, server } = fakeIndexer({}, { seen });
+    try {
+      expect(
+        await findLandedMidnightTransaction({ indexer: url, identifiers: [] }),
+      ).toBeUndefined();
+      expect(seen).toEqual([]);
+    } finally {
+      await server.stop(true);
+    }
+  });
+});
+
+describe("the identifiers a landed-check can watch for", () => {
+  test("a transaction's identifiers come back as bare lowercase hex", () => {
+    expect(
+      midnightTxIdentifiers({ identifiers: () => ["0xAABB", "ccdd"] }),
+    ).toEqual(["aabb", "ccdd"]);
+  });
+
+  test("bytes are hex-encoded, and duplicates collapse", () => {
+    expect(
+      midnightTxIdentifiers({
+        identifiers: () => [new Uint8Array([0xde, 0xad]), "dead"],
+      }),
+    ).toEqual(["dead"]);
+  });
+
+  test("anything that is not hex is dropped rather than guessed at", () => {
+    // A malformed offset is a query that answers nothing — and "nothing" is
+    // exactly what must not be mistaken for "it did not land".
+    expect(
+      midnightTxIdentifiers({ identifiers: () => ["zzzz", "abc", "", "ab"] }),
+    ).toEqual(["ab"]);
+  });
+
+  test("a transaction that cannot identify itself yields an empty list", () => {
+    expect(midnightTxIdentifiers({})).toEqual([]);
+    expect(midnightTxIdentifiers({ identifiers: () => [] })).toEqual([]);
+    expect(
+      midnightTxIdentifiers({
+        identifiers: () => {
+          throw new Error("wasm boundary");
+        },
+      }),
+    ).toEqual([]);
+  });
+
+  test("an iterable that is not an array still works", () => {
+    expect(
+      midnightTxIdentifiers({ identifiers: () => new Set(["aa", "bb"]) }),
+    ).toEqual(["aa", "bb"]);
+  });
+});
+
+describe("hash normalization", () => {
+  test("the indexer's 64-char hex form is produced from whatever we hold", () => {
+    expect(normalizeMidnightHash(`0x${"ab".repeat(32)}`)).toBe("ab".repeat(32));
+    expect(normalizeMidnightHash("ABCD")).toBe("abcd".padStart(64, "0"));
+    expect(normalizeMidnightHash(`ff${"ab".repeat(32)}`)).toBe("ab".repeat(32));
+  });
+});

--- a/packages/batcher/test/outage-parking-scenario.test.ts
+++ b/packages/batcher/test/outage-parking-scenario.test.ts
@@ -1,0 +1,356 @@
+// SC-3: a node outage, end to end, against the real storage backend.
+//
+// Every other file in this project tests one joint. This one runs the whole
+// chain the defect actually travelled — real `DatabaseStorage`, real
+// `createNewBatcher`, the real `probeNodeReachable`, the real
+// `buildWorkerBatchOutcome`, the real `BatchProcessor` — and asks the question
+// a poller would ask: what does `/input-status` say?
+//
+// Two shapes, both measured in 00017/00020:
+//
+//  1. OUTAGE BEFORE SUBMISSION (00017's Q-2). The node is down when the batch
+//     is built. Nothing reached the chain. Before this project, one charged
+//     retry per poll round meant ~3 seconds of downtime deleted the input and
+//     published `failed / RETRIES_EXHAUSTED` for a transaction that was never
+//     submitted — real input loss.
+//
+//  2. OUTAGE STRADDLING A LANDED SUBMISSION (00020's M13). The transaction
+//     landed, the receipt was lost, the row survived, the resubmission was
+//     refused because the spends were used. Before this project the request
+//     went terminal `failed / RETRIES_EXHAUSTED` while being CONFIRMED on
+//     chain — the store telling pollers the opposite of the truth.
+//
+// The adapter here is deliberately shaped like the balancing adapter — workers
+// under `Promise.allSettled`, so nothing ever throws out of `submitBatch` and
+// the thrown-channel parking path is unreachable — because that shape IS the
+// defect.
+
+import { expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { createNewBatcher } from "../core/batcher.ts";
+import { DatabaseStorage } from "../core/storage.ts";
+import { RETRIES_EXHAUSTED } from "../core/batch-processor.ts";
+import {
+  buildWorkerBatchOutcome,
+  findLandedMidnightTransaction,
+  probeNodeReachable,
+} from "../adapters/midnight-balancing-adapter.ts";
+import type { DefaultBatcherInput } from "../core/types.ts";
+
+const TARGET = "product-a";
+const NOW = Date.now();
+const LANDED_HASH = "ab".repeat(32);
+
+/** The verbatim wrapper 00017's Q-2 and 00020's M13 both recorded. */
+const SUBMIT_ERROR = "Transaction submission error";
+
+const makeInput = (nonce: string): DefaultBatcherInput => ({
+  addressType: 5,
+  address: "product-a-workload",
+  input: JSON.stringify({ nonce }),
+  timestamp: String(NOW),
+  signature: `0xsignature-${nonce}`,
+  target: TARGET,
+});
+
+interface Chain {
+  /** The node's JSON-RPC endpoint; stopping the server IS the outage. */
+  nodeUrl: string;
+  indexerUrl: string;
+  stopNode: () => Promise<void>;
+  /** Transactions the indexer will admit to knowing about. */
+  onChain: Set<string>;
+  stopAll: () => Promise<void>;
+}
+
+async function startChain(): Promise<Chain> {
+  const onChain = new Set<string>();
+  const node = Bun.serve({
+    port: 0,
+    fetch: async (request) => {
+      const body = await request.json() as { id?: unknown };
+      return Response.json({
+        jsonrpc: "2.0",
+        id: body.id,
+        result: { peers: 1, isSyncing: false, shouldHavePeers: true },
+      });
+    },
+  });
+  const indexer = Bun.serve({
+    port: 0,
+    fetch: async (request) => {
+      const body = await request.json() as {
+        variables: { offset: Record<string, string> };
+      };
+      const key = Object.values(body.variables.offset)[0];
+      return Response.json({
+        data: {
+          transactions: onChain.has(key)
+            ? [{
+              hash: LANDED_HASH,
+              block: { height: 4242 },
+              transactionResult: { status: "SUCCESS" },
+            }]
+            : [],
+        },
+      });
+    },
+  });
+  let nodeStopped = false;
+  const stopNode = async () => {
+    if (nodeStopped) return;
+    nodeStopped = true;
+    await node.stop(true);
+  };
+  return {
+    nodeUrl: `http://127.0.0.1:${node.port}`,
+    indexerUrl: `http://127.0.0.1:${indexer.port}`,
+    onChain,
+    stopNode,
+    stopAll: async () => {
+      await stopNode();
+      await indexer.stop(true);
+    },
+  };
+}
+
+interface AdapterScript {
+  /** What each worker does this round. */
+  outcome: "submit" | "refuse";
+  /** Swallow the receipt, as a lost/restarted confirmation would. */
+  loseReceipt?: boolean;
+}
+
+/**
+ * An adapter shaped like `MidnightBalancingAdapter`: per-worker pipelines under
+ * `Promise.allSettled`, a `BatchOutcome` return, and the SHIPPED classification
+ * and landed-check helpers rather than test re-implementations of them.
+ */
+function outageAdapter(chain: Chain, script: AdapterScript) {
+  return {
+    verifySignature: () => true,
+    validateInput: () => ({ valid: true }),
+    buildBatchData: (inputs: DefaultBatcherInput[]) =>
+      inputs.length === 0 ? null : { selectedInputs: inputs, data: { inputs } },
+    estimateBatchFee: () => 0n,
+    submitBatch: async (data: { inputs: DefaultBatcherInput[] }) => {
+      const results = await Promise.allSettled(
+        data.inputs.map(async () => {
+          if (script.outcome === "submit") return LANDED_HASH;
+          throw new Error(SUBMIT_ERROR);
+        }),
+      );
+      const nodeReachable =
+        results.some((result) => result.status === "rejected")
+          ? await probeNodeReachable(chain.nodeUrl, 2_000)
+          : undefined;
+      return buildWorkerBatchOutcome(
+        [],
+        data.inputs,
+        results as PromiseSettledResult<string>[],
+        nodeReachable,
+      );
+    },
+    findLandedTransaction: async (
+      input: DefaultBatcherInput,
+      context: { target: string; transactionHash?: string },
+    ) =>
+      await findLandedMidnightTransaction({
+        indexer: chain.indexerUrl,
+        // The M13 case: the batcher wrote the hash down before it died.
+        transactionHash: context.transactionHash,
+        timeoutMs: 2_000,
+      }),
+    waitForTransactionReceipt: async () => {
+      if (script.loseReceipt) {
+        throw new Error("receipt never arrived — the batcher was restarted");
+      }
+      return { hash: LANDED_HASH, blockNumber: 4242n, status: 1 };
+    },
+    getAccountAddress: () => "batcher",
+    getChainName: () => "midnight-like",
+    isReady: () => true,
+    getBlockNumber: async () => 4242n,
+  };
+}
+
+async function withBatcher(
+  script: AdapterScript,
+  fn: (ctx: {
+    batcher: ReturnType<typeof createNewBatcher>;
+    storage: DatabaseStorage;
+    chain: Chain;
+    script: AdapterScript;
+    cooldowns: number[];
+  }) => Promise<void>,
+): Promise<void> {
+  const chain = await startChain();
+  const dir = mkdtempSync(path.join(tmpdir(), "batcher-outage-"));
+  const storage = new DatabaseStorage({ dataDirectory: dir });
+  const batcher = createNewBatcher({
+    pollingIntervalMs: 1_000_000,
+    enableHttpServer: false,
+    enableEventSystem: false,
+    maxRetries: 3,
+    retryDelayMs: 10,
+  }, storage as any);
+  batcher.addBlockchainAdapter(TARGET, outageAdapter(chain, script) as any, {
+    criteriaType: "size",
+    maxBatchSize: 4,
+  });
+  await batcher.init({ startPolling: false });
+
+  // The processor calls `this.setTargetCooldown(...)` through the batcher, so
+  // overriding the method here observes exactly what it asked for.
+  const cooldowns: number[] = [];
+  const original = batcher.setTargetCooldown.bind(batcher);
+  batcher.setTargetCooldown = (target: string, ms: number) => {
+    cooldowns.push(ms);
+    original(target, ms);
+  };
+
+  try {
+    await fn({ batcher, storage, chain, script, cooldowns });
+  } finally {
+    await (batcher as any).gracefulShutdown().catch(() => {});
+    await storage.close().catch(() => {});
+    rmSync(dir, { recursive: true, force: true });
+    await chain.stopAll();
+  }
+}
+
+test("SC-3 shape 1: a node outage before submission parks every input, charges nothing, drops nothing", async () => {
+  await withBatcher({ outcome: "refuse" }, async (ctx) => {
+    const ids = await Promise.all(
+      ["a", "b", "c", "d"].map(async (nonce) =>
+        (await ctx.batcher.batchInput(makeInput(nonce), "no-wait")).requestId
+      ),
+    );
+
+    // The node goes away BEFORE anything is submitted. Nothing reaches the
+    // chain in this whole test; the counter delta would be zero.
+    await ctx.chain.stopNode();
+
+    const OUTAGE_ROUNDS = 6;
+    for (let round = 0; round < OUTAGE_ROUNDS; round++) {
+      await ctx.batcher.forceProcessBatches();
+    }
+
+    // Before this project: 6 rounds × 1 charge, `maxRetries: 3` → every input
+    // deleted by round 3 with `failed / RETRIES_EXHAUSTED`, for transactions
+    // the node never even saw.
+    const statuses = await Promise.all(
+      ids.map((id) => ctx.batcher.getRequestStatus(id)),
+    );
+    const drops = statuses.filter((s) => s?.errorCode === RETRIES_EXHAUSTED);
+    expect(drops.length).toBe(0);
+    expect(statuses.every((s) => s?.state !== "failed")).toBe(true);
+    expect(statuses.every((s) => s?.retryCount === 0)).toBe(true);
+
+    // Parked, and the target actually rested — one cooldown per round, each
+    // longer than the last, which is what stops a long outage from rebuilding
+    // the same doomed batch thousands of times.
+    expect(ctx.cooldowns.length).toBe(OUTAGE_ROUNDS);
+    for (let i = 1; i < ctx.cooldowns.length; i++) {
+      expect(ctx.cooldowns[i]).toBeGreaterThan(ctx.cooldowns[i - 1]);
+    }
+    expect(ctx.cooldowns[0]).toBe(1000);
+
+    // The rows are still there, which is the whole point: nothing was lost.
+    expect((await ctx.storage.getAllInputs()).length).toBe(4);
+
+    // The node comes back. The identical inputs, never charged, now confirm.
+    ctx.script.outcome = "submit";
+    await ctx.batcher.forceProcessBatches();
+
+    const settled = await Promise.all(
+      ids.map((id) => ctx.batcher.getRequestStatus(id)),
+    );
+    expect(settled.every((s) => s?.state === "confirmed")).toBe(true);
+    expect(settled.every((s) => s?.transactionHash === LANDED_HASH)).toBe(true);
+    expect(settled.every((s) => s?.errorCode !== RETRIES_EXHAUSTED)).toBe(true);
+  });
+}, 120_000);
+
+test("SC-3 shape 2 (M13): a request whose transaction landed reads CONFIRMED, not retry-exhausted", async () => {
+  await withBatcher({ outcome: "submit", loseReceipt: true }, async (ctx) => {
+    const { requestId } = await ctx.batcher.batchInput(makeInput("m13"), "no-wait");
+
+    // Round 1 submits successfully and the transaction lands — but the receipt
+    // never comes back, exactly as a restart mid-confirmation loses it. The row
+    // survives because rows are only removed after a receipt.
+    await ctx.batcher.forceProcessBatches().catch(() => {});
+    ctx.chain.onChain.add(LANDED_HASH);
+
+    const midFlight = await ctx.batcher.getRequestStatus(requestId);
+    expect(midFlight?.state).toBe("submitted");
+    expect(midFlight?.transactionHash).toBe(LANDED_HASH);
+    expect((await ctx.storage.getAllInputs()).length).toBe(1);
+
+    // Round 2 re-picks the surviving row. The node is UP, so the probe says so
+    // and the refusal is a real verdict — the spends are already used. This is
+    // precisely where the batcher used to start charging a confirmed request.
+    ctx.script.outcome = "refuse";
+    await ctx.batcher.forceProcessBatches();
+
+    const status = await ctx.batcher.getRequestStatus(requestId);
+    expect(status?.state).toBe("confirmed");
+    expect(status?.errorCode).not.toBe(RETRIES_EXHAUSTED);
+    expect(status?.transactionHash).toBe(LANDED_HASH);
+    expect(status?.blockNumber).toBe(4242n);
+    expect(status?.retryCount).toBe(0);
+    // Reconciled means resolved: the row is gone, so it cannot be re-picked.
+    expect((await ctx.storage.getAllInputs()).length).toBe(0);
+  });
+}, 120_000);
+
+test("SC-3 negative control: with nothing on chain, the SAME sequence still exhausts and drops", async () => {
+  // Without this, the case above could pass because the batcher had quietly
+  // stopped charging anything at all. Here the indexer knows about no
+  // transaction, so the identical path must reach the identical old ending.
+  await withBatcher({ outcome: "submit", loseReceipt: true }, async (ctx) => {
+    const { requestId } = await ctx.batcher.batchInput(makeInput("ctl"), "no-wait");
+
+    await ctx.batcher.forceProcessBatches().catch(() => {});
+    // NOTE: `chain.onChain` is left EMPTY — the transaction never landed.
+    ctx.script.outcome = "refuse";
+
+    for (let round = 0; round < 3; round++) {
+      await ctx.batcher.forceProcessBatches();
+    }
+
+    const status = await ctx.batcher.getRequestStatus(requestId);
+    expect(status?.state).toBe("failed");
+    expect(status?.errorCode).toBe(RETRIES_EXHAUSTED);
+    expect((await ctx.storage.getAllInputs()).length).toBe(0);
+  });
+}, 120_000);
+
+test("SC-3/FR-4: an outage that never ends still bounds a deterministically doomed input", async () => {
+  // The masking risk stated plainly. If parking were unbounded, an input that
+  // is in fact never going to succeed would sit uncharged for the life of the
+  // process. It parks, then it pays.
+  await withBatcher({ outcome: "refuse" }, async (ctx) => {
+    const { requestId } = await ctx.batcher.batchInput(makeInput("doomed"), "no-wait");
+    await ctx.chain.stopNode();
+
+    let terminal = await ctx.batcher.getRequestStatus(requestId);
+    let rounds = 0;
+    while (rounds < 200 && terminal?.state !== "failed") {
+      await ctx.batcher.forceProcessBatches();
+      terminal = await ctx.batcher.getRequestStatus(requestId);
+      rounds++;
+    }
+
+    expect(terminal?.state).toBe("failed");
+    expect(terminal?.errorCode).toBe(RETRIES_EXHAUSTED);
+    // Bounded, and generously: 50 free parks and then the ordinary 3-retry
+    // budget. The escalating cooldown means those 53 rounds span more than
+    // three quarters of an hour of real downtime.
+    expect(rounds).toBeLessThanOrEqual(60);
+    expect(rounds).toBeGreaterThan(50);
+  });
+}, 180_000);

--- a/packages/batcher/test/receipt-reconciliation.test.ts
+++ b/packages/batcher/test/receipt-reconciliation.test.ts
@@ -1,0 +1,473 @@
+// FR-3: never record RETRIES_EXHAUSTED for a transaction that is on chain.
+//
+// This is 00020's M13 in miniature. A batcher is restarted while a batch is in
+// flight; the transactions land, but the receipts never come back, so the rows
+// survive. They are re-picked, the resubmission is refused because the spends
+// are already used, three retries are charged, the rows are dropped — and the
+// tracking store publishes `failed / RETRIES_EXHAUSTED` for four requests the
+// chain CONFIRMED. Pollers are then told the exact opposite of what happened.
+//
+// The fix asks before it charges: an input whose earlier submission is findable
+// on chain is confirmed, removed and resolved instead. The adapter owns the
+// "did it land" question, because only it knows what its payloads mean.
+
+import { describe, expect, test } from "bun:test";
+import {
+  BatchProcessor,
+  ONCHAIN_FAILED,
+  RETRIES_EXHAUSTED,
+} from "../core/batch-processor.ts";
+import { computeRequestId } from "../core/request-id.ts";
+import type {
+  RequestState,
+  RequestStatusRecord,
+  RequestTransitionDetail,
+  TransitionOutcome,
+} from "../core/storage.ts";
+import type { DefaultBatcherInput } from "../core/types.ts";
+import type {
+  BatchSubmitResult,
+  BlockchainAdapter,
+  BlockchainTransactionReceipt,
+  LandedTransaction,
+} from "../adapters/adapter.ts";
+
+const TARGET = "product-a";
+
+function makeInput(address: string): DefaultBatcherInput {
+  return {
+    addressType: 1 as DefaultBatcherInput["addressType"],
+    input: `input-from-${address}`,
+    address,
+    timestamp: "2026-08-25T00:00:00.000Z",
+    target: TARGET,
+  };
+}
+
+interface Recorded {
+  requestId: string;
+  state: RequestState;
+  detail?: RequestTransitionDetail;
+}
+
+interface HarnessOptions {
+  /** Pre-existing status records, keyed by request id — the pre-restart state. */
+  statuses?: Map<string, Partial<RequestStatusRecord>>;
+  /** Drop `getStatus` entirely: a tracking backend that predates this method. */
+  withoutGetStatus?: boolean;
+  /** Make the status lookup blow up. */
+  statusError?: Error;
+  /** Make row removal blow up. */
+  removeError?: Error;
+  /** Which inputs storage drops when charged a retry. */
+  dropOnRetry?: (inputs: DefaultBatcherInput[]) => DefaultBatcherInput[];
+}
+
+function makeHarness(options: HarnessOptions = {}) {
+  const recorded: Recorded[] = [];
+  const removed: DefaultBatcherInput[] = [];
+  const charged: DefaultBatcherInput[] = [];
+  /** Every step in order, so ordering claims are measured and not asserted twice. */
+  const journal: string[] = [];
+  const settled = new Map<string, { status: "resolved" | "rejected"; value: any }>();
+  const callbacks = new Map<string, {
+    resolve: (result: any) => void;
+    reject: (error: Error) => void;
+    timeoutId: ReturnType<typeof setTimeout>;
+  }>();
+
+  const storage: Record<string, unknown> = {
+    removeProcessedInputs: async (inputs: DefaultBatcherInput[]) => {
+      if (options.removeError) throw options.removeError;
+      journal.push(`remove:${inputs.map((i) => i.address).join("+")}`);
+      removed.push(...inputs);
+    },
+    incrementRetryCount: async (inputs: DefaultBatcherInput[]) => {
+      journal.push(`charge:${inputs.map((i) => i.address).join("+")}`);
+      charged.push(...inputs);
+      return options.dropOnRetry?.(inputs) ?? [];
+    },
+    recordTransition: async (
+      requestId: string,
+      state: RequestState,
+      detail?: RequestTransitionDetail,
+    ): Promise<TransitionOutcome> => {
+      journal.push(`record:${state}`);
+      recorded.push({ requestId, state, detail });
+      return {
+        applied: true,
+        record: { requestId, state } as RequestStatusRecord,
+      };
+    },
+  };
+  if (!options.withoutGetStatus) {
+    storage.getStatus = async (
+      requestId: string,
+    ): Promise<RequestStatusRecord | undefined> => {
+      if (options.statusError) throw options.statusError;
+      journal.push("getStatus");
+      const found = options.statuses?.get(requestId);
+      return found === undefined
+        ? undefined
+        : { requestId, state: "submitted", ...found } as RequestStatusRecord;
+    };
+  }
+
+  const processor = new BatchProcessor<DefaultBatcherInput>({
+    emitStateTransition: async () => {},
+    // deno-lint-ignore no-explicit-any
+    storage: storage as any,
+    submissionCallbacks: callbacks,
+    waitForEffectStreamProcessed: async () => null,
+    getCallbackKey: (input) => input.address,
+    getRetryPolicy: () => ({ maxRetries: 3, retryDelayMs: 10 }),
+    setTargetCooldown: () => {},
+  });
+
+  const waitOn = (input: DefaultBatcherInput) => {
+    const key = input.address;
+    const promise = new Promise<{ ok?: unknown; err?: unknown }>((resolve) => {
+      callbacks.set(key, {
+        resolve: (value) => {
+          settled.set(key, { status: "resolved", value });
+          resolve({ ok: value });
+        },
+        reject: (value) => {
+          settled.set(key, { status: "rejected", value });
+          resolve({ err: value });
+        },
+        timeoutId: setTimeout(() => {}, 60_000),
+      });
+    });
+    return promise;
+  };
+
+  const statesOf = (input: DefaultBatcherInput) =>
+    recorded
+      .filter((r) => r.requestId === computeRequestId(input, TARGET))
+      .map((r) => r.state);
+  const detailOf = (input: DefaultBatcherInput, state: RequestState) =>
+    recorded.find((r) =>
+      r.requestId === computeRequestId(input, TARGET) && r.state === state
+    )?.detail;
+
+  return {
+    processor,
+    recorded,
+    removed,
+    charged,
+    journal,
+    settled,
+    waitOn,
+    statesOf,
+    detailOf,
+  };
+}
+
+/**
+ * An adapter whose submission FAILS for every input — the post-restart shape —
+ * and which can answer whether that input's earlier attempt is on chain.
+ */
+function makeAdapter(
+  inputs: DefaultBatcherInput[],
+  landed: Map<string, LandedTransaction>,
+  options: {
+    findError?: Error;
+    withoutHook?: boolean;
+    throwInstead?: Error;
+    seenContexts?: Array<{ address: string; transactionHash?: string }>;
+  } = {},
+): BlockchainAdapter<any> {
+  const submit = async (): Promise<BatchSubmitResult<DefaultBatcherInput>> => {
+    if (options.throwInstead) throw options.throwInstead;
+    return {
+      failed: inputs.map((input) => ({
+        input,
+        error: "Transaction submission error",
+      })),
+    };
+  };
+
+  const adapter: BlockchainAdapter<any> = {
+    buildBatchData: () => ({
+      selectedInputs: inputs,
+      data: { selectedInputs: [...inputs] },
+    }),
+    estimateBatchFee: () => "1",
+    submitBatch: submit,
+    waitForTransactionReceipt: async (): Promise<
+      BlockchainTransactionReceipt
+    > => {
+      throw new Error("no receipt should ever be awaited in these cases");
+    },
+    getAccountAddress: () => "batcher",
+    getChainName: () => "test",
+    isReady: () => true,
+    getBlockNumber: async () => 1n,
+  };
+
+  if (!options.withoutHook) {
+    adapter.findLandedTransaction = async (input, context) => {
+      options.seenContexts?.push({
+        address: input.address,
+        transactionHash: context.transactionHash,
+      });
+      if (options.findError) throw options.findError;
+      return landed.get(input.address);
+    };
+  }
+  return adapter;
+}
+
+describe("FR-3 — a request whose transaction landed is never retry-exhausted", () => {
+  test("M13's shape: the landed input is confirmed, removed and resolved — not charged", async () => {
+    const landed = makeInput("landed");
+    const h = makeHarness({
+      statuses: new Map([[computeRequestId(landed, TARGET), {
+        transactionHash: "0xearlier",
+      }]]),
+    });
+    const waiting = h.waitOn(landed);
+    const adapter = makeAdapter([landed], new Map([
+      ["landed", { hash: "0xearlier", blockNumber: 4242n, status: 1 }],
+    ]));
+
+    await h.processor.processBatchForTarget(adapter, TARGET, [landed]);
+
+    // The whole point: nothing was charged, so nothing can ever be dropped.
+    expect(h.charged).toEqual([]);
+    expect(h.statesOf(landed)).toEqual(["batching", "confirmed"]);
+    expect(h.detailOf(landed, "confirmed")).toEqual({
+      transactionHash: "0xearlier",
+      blockNumber: 4242n,
+    });
+    expect(h.removed).toEqual([landed]);
+    const settled = await waiting;
+    expect(settled.err).toBeUndefined();
+    expect((settled.ok as BlockchainTransactionReceipt).hash).toBe("0xearlier");
+    expect((settled.ok as BlockchainTransactionReceipt).blockNumber).toBe(4242n);
+  });
+
+  test("the verdict is written BEFORE the row is removed (00011 F-P3.14)", async () => {
+    const landed = makeInput("landed");
+    const h = makeHarness();
+    const adapter = makeAdapter([landed], new Map([
+      ["landed", { hash: "0xearlier", blockNumber: 7n }],
+    ]));
+
+    await h.processor.processBatchForTarget(adapter, TARGET, [landed]);
+
+    // Under kill -9 record-then-remove leaves `confirmed` with a surviving row,
+    // which the append-only guard repairs on the next pick. Remove-then-record
+    // leaves an orphaned in-flight record nothing will ever resolve.
+    const confirmedAt = h.journal.indexOf("record:confirmed");
+    const removedAt = h.journal.indexOf("remove:landed");
+    expect(confirmedAt).toBeGreaterThanOrEqual(0);
+    expect(removedAt).toBeGreaterThanOrEqual(0);
+    expect(confirmedAt).toBeLessThan(removedAt);
+  });
+
+  test("the adapter is handed the hash the earlier submission recorded", async () => {
+    const landed = makeInput("landed");
+    const seenContexts: Array<{ address: string; transactionHash?: string }> = [];
+    const h = makeHarness({
+      statuses: new Map([[computeRequestId(landed, TARGET), {
+        transactionHash: "0xrecorded",
+      }]]),
+    });
+    const adapter = makeAdapter([landed], new Map(), { seenContexts });
+
+    await h.processor.processBatchForTarget(adapter, TARGET, [landed]);
+
+    expect(seenContexts).toEqual([{
+      address: "landed",
+      transactionHash: "0xrecorded",
+    }]);
+  });
+
+  test("only the landed input is spared; its neighbours still pay", async () => {
+    const landed = makeInput("landed");
+    const lost = makeInput("lost");
+    const h = makeHarness();
+    const adapter = makeAdapter([landed, lost], new Map([
+      ["landed", { hash: "0xearlier", blockNumber: 9n }],
+    ]));
+
+    await h.processor.processBatchForTarget(adapter, TARGET, [landed, lost]);
+
+    expect(h.removed).toEqual([landed]);
+    expect(h.charged).toEqual([lost]);
+    expect(h.statesOf(landed)).toEqual(["batching", "confirmed"]);
+    expect(h.statesOf(lost)).toEqual(["batching"]);
+  });
+
+  test("a transaction the chain mined and FAILED is recorded ONCHAIN_FAILED, not exhausted", async () => {
+    const reverted = makeInput("reverted");
+    const h = makeHarness();
+    const waiting = h.waitOn(reverted);
+    const adapter = makeAdapter([reverted], new Map([
+      ["reverted", { hash: "0xreverted", blockNumber: 11n, status: 0 }],
+    ]));
+
+    await h.processor.processBatchForTarget(adapter, TARGET, [reverted]);
+
+    expect(h.charged).toEqual([]);
+    expect(h.detailOf(reverted, "failed")?.errorCode).toBe(ONCHAIN_FAILED);
+    expect(h.detailOf(reverted, "failed")?.errorCode).not.toBe(
+      RETRIES_EXHAUSTED,
+    );
+    const settled = await waiting;
+    expect((settled.err as Error).message).toContain("0xreverted");
+  });
+
+  test("a landed input found on the THROWN channel is spared too", async () => {
+    const landed = makeInput("landed");
+    const h = makeHarness();
+    const adapter = makeAdapter([landed], new Map([
+      ["landed", { hash: "0xearlier", blockNumber: 3n }],
+    ]), { throwInstead: new Error("Transaction submission error") });
+
+    await h.processor.processBatchForTarget(adapter, TARGET, [landed])
+      .catch(() => {});
+
+    expect(h.charged).toEqual([]);
+    expect(h.statesOf(landed)).toEqual(["batching", "confirmed"]);
+    expect(h.removed).toEqual([landed]);
+  });
+});
+
+describe("FR-3 — the check can never make things worse", () => {
+  test("an adapter without the hook behaves EXACTLY as it did before", async () => {
+    const lost = makeInput("lost");
+    const h = makeHarness();
+    const adapter = makeAdapter([lost], new Map(), { withoutHook: true });
+
+    await h.processor.processBatchForTarget(adapter, TARGET, [lost]);
+
+    expect(h.charged).toEqual([lost]);
+    expect(h.removed).toEqual([]);
+    expect(h.journal).not.toContain("getStatus");
+  });
+
+  test("a hook that throws charges exactly as before", async () => {
+    const lost = makeInput("lost");
+    const h = makeHarness();
+    const adapter = makeAdapter([lost], new Map(), {
+      findError: new Error("indexer unreachable"),
+    });
+
+    await h.processor.processBatchForTarget(adapter, TARGET, [lost]);
+
+    expect(h.charged).toEqual([lost]);
+  });
+
+  test("a status lookup that throws still lets the check run", async () => {
+    const landed = makeInput("landed");
+    const seenContexts: Array<{ address: string; transactionHash?: string }> = [];
+    const h = makeHarness({ statusError: new Error("status store down") });
+    const adapter = makeAdapter([landed], new Map([
+      ["landed", { hash: "0xfound-by-identifier" }],
+    ]), { seenContexts });
+
+    await h.processor.processBatchForTarget(adapter, TARGET, [landed]);
+
+    // No recorded hash is not the same as no evidence: the adapter may still
+    // watch the input's own identifiers, which is the case where the batcher
+    // died BEFORE it could write the hash down.
+    expect(seenContexts).toEqual([{ address: "landed", transactionHash: undefined }]);
+    expect(h.charged).toEqual([]);
+    expect(h.detailOf(landed, "confirmed")?.transactionHash).toBe(
+      "0xfound-by-identifier",
+    );
+  });
+
+  test("a queue-only backend with no getStatus still reconciles", async () => {
+    const landed = makeInput("landed");
+    const h = makeHarness({ withoutGetStatus: true });
+    const adapter = makeAdapter([landed], new Map([
+      ["landed", { hash: "0xfound" }],
+    ]));
+
+    await h.processor.processBatchForTarget(adapter, TARGET, [landed]);
+
+    expect(h.charged).toEqual([]);
+    expect(h.removed).toEqual([landed]);
+  });
+
+  test("a removal that fails still leaves the request confirmed, never exhausted", async () => {
+    const landed = makeInput("landed");
+    const h = makeHarness({ removeError: new Error("storage down") });
+    const adapter = makeAdapter([landed], new Map([
+      ["landed", { hash: "0xearlier", blockNumber: 5n }],
+    ]));
+
+    await h.processor.processBatchForTarget(adapter, TARGET, [landed]);
+
+    expect(h.statesOf(landed)).toEqual(["batching", "confirmed"]);
+    // The row survives and will be re-picked — and will be reconciled again,
+    // which is self-healing. What must never happen is that it gets charged.
+    expect(h.charged).toEqual([]);
+  });
+
+  test("nothing is asked when there is nothing to charge", async () => {
+    const fine = makeInput("fine");
+    const seenContexts: Array<{ address: string; transactionHash?: string }> = [];
+    const h = makeHarness();
+    const adapter = makeAdapter([fine], new Map(), { seenContexts });
+    adapter.submitBatch = async () => ({ hash: "0xok", submitted: [fine] });
+    adapter.waitForTransactionReceipt = async () => ({
+      hash: "0xok",
+      blockNumber: 1n,
+      status: 1,
+    });
+
+    await h.processor.processBatchForTarget(adapter, TARGET, [fine]);
+
+    expect(seenContexts).toEqual([]);
+    expect(h.statesOf(fine)).toEqual(["batching", "submitted", "confirmed"]);
+  });
+});
+
+describe("FR-3 — the per-input hash the reconciliation depends on", () => {
+  test("a multi-transaction batch records each input's OWN hash at submit time", async () => {
+    // A comma-joined batch hash is not evidence about an individual input: if
+    // `submitted` recorded it, a later landed-check keyed on that field would
+    // confirm every input in the batch the moment ANY of them was found.
+    const a = makeInput("a");
+    const b = makeInput("b");
+    const h = makeHarness();
+    const adapter = makeAdapter([a, b], new Map());
+    adapter.submitBatch = async () => ({
+      hash: "0xhash-a,0xhash-b",
+      submitted: [a, b],
+    });
+    adapter.waitForTransactionReceipt = async () => ({
+      hash: "0xhash-a,0xhash-b",
+      blockNumber: 2n,
+      status: 1,
+    });
+
+    await h.processor.processBatchForTarget(adapter, TARGET, [a, b]);
+
+    expect(h.detailOf(a, "submitted")?.transactionHash).toBe("0xhash-a");
+    expect(h.detailOf(b, "submitted")?.transactionHash).toBe("0xhash-b");
+  });
+
+  test("a shared batch hash is still shared by everyone in it", async () => {
+    const a = makeInput("a");
+    const b = makeInput("b");
+    const h = makeHarness();
+    const adapter = makeAdapter([a, b], new Map());
+    adapter.submitBatch = async () => ({ hash: "0xshared", submitted: [a, b] });
+    adapter.waitForTransactionReceipt = async () => ({
+      hash: "0xshared",
+      blockNumber: 2n,
+      status: 1,
+    });
+
+    await h.processor.processBatchForTarget(adapter, TARGET, [a, b]);
+
+    expect(h.detailOf(a, "submitted")?.transactionHash).toBe("0xshared");
+    expect(h.detailOf(b, "submitted")?.transactionHash).toBe("0xshared");
+  });
+});


### PR DESCRIPTION
Fixes **00017's Q-2** and the defect **00020's M13** observed live: a node outage is charged to the caller's retry budget instead of parking the target, and a request whose transaction already landed is recorded `failed / RETRIES_EXHAUSTED`.

Spec: `spec/00021-outage-parking-reconciliation.md` (user decision D7-A+). Base `claude/multi-batcher-sdk-v2` @ `d39fdba5`. **Changes are confined to `packages/batcher/**`.**

## The two defects, both measured

**1. An outage before submission deleted user input.** `isInfraFailure` is consulted in exactly one place — the catch around `adapter.submitBatch` — and `MidnightBalancingAdapter` runs its workers under `Promise.allSettled`, so no per-worker error can ever escape as a throw. Every outage therefore arrived on the *returned* `BatchOutcome` channel, which had no infra check at all: `retryable` was logged and forgotten, `failed` was charged unconditionally. At one charged retry per poll round against a default `maxRetries: 3`, **~3 seconds of node downtime deleted the input** and published `failed / RETRIES_EXHAUSTED` for a transaction the node never saw.

**2. An outage straddling a landed submission published the opposite of the truth.** A restart mid-flight loses receipts but not rows. The rows are re-picked, the resubmission is refused because the spends are already used, three retries are charged, the rows are dropped — and a request the chain **CONFIRMED** goes terminal `failed`. 00020 captured this with an on-chain counter proving all four transactions landed.

Both violate documented behaviour: 00011's "infra failures park inputs uncharged with a target cooldown", and `BatchInputDeferral`'s own doc — *a user's retry budget exists to bound bad inputs, not to absorb our outages*.

## What changed

**Classification asks the node; it does not read the error.** The observed failure is the string `"Transaction submission error"` — the SDK's generic wrapper around an unreachable node, a dead socket, and an already-spent input alike, so no regex can separate an outage from a verdict. `classifyWorkerFailure` now takes the verdict of a cheap JSON-RPC liveness probe as an optional third argument: **one probe per batch**, fired only when the batch actually contains an unrecognized failure, against the node URL the adapter already has (a Midnight node serves JSON-RPC over HTTP on its WebSocket port — the template's own compose healthcheck proves it). A node that answers *even with a JSON-RPC error* counts as reachable, so an unexpected RPC surface degrades to today's behaviour rather than parking everything. Typed channels are untouched, and omitting the argument reproduces the old default branch exactly.

**Parking is additive and bounded.** `BatchInputDeferral.infra` marks a deferral as our environment: the row stays uncharged *and* the target rests, instead of rebuilding and re-proving the same doomed batch every poll round. The processor owns the schedule (it is the only party that knows how many rounds in a row this input has failed) and backs off 1s, 2s, 4s … capped at 60s, reset the moment the input is carried. `BatchOutcome.cooldownMs` lets an adapter that knows its own chain override it. After `MAX_CONSECUTIVE_INFRA_PARKS` (50) an input is charged anyway, so a misclassification cannot hold a doomed input uncharged forever — with the backoff that bound is upwards of 45 minutes of continuous downtime.

**Reconciliation asks the chain before charging.** The optional `findLandedTransaction(input, { target, transactionHash })` adapter hook is consulted on *every* charge path. A hit is recorded `confirmed` with its hash and block, the row removed and the caller resolved — the ordinary confirmation path, with the verdict written **before** removal per 00011's F-P3.14. No hook, a throw, or an unreachable indexer all degrade to charging exactly as before. The Midnight implementation asks the indexer by the transaction's own watchable identifiers first and by a recorded hash second; the query and both offset shapes were validated against a real `indexer-standalone:4.3.2` schema.

**One soundness fix this depends on.** The `submitted` transition recorded the batch's whole comma-joined hash for *every* input, so a landed-check keyed on that field would have confirmed all four inputs of a batch the moment any one was found — a chain verdict for a request the chain never saw. It now records each input's **own** hash by the same split rule the receipt path already uses, and the adapter refuses a comma-bearing hash outright.

## Verification

| gate | result |
|---|---|
| Full suite, PgLite | **677 pass / 9 skip / 0 fail** (base `d39fdba5`: 609/9/0) |
| Full suite, PostgreSQL 16 | **744 pass / 0 fail** (base: 676/0) |
| Delta | **+68 on both backends** = 60 new cases in 4 new files + 8 appended to `batch-processor.test.ts`. Failure set EMPTY on both sides. |
| Typecheck | exit 1, 11 errors, **all 11 reproduced byte-identically on the stashed base tree**; zero new diagnostics |
| `bun.lock` | diff empty |

**End-to-end outage scenario** against the real `DatabaseStorage`, using the shipped probe and classifier (not stubs), with the outage induced by stopping a real server on a real socket:

- *Outage before submission*: 4 inputs, 6 rounds — `drops=0`, zero `RETRIES_EXHAUSTED`, `retryCount=0` on all four, all rows retained, 6 strictly increasing cooldowns starting at 1000 ms. Node returns and the same four inputs confirm, still never charged.
- *Straddled submission*: the request reads **`confirmed`** with its hash, `blockNumber`, `retryCount: 0` and the row removed — after first pinning `submitted` + hash mid-flight.
- *Negative control*: with nothing on chain the identical sequence still ends `failed / RETRIES_EXHAUSTED`, so the case above cannot pass by the batcher having quietly stopped charging.
- *FR-4 under a permanent outage*: terminates in >50 and ≤60 rounds.

The probe was also exercised against the real `midnightntwrk/midnight-node:1.0.0` image with container state verified via `docker inspect` at each step (the M8 `docker pause` hazard): `true` → stop → `false` → start → `true`, ~30 ms per probe.

## Known-not-fixed: 00017's M13 still reports `fail`

Run four times from the templates clone with **zero edits** to it (`git status` empty and `TESTING-RESULTS.md` sha256 unchanged before and after), against a batcher built from this branch. It fails on the same clause as before, and the batcher's own log states why:

```
Cannot tell whether an input for target product-a already landed: it yielded no
watchable identifiers and no earlier transaction hash was recorded. It will be
charged a retry, which is the pre-existing behaviour.
```

Both of FR-3's evidence sources are empty in M13's exact timing. The restart lands *inside* `submitTransaction` — `✅ Submitted` appears **zero** times in the pre-restart log while all four workers reach `Submitting (hash: …)` — so `submitBatch` never returns and no hash is ever recorded. And the template's payloads yield no watchable identifiers, which is the same root cause as M14's `dup=false` and is under separate investigation. The mechanism itself is proven end to end by the scenario above; on this particular workload it correctly falls back to the pre-existing behaviour rather than guessing.

## Adapter audit (FR-5) — recorded, not fixed

Every other adapter in the package returns a bare `BlockchainHash`, so their failures throw and they all reach the pre-existing parking path; `MidnightBalancingAdapter` was the only one on the `BatchOutcome` contract and therefore the only one with this trap. Two follow-ups, neither a regression introduced here: **solana** swallows each transport error and throws a constant that matches nothing in the regex, so its RPC outages are charged (~3-line fix, over the one-line bar set for this audit); **evm-contract / effectstream-l2** match viem's `fetch failed` but not its timeout text.

**FR-6 decision: the `isInfraFailure` regex is deliberately left alone.** Adding `"Transaction submission error"` would be unsound — it is a generic wrapper, so parking on it would strand genuinely doomed inputs on a path that has no park budget — and it would be dead code, since the adapter that produces that string cannot reach that regex's only call site.

## Breaking changes

**None.** Every addition is optional and feature-detected: an adapter that sets neither `infra` nor `cooldownMs` and implements no `findLandedTransaction` behaves exactly as before, as asserted by dedicated back-compat cases. The one visible behaviour change is that the `submitted` status of a multi-transaction batch now carries the input's own hash instead of the batch's comma-joined list — strictly more correct, and already what `confirmed` recorded.

**Do not merge without review.**
