### PR TITLE
fix(batcher): call the ledger's accessors ON the transaction — restore Midnight dedup

### DIFF
--- a/packages/batcher/README.md
+++ b/packages/batcher/README.md
@@ -396,7 +396,14 @@ Where the key comes from is a per-adapter decision:
   during validation, which already deserializes the transaction.
 - **Custom adapters**: implement `getReplayKey(input)`. Return `undefined` to
   disable dedup for that input; the batcher warns once per target that
-  submissions there have no duplicate protection.
+  submissions there have no duplicate protection, and says which of the two
+  cases it is — no hook at all, or a hook that answered `undefined`.
+
+  If your key comes from WASM bindings (ledger, wallet, anything wasm-bindgen
+  generated), call their accessors **on** the object — `tx.identifiers()`, or
+  `fn.call(tx)` — never detached. Such a method reads `this.__wbg_ptr` first, so
+  a detached call throws before it reaches the chain code, and a `try/catch`
+  around it turns that into "no key" for every transaction you will ever see.
 
 Note that a single signature reused across two targets is one paid request, not
 two. Real wallets do not do this — the default signing message includes the

--- a/packages/batcher/adapters/midnight-replay-key.ts
+++ b/packages/batcher/adapters/midnight-replay-key.ts
@@ -51,17 +51,91 @@ function encodePart(value: unknown): string {
   }
 }
 
-/** Call a WASM accessor without letting its failure become the caller's. */
-function attempt<R>(fn: (() => R) | undefined): R | undefined {
-  if (typeof fn !== "function") return undefined;
+/** What a single accessor had to say, and why it could not say it. */
+interface Attempt<R> {
+  /** The boundary's answer, or `undefined` when there was none. */
+  value: R | undefined;
+  /** Present only when the accessor THREW — the message it threw with. */
+  failure?: string;
+}
+
+/**
+ * Call a WASM accessor ON its transaction, without letting a failure become the
+ * caller's.
+ *
+ * The receiver is the whole point. A wasm-bindgen method's first act is to read
+ * `this.__wbg_ptr`, so calling it detached — `const fn = tx.identifiers; fn()` —
+ * throws a `TypeError` before it reaches the ledger at all. That is a bug in
+ * the CALL, not a boundary that cannot answer, and it is exactly what used to
+ * happen here: the catch below dutifully swallowed our own mistake and reported
+ * "this spend cannot identify itself" for every real Midnight transaction ever
+ * submitted (00020 F-1.10a). Hence `fn.call(tx)`.
+ *
+ * The catch stays, because GENUINE failures are real and routine — an unproven
+ * transaction has no `transactionHash()`, and the bindings say so by throwing.
+ */
+function attempt<R>(
+  tx: ReplayIdentifiableTx,
+  fn: (() => R) | undefined,
+): Attempt<R> {
+  if (typeof fn !== "function") return { value: undefined };
   try {
-    return fn();
-  } catch {
+    return { value: fn.call(tx) };
+  } catch (error) {
     // A boundary that cannot answer is not an error here: the caller degrades
     // to a weaker key, or to no dedup at all. Refusing the input instead would
-    // punish a user for our inability to fingerprint their transaction.
-    return undefined;
+    // punish a user for our inability to fingerprint their transaction. The
+    // reason is kept so the degradation can at least be SAID out loud.
+    return {
+      value: undefined,
+      failure: error instanceof Error ? error.message : String(error),
+    };
   }
+}
+
+/**
+ * How many distinct derivation failures are worth a line before the module goes
+ * quiet. The failure this exists to catch is systematic — one line names it —
+ * and an unbounded set of remembered reasons would be a leak with a log
+ * attached.
+ */
+export const REPLAY_KEY_FAILURE_LOG_LIMIT = 8;
+
+/** Reasons already reported, so a per-transaction fault is not a per-call log. */
+const reportedFailures = new Set<string>();
+
+/** Test seam: forget what has already been reported. */
+export function __resetReplayKeyDerivationLog(): void {
+  reportedFailures.clear();
+}
+
+/**
+ * Say, once per distinct reason, that a transaction could not be fingerprinted
+ * at all.
+ *
+ * Silence is what let the detached-receiver bug survive from Phase 3 to 00017's
+ * M14: every submission through the balancing adapter lost its replay key and
+ * nothing anywhere said so. Only THROWN failures are reported — a transaction
+ * that simply has no identifiers and no hash is the documented duck-typed case,
+ * not a fault, and warning about it would bury the signal in the noise.
+ *
+ * Bounded by reason rather than by call, because a systematic fault produces
+ * one reason and a flood of transactions.
+ */
+function reportDerivationFailure(reasons: Array<string | undefined>): void {
+  const said = reasons.filter((r): r is string => r !== undefined);
+  if (said.length === 0) return;
+  const signature = said.join(" | ");
+  if (reportedFailures.has(signature)) return;
+  if (reportedFailures.size >= REPLAY_KEY_FAILURE_LOG_LIMIT) return;
+  reportedFailures.add(signature);
+  console.warn(
+    `⚠️ [Midnight] Could not derive a replay key for a transaction: the ` +
+      `ledger bindings refused to identify it (${signature}). Submissions ` +
+      `carrying this transaction are accepted WITHOUT duplicate protection — ` +
+      `a resubmission will be balanced, proven and paid for a second time. ` +
+      `Further transactions failing the same way are not logged again.`,
+  );
 }
 
 /**
@@ -78,7 +152,8 @@ function attempt<R>(fn: (() => R) | undefined): R | undefined {
 export function midnightReplayKey(
   tx: ReplayIdentifiableTx,
 ): string | undefined {
-  const raw = attempt(tx.identifiers);
+  const identifiers = attempt(tx, tx.identifiers);
+  const raw = identifiers.value;
   const list: unknown[] = Array.isArray(raw)
     ? raw
     : raw !== null && raw !== undefined && typeof raw !== "string" &&
@@ -93,11 +168,18 @@ export function midnightReplayKey(
       .digest("hex");
   }
 
-  const hash = attempt(tx.transactionHash);
-  if (hash === undefined || hash === null) return undefined;
-  const encoded = encodePart(hash);
-  if (encoded === "") return undefined;
-  return createHash("sha256")
-    .update(HASH_NAMESPACE + encoded, "utf8")
-    .digest("hex");
+  const hash = attempt(tx, tx.transactionHash);
+  if (hash.value !== undefined && hash.value !== null) {
+    const encoded = encodePart(hash.value);
+    if (encoded !== "") {
+      return createHash("sha256")
+        .update(HASH_NAMESPACE + encoded, "utf8")
+        .digest("hex");
+    }
+  }
+
+  // Nothing left to key on. If the boundary THREW on the way here, that is a
+  // loss of double-payment protection nobody asked for, and it gets said.
+  reportDerivationFailure([identifiers.failure, hash.failure]);
+  return undefined;
 }

--- a/packages/batcher/core/batcher.ts
+++ b/packages/batcher/core/batcher.ts
@@ -887,6 +887,14 @@ export class Batcher<T extends DefaultBatcherInput = DefaultBatcherInput> {
    * spend the chain will reject anyway. Logged once per target, because the
    * operator should know their deployment has no replay protection, and should
    * not learn it once per request.
+   *
+   * The message distinguishes the two ways a target arrives here, because they
+   * have opposite remedies and conflating them cost a real investigation: the
+   * old text said "implement getReplayKey()" unconditionally, and 00017's M14
+   * was read for a day as a missing hook when in fact `MidnightBalancingAdapter`
+   * implements it and the hook was answering `undefined` for every transaction
+   * (00020 F-1.10 / F-1.10a). A warning that names the wrong cause is worse
+   * than no warning: it sends the reader somewhere there is nothing to find.
    */
   private replayKeyFor(
     adapter: BlockchainAdapter<any>,
@@ -896,12 +904,21 @@ export class Batcher<T extends DefaultBatcherInput = DefaultBatcherInput> {
     const key = resolveReplayKey(adapter, input);
     if (key === undefined && !this.replayKeylessTargetsLogged.has(target)) {
       this.replayKeylessTargetsLogged.add(target);
+      const hasHook = typeof (adapter as { getReplayKey?: unknown })
+        ?.getReplayKey === "function";
       console.warn(
-        `⚠️ [Batcher] Target "${target}" produced no replay key for an input ` +
-          `(no signature, and its adapter supplies none). Submissions to this ` +
-          `target are accepted WITHOUT duplicate protection — a resubmitted ` +
-          `request will be balanced and paid for again. Implement ` +
-          `getReplayKey() on the adapter to close this.`,
+        `⚠️ [Batcher] Target "${target}" produced no replay key for an input. ` +
+          `Submissions to this target are accepted WITHOUT duplicate ` +
+          `protection — a resubmitted request will be balanced and paid for ` +
+          `again. ` +
+          (hasHook
+            ? `Its adapter DOES implement getReplayKey(); that hook returned ` +
+              `undefined for this input, so the gap is in the adapter's own ` +
+              `derivation (or the input genuinely cannot be fingerprinted) — ` +
+              `adding the hook is not the fix, look at what it answers.`
+            : `Its adapter implements no getReplayKey(), and the input carries ` +
+              `no signature to key on: implement getReplayKey() on the adapter ` +
+              `to close this.`),
       );
     }
     return key;

--- a/packages/batcher/test/dedup-gate.test.ts
+++ b/packages/batcher/test/dedup-gate.test.ts
@@ -248,6 +248,49 @@ describe("the replay gate at the accept path", () => {
     });
   });
 
+  test("the keyless warning names the RIGHT cause of the two", async () => {
+    // A diagnostic that points somewhere there is nothing to find is worse
+    // than silence. The old text said "Implement getReplayKey() on the adapter"
+    // whatever the reason, and that sentence sent 00017's M14 investigation
+    // after a missing hook for a day — while the hook was there all along,
+    // answering `undefined` because it called the ledger accessors detached
+    // from their receiver (00020 F-1.10 / F-1.10a).
+    const say = async (script: Script): Promise<string> => {
+      const lines: string[] = [];
+      const original = console.warn;
+      console.warn = (...args: unknown[]) => {
+        lines.push(args.map(String).join(" "));
+      };
+      try {
+        await withBatcher(async ({ batcher }) => {
+          await batcher.batchInput(input({ signature: undefined }), "no-wait");
+        }, script);
+      } finally {
+        console.warn = original;
+      }
+      return lines.filter((l) => l.includes("no replay key")).join("\n");
+    };
+
+    const noHook = await say({});
+    // Here the advice is correct, and stays.
+    expect(noHook).toContain("implements no getReplayKey()");
+    expect(noHook).toContain("implement getReplayKey() on the adapter");
+
+    const hookAnsweredUndefined = await say({
+      hasReplayKeyHook: true,
+      getReplayKey: () => undefined,
+    });
+    // Here it was a lie. The reader must be sent to the adapter's DERIVATION.
+    expect(hookAnsweredUndefined).toContain("DOES implement getReplayKey()");
+    expect(hookAnsweredUndefined).toContain("adding the hook is not the fix");
+
+    // Both still say what it COSTS, which is the part an operator acts on.
+    for (const line of [noHook, hookAnsweredUndefined]) {
+      expect(line).toContain("WITHOUT duplicate");
+      expect(line).toContain("paid for");
+    }
+  });
+
   test("an adapter hook that declines a key disables dedup for that input", async () => {
     await withBatcher(async ({ batcher, storage }) => {
       // The adapter implements the hook and answers `undefined`: authoritative.

--- a/packages/batcher/test/midnight-replay-key-wasm.test.ts
+++ b/packages/batcher/test/midnight-replay-key-wasm.test.ts
@@ -1,0 +1,201 @@
+// The replay key against the REAL ledger bindings.
+//
+// This is the test class 00011 deliberately skipped. `midnight-replay-key.ts`
+// is duck-typed so it — and its unit tests — stay free of the 10 MB WASM blob,
+// and that was a good trade right up until the one property the duck cannot
+// express turned out to be the one that mattered: a wasm-bindgen method reads
+// `this.__wbg_ptr` before it does anything else, so it only works when called
+// ON the transaction. Every mock was arrow functions, which do not care. The
+// derivation was therefore calling the accessors detached, throwing a TypeError
+// into its own fail-open catch, and reporting "no key" for every single real
+// Midnight transaction (00020 F-1.10a) — silently disabling double-payment
+// protection for the whole balancing adapter.
+//
+// So one file crosses the boundary for real. It is cheap: the transaction is
+// built entirely offline from the ledger's own sampling helpers — no wallet, no
+// node, no indexer, no proof server — and it pins the two properties a replay
+// key lives or dies on, against the actual object the adapter is handed.
+
+import { describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
+
+import {
+  createShieldedCoinInfo,
+  sampleCoinPublicKey,
+  sampleEncryptionPublicKey,
+  sampleRawTokenType,
+  Transaction as LedgerTransaction,
+  ZswapOffer,
+  ZswapOutput,
+} from "@midnight-ntwrk/ledger-v8";
+
+import { MidnightBalancingAdapter } from "../adapters/midnight-balancing-adapter.ts";
+import {
+  midnightReplayKey,
+  type ReplayIdentifiableTx,
+} from "../adapters/midnight-replay-key.ts";
+import type { DefaultBatcherInput } from "../core/types.ts";
+
+/**
+ * A real unproven transaction, built offline.
+ *
+ * One shielded output to a sampled recipient is the smallest thing the ledger
+ * will call a transaction, and it is enough: `identifiers()` is non-empty for
+ * it, which is all the derivation asks for. The coin's nonce is sampled, so two
+ * calls produce two genuinely different spends — which the "different spends
+ * key differently" case below relies on.
+ */
+function realUnprovenTx() {
+  const coin = createShieldedCoinInfo(sampleRawTokenType(), 10n);
+  const output = ZswapOutput.new(
+    coin,
+    0,
+    sampleCoinPublicKey(),
+    sampleEncryptionPublicKey(),
+  );
+  return LedgerTransaction.fromParts(
+    "undeployed",
+    ZswapOffer.fromOutput(output, sampleRawTokenType(), 10n),
+  );
+}
+
+const toHex = (bytes: Uint8Array) => Buffer.from(bytes).toString("hex");
+
+describe("the Midnight replay key against real ledger-v8 bindings", () => {
+  test("a real transaction produces a real key", () => {
+    const tx = realUnprovenTx();
+
+    // The property the whole gate rests on, stated against the real object:
+    // the ledger CAN name this transaction…
+    expect(tx.identifiers().length).toBeGreaterThan(0);
+    // …and so can we.
+    expect(midnightReplayKey(tx as unknown as ReplayIdentifiableTx))
+      .toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  test("REGRESSION: the accessors are called ON the transaction", () => {
+    const tx = realUnprovenTx();
+
+    // This is the bug, in one assertion. Detached — how the derivation used to
+    // call it — a wasm-bindgen method cannot find its own pointer.
+    const detached = tx.identifiers as () => unknown;
+    expect(() => detached()).toThrow(/__wbg_ptr/);
+    // Bound, it answers. Any implementation that loses the receiver turns the
+    // line above into the fail-open `undefined` that cost the adapter its
+    // dedup, and this file is what stops that from happening again.
+    expect(midnightReplayKey(tx as unknown as ReplayIdentifiableTx))
+      .not.toBeUndefined();
+  });
+
+  test("the key survives a serialize / deserialize round trip", () => {
+    // The defining property of a REPLAY key: the same spend, re-encoded and
+    // arriving again, must key the same — otherwise a resubmission is balanced
+    // and paid for twice. `unproven` is the stage the template envelope uses.
+    const tx = realUnprovenTx();
+    const before = midnightReplayKey(tx as unknown as ReplayIdentifiableTx);
+
+    const round = LedgerTransaction.deserialize(
+      "signature",
+      "pre-proof",
+      "pre-binding",
+      tx.serialize(),
+    );
+
+    expect(midnightReplayKey(round as unknown as ReplayIdentifiableTx))
+      .toBe(before);
+    expect(before).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  test("different spends are not confused for one another", () => {
+    // A key that collided across distinct transactions would refuse legitimate
+    // work, which is a worse failure than paying twice.
+    expect(midnightReplayKey(realUnprovenTx() as unknown as ReplayIdentifiableTx))
+      .not.toBe(
+        midnightReplayKey(realUnprovenTx() as unknown as ReplayIdentifiableTx),
+      );
+  });
+
+  test("an unproven transaction has no hash to fall back to — and that is fine", () => {
+    // Worth pinning, because it says the identifiers path is not merely the
+    // PREFERRED route for this shape, it is the ONLY one: `transactionHash()`
+    // throws for anything not proven, signed and bound. Losing the receiver
+    // therefore cost 100% of dedup rather than degrading it to a weaker key.
+    expect(() => realUnprovenTx().transactionHash())
+      .toThrow(/proven, signed and bound/);
+  });
+});
+
+describe("the balancing adapter's replay key over a real envelope", () => {
+  /**
+   * The adapter driven through its prototype — the pattern `midnight-replay-memo`
+   * and `pre-spend-gate` already use. Constructing a real one needs wallet
+   * seeds, an indexer and a worker pool; `getReplayKey` and the deserialization
+   * it calls touch none of them.
+   */
+  function adapterProbe() {
+    const adapter = Object.create(
+      MidnightBalancingAdapter.prototype,
+    ) as MidnightBalancingAdapter;
+    const memo = new Map<string, string | undefined>();
+    Object.assign(adapter as unknown as Record<string, unknown>, {
+      replayKeyMemo: memo,
+    });
+    return { adapter, memo };
+  }
+
+  const envelope = (hex: string): DefaultBatcherInput => ({
+    addressType: 5,
+    address: "addr-1",
+    // Exactly the shape the multi-batcher template submits.
+    input: JSON.stringify({ tx: hex, txStage: "unproven" }),
+    timestamp: "1754350000000",
+    target: "product-b",
+  });
+
+  test("a real template envelope yields a defined key", () => {
+    const { adapter } = adapterProbe();
+    const key = adapter.getReplayKey(envelope(toHex(realUnprovenTx().serialize())));
+
+    // 00017's M14 failed because this was `undefined` for every payload the
+    // template sent.
+    expect(key).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  test("the memo-miss and memo-hit paths agree", () => {
+    const { adapter, memo } = adapterProbe();
+    const input = envelope(toHex(realUnprovenTx().serialize()));
+
+    // Miss: deserializes and derives.
+    const derived = adapter.getReplayKey(input);
+    expect(memo.size).toBe(1);
+    // Hit: answered from the memo. A memo that disagreed with the derivation
+    // would make dedup depend on whether the entry had been evicted.
+    expect(adapter.getReplayKey(input)).toBe(derived);
+    // And on the path intake actually takes — `validateInput` memoizes, then
+    // the batcher asks — the answer is the same one.
+    expect(
+      memo.get(createHash("sha256").update(input.input, "utf8").digest("hex")),
+    ).toBe(derived);
+  });
+
+  test("the same spend resubmitted keys identically", () => {
+    // The whole reason the key exists: two byte-identical submissions are one
+    // paid spend. Distinct adapters so neither answer comes from a memo.
+    const hex = toHex(realUnprovenTx().serialize());
+    const first = adapterProbe().adapter.getReplayKey(envelope(hex));
+    const second = adapterProbe().adapter.getReplayKey(envelope(hex));
+
+    expect(first).toBe(second);
+    expect(first).not.toBeUndefined();
+  });
+
+  test("two different spends do not", () => {
+    const a = adapterProbe().adapter.getReplayKey(
+      envelope(toHex(realUnprovenTx().serialize())),
+    );
+    const b = adapterProbe().adapter.getReplayKey(
+      envelope(toHex(realUnprovenTx().serialize())),
+    );
+    expect(a).not.toBe(b);
+  });
+});

--- a/packages/batcher/test/replay-key.test.ts
+++ b/packages/batcher/test/replay-key.test.ts
@@ -22,7 +22,11 @@ import { describe, expect, test } from "bun:test";
 import { createHash } from "node:crypto";
 
 import { defaultReplayKey, resolveReplayKey } from "../core/replay-key.ts";
-import { midnightReplayKey } from "../adapters/midnight-replay-key.ts";
+import {
+  __resetReplayKeyDerivationLog,
+  midnightReplayKey,
+  REPLAY_KEY_FAILURE_LOG_LIMIT,
+} from "../adapters/midnight-replay-key.ts";
 import type { DefaultBatcherInput } from "../core/types.ts";
 
 const input = (
@@ -177,5 +181,204 @@ describe("the Midnight replay key", () => {
       },
     };
     expect(midnightReplayKey(fullyExploding)).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The receiver.
+//
+// Every fixture above hands `midnightReplayKey` an object of ARROW functions,
+// and an arrow function does not care what it is called on. A wasm-bindgen
+// method does: its first act is to read `this.__wbg_ptr`, so calling it
+// detached from the transaction throws a TypeError — which the fail-open catch
+// then turns into "this spend cannot identify itself". Every real Midnight
+// transaction, every shape, silently lost its dedup that way (00020 F-1.10a).
+//
+// The blind spot was structural, not accidental: the module is duck-typed on
+// purpose to keep the 10 MB WASM blob out of these tests, and the one property
+// the mocks could not express is the one that broke. So the mock grows a
+// receiver — a class with a PRIVATE field, which is the smallest faithful
+// stand-in for `this.__wbg_ptr`: read it off a detached call and it throws.
+// ---------------------------------------------------------------------------
+
+describe("the Midnight replay key when the accessors need their receiver", () => {
+  /** The arrow-function shape every fixture above uses, for comparison. */
+  const duckTx = (identifiers?: unknown, hash?: unknown) => ({
+    ...(identifiers === undefined ? {} : { identifiers: () => identifiers }),
+    ...(hash === undefined ? {} : { transactionHash: () => hash }),
+  });
+
+  /** A transaction that, like the real bindings, only works when called ON it. */
+  class ReceiverBoundTx {
+    readonly #identifiers: unknown[];
+    readonly #hash: unknown;
+
+    constructor(identifiers: unknown[], hash?: unknown) {
+      this.#identifiers = identifiers;
+      this.#hash = hash;
+    }
+
+    identifiers(): unknown[] {
+      // `this.#identifiers` on a detached call throws exactly as
+      // `this.__wbg_ptr` does.
+      return this.#identifiers;
+    }
+
+    transactionHash(): unknown {
+      if (this.#hash === undefined) {
+        // What ledger-v8 really does for an unproven transaction: "Transaction
+        // hash is available for proven, signed and bound transactions only."
+        throw new Error("hash unavailable at this stage");
+      }
+      return this.#hash;
+    }
+  }
+
+  test("REGRESSION: a transaction whose accessors read `this` still keys", () => {
+    // Red before the fix: `attempt(tx.identifiers)` invoked the method with
+    // `this === undefined`, the private-field read threw, and the fail-open
+    // catch reported "no key" for a spend that names itself perfectly well.
+    const key = midnightReplayKey(new ReceiverBoundTx(["id-a", "id-b"]));
+    expect(key).toMatch(/^[0-9a-f]{64}$/);
+    // And it is the SAME key the duck-typed fixture produces: binding the
+    // receiver changed who the call is made on, not what is hashed.
+    expect(key).toBe(midnightReplayKey(duckTx(["id-a", "id-b"])));
+  });
+
+  test("the key is stable across instances carrying the same spend", () => {
+    // Two deserializations of one transaction are two objects; they must not
+    // be two spends.
+    expect(midnightReplayKey(new ReceiverBoundTx(["id-a"])))
+      .toBe(midnightReplayKey(new ReceiverBoundTx(["id-a"])));
+    expect(midnightReplayKey(new ReceiverBoundTx(["id-a"])))
+      .not.toBe(midnightReplayKey(new ReceiverBoundTx(["id-b"])));
+  });
+
+  test("the hash fallback is reached with its receiver too", () => {
+    // Not just `identifiers` — the second accessor is a wasm-bindgen method as
+    // well, and losing its receiver would swallow the weaker key the same way.
+    expect(midnightReplayKey(new ReceiverBoundTx([], "0xtxhash")))
+      .toBe(midnightReplayKey(duckTx([], "0xtxhash")));
+  });
+
+  test("a BOUND accessor that genuinely fails still fails OPEN", () => {
+    // The point of the fix is not to stop catching — it is to stop MANUFACTURING
+    // the failure. A transaction called correctly and still unable to answer
+    // (an unproven one has no transaction hash) is admitted without dedup,
+    // exactly as before.
+    expect(midnightReplayKey(new ReceiverBoundTx([]))).toBeUndefined();
+
+    class UnreadableTx {
+      identifiers(): unknown[] {
+        throw new Error("wasm boundary");
+      }
+      transactionHash(): unknown {
+        throw new Error("wasm boundary");
+      }
+    }
+    expect(midnightReplayKey(new UnreadableTx())).toBeUndefined();
+  });
+});
+
+describe("a total derivation failure is not silent", () => {
+  // Silence is what let the receiver bug live from Phase 3 to now: every
+  // submission lost its dedup and nothing in the log said so. The warning is
+  // bounded — once per distinct failure reason, never per call — because the
+  // failure mode it exists to catch is systematic, so one line is the whole
+  // signal and a line per transaction is just a flood.
+  const capture = () => {
+    const lines: string[] = [];
+    const original = console.warn;
+    console.warn = (...args: unknown[]) => {
+      lines.push(args.map(String).join(" "));
+    };
+    return { lines, restore: () => { console.warn = original; } };
+  };
+
+  test("both accessors throwing says so, once", () => {
+    __resetReplayKeyDerivationLog();
+    const log = capture();
+    try {
+      const broken = () => ({
+        identifiers: () => {
+          throw new Error("wasm boundary: this.__wbg_ptr");
+        },
+        transactionHash: () => {
+          throw new Error("wasm boundary: this.__wbg_ptr");
+        },
+      });
+      expect(midnightReplayKey(broken())).toBeUndefined();
+      expect(midnightReplayKey(broken())).toBeUndefined();
+      expect(midnightReplayKey(broken())).toBeUndefined();
+    } finally {
+      log.restore();
+    }
+    // Not three lines, and not zero.
+    expect(log.lines.length).toBe(1);
+    // It must name the CONSEQUENCE, not just the exception: an operator
+    // reading it should know they are paying twice for resubmissions.
+    expect(log.lines[0]).toContain("duplicate");
+    // …and carry the reason, which is the thing that would have pointed
+    // straight at the receiver.
+    expect(log.lines[0]).toContain("this.__wbg_ptr");
+  });
+
+  test("a DIFFERENT failure reason is still worth one line", () => {
+    __resetReplayKeyDerivationLog();
+    const log = capture();
+    try {
+      midnightReplayKey({
+        identifiers: () => {
+          throw new Error("reason one");
+        },
+      });
+      midnightReplayKey({
+        identifiers: () => {
+          throw new Error("reason two");
+        },
+      });
+      midnightReplayKey({
+        identifiers: () => {
+          throw new Error("reason one");
+        },
+      });
+    } finally {
+      log.restore();
+    }
+    expect(log.lines.length).toBe(2);
+  });
+
+  test("a transaction that simply has nothing to key on is NOT an error", () => {
+    // No accessors at all is the documented duck-typed case — a custom shape
+    // the batcher was never able to fingerprint. Warning about it every time
+    // would bury the real signal.
+    __resetReplayKeyDerivationLog();
+    const log = capture();
+    try {
+      expect(midnightReplayKey({})).toBeUndefined();
+      expect(midnightReplayKey({ identifiers: () => [] })).toBeUndefined();
+    } finally {
+      log.restore();
+    }
+    expect(log.lines).toEqual([]);
+  });
+
+  test("the warning cannot grow without bound", () => {
+    __resetReplayKeyDerivationLog();
+    const log = capture();
+    try {
+      for (let i = 0; i < 500; i += 1) {
+        midnightReplayKey({
+          identifiers: () => {
+            throw new Error(`distinct reason ${i}`);
+          },
+        });
+      }
+    } finally {
+      log.restore();
+    }
+    // A per-reason set that never stops growing is a leak with a log attached.
+    expect(log.lines.length).toBeLessThanOrEqual(REPLAY_KEY_FAILURE_LOG_LIMIT);
+    expect(log.lines.length).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
## The defect

`packages/batcher/adapters/midnight-replay-key.ts` passed the ledger's accessors to `attempt()` **detached from their receiver**:

```ts
const raw = attempt(tx.identifiers);   // -> fn() -> this === undefined
```

A wasm-bindgen method's first act is to read `this.__wbg_ptr`, so the bare call throws a `TypeError` before it reaches the ledger at all — and `attempt`'s deliberate fail-open catch swallowed our own mistake into "this spend cannot identify itself".

Deterministic, for every transaction and every shape. **Every payload through `MidnightBalancingAdapter` has been accepted with no duplicate protection since the hook shipped**: a byte-identical resubmission was balanced, proven and paid for a second time, out of the batcher's own dust. The once-per-target warning masked the breadth, and its text ("Implement `getReplayKey()` on the adapter") pointed at a method that was already there — which is how #883's M14 result was misdiagnosed for a day (00020 F-1.10 → F-1.10a).

Measured on this branch against real `@midnight-ntwrk/ledger-v8@8.1.0`, before any fix:

```
bound identifiers(): ["0060939839003c1238f261dfdbdd93768138b20a40b13ab3b998856bcbd51dee1d"]
bound transactionHash() THREW: Transaction hash is available for proven, signed and bound transactions only.
DETACHED identifiers() THREW: undefined is not an object (evaluating 'this.__wbg_ptr')
midnightReplayKey(tx) = undefined
```

The identifiers are there and survive a serialize/deserialize round trip byte-for-byte. Note the third line: an unproven transaction legitimately has no `transactionHash()`, so the hash fallback can never rescue this shape — the detached call cost **100%** of dedup rather than degrading it.

Why no test caught it: `midnight-replay-key.ts` is duck-typed on purpose to keep the 10 MB WASM blob out of its tests, and 00011's fixtures were arrow functions, which ignore `this`. The one property the real object has is the one the mocks could not express.

## The fix

`fn.call(tx)`. Five lines of real change.

The fail-open **stays**. A transaction called correctly and still unable to answer is admitted without dedup, exactly as before — refusing a submission because we cannot fingerprint it is worse than occasionally paying twice for a spend the chain will reject anyway. What changed is that a self-inflicted `TypeError` is no longer one of those cases.

Two things so this cannot go quiet again:

- **A total derivation failure is now said out loud** — once per distinct failure reason, capped at 8, naming what it costs ("accepted WITHOUT duplicate protection — a resubmission will be balanced, proven and paid for a second time"). Only *thrown* failures are reported; a transaction that simply has nothing to key on is the documented duck-typed case, not a fault. Silence is what let this survive from Phase 3 to now.
- **`replayKeyFor`'s warning distinguishes the two cases**: no hook at all (the old advice, kept, because it is right there) versus a hook that answered `undefined` ("adding the hook is not the fix, look at what it answers").

## Tests

- **Regression, no WASM**: a fixture class with a `readonly #private` field stands in for `this.__wbg_ptr` — read it off a detached call and it throws. Returns `undefined` on the old code, a stable 64-hex key on the new. A genuinely-throwing *bound* accessor still yields `undefined`, pinning the preserved fail-open.
- **`packages/batcher/test/midnight-replay-key-wasm.test.ts` — new, and the test class 00011 deliberately skipped.** A real ledger-v8 transaction built entirely offline (no wallet, node, indexer or proof server; ~1.3 s): 64-hex key, identical across `serialize()` → `deserialize("signature","pre-proof","pre-binding")`, distinct transactions distinct keys — plus `expect(() => detached()).toThrow(/__wbg_ptr/)`, so re-detaching the receiver fails loudly here instead of degrading in production. Then the adapter over the real template envelope `{"tx": <hex>, "txStage": "unproven"}`: defined key, memo-hit and memo-miss agree, same spend keys identically, different spends do not.
- **The warning's two branches** are pinned in `dedup-gate.test.ts`.

No existing test was modified or deleted — every diff to `replay-key.test.ts` and `dedup-gate.test.ts` is pure addition.

## Acceptance — 00017's M14 flips `fail` → `pass`

Run from the 00017 deep-suite clone with **zero edits to it** (its batcher `core/` and this one adapter file are supplied by read-only bind mounts declared in an overlay kept outside the clone; `git status` there is empty before and after, and the tracked `TESTING-RESULTS.md` is restored to its exact sha256). Same stack, same chain, same wallets; the only difference between the two runs is that one mounted file.

**Before**

```
[deep] M14 → fail (30s) — first=200/1971fe841727… dup=false replay=200 dup=false sameId=true crossTarget=200 dup=false sameId=false rows: b=1→2 c=1 pollable=200
```

**After**

```
[deep] M14 → pass (30s) — first=200/5bb3a2c774a8… dup=false replay=200 dup=true sameId=true crossTarget=200 dup=true sameId=true rows: b=1→1 c=0 pollable=200
```

Every clause the replay key controls flipped: the resubmission is a duplicate; the same spend addressed to a *different product* is one too (the key is the transaction's identity, not the target — 00011 Q-P8); and the row counts `b=1→2, c=1` collapse to `b=1→1, c=0`, i.e. the replay queued nothing anywhere.

The reworded warning was captured live during the *before* run, on the real defect:

```
⚠️ [Batcher] Target "product-b" produced no replay key for an input. … Its adapter DOES implement getReplayKey(); that hook returned undefined for this input, so the gap is in the adapter's own derivation … — adding the hook is not the fix, look at what it answers.
```

In the *after* run that grep returns 0.

**M13 is character-for-character identical across both runs** (`fail (55s) — … complete=0 withHash=0 …`). That is deliberate isolation evidence: M13's failure is a restart straddling an in-flight submission recording `failed` for work that confirmed, which is **project 00021's** to fix, and this PR touches nothing it depends on.

## No regressions

| Run | Base `d39fdba5` | This branch | Delta |
|---|---|---|---|
| `bun test packages/batcher`, no database | 609 pass / 9 skip / 0 fail, 618 tests, 51 files | 627 pass / 9 skip / 0 fail, 636 tests, 52 files | +18 |
| same + `BATCHER_TEST_POSTGRES_URL` (PostgreSQL 16.14) | 676 pass / 0 fail, 676 tests, 51 files | 694 pass / 0 fail, 694 tests, 52 files | +18 |

Failure set empty on both sides. +18 is exactly the new tests: 8 in `replay-key.test.ts`, 9 in the new WASM file, 1 in `dedup-gate.test.ts`.

Typecheck: 11 errors, **all 11 proven pre-existing** by running the identical command on the stashed base tree in the same session — the only difference in the whole output is one line number moving 2072 → 2089, shifted by the lines added above it. The new WASM test contributes zero diagnostics. `bun.lock` diff is empty.

Every changed path is under `packages/batcher/**`. `core/batch-processor.ts` and the balancing adapter's `classifyWorkerFailure`/submit paths are untouched — 00021 owns those and runs concurrently.

Not for merge without review; base is `claude/multi-batcher-sdk-v2`.
