### PR TITLE
fix(batcher): stop the Solana adapter swallowing RPC transport errors (v-next)

### DIFF
--- a/packages/batcher/adapters/solana-adapter.ts
+++ b/packages/batcher/adapters/solana-adapter.ts
@@ -346,6 +346,7 @@ export class SolanaAdapter implements BlockchainAdapter<SolanaBatchPayload> {
     _fee: string | bigint,
   ): Promise<BlockchainHash> {
     const signatures: BlockchainHash[] = [];
+    const failures: string[] = [];
     for (const txBase64 of data.transactions) {
       if (!txBase64) continue;
       const tx = this.deserialize(txBase64);
@@ -364,10 +365,22 @@ export class SolanaAdapter implements BlockchainAdapter<SolanaBatchPayload> {
         // be resubmitted). Log, keep going, and surface a failure only if the
         // whole batch failed.
         this.logger.log(`Failed to submit a sponsored Solana tx: ${String(e)}`);
+        failures.push(String(e));
       }
     }
     if (signatures.length === 0) {
-      throw new Error("[Solana] no transaction in the batch could be submitted");
+      // Carry the per-transaction texts, don't just log them. The batcher reads
+      // this message to tell an environment failure from a verdict about the
+      // inputs (`BatchProcessor.isInfraFailure`): a bare constant matches
+      // nothing, so an outage of our own RPC was charged to every input's
+      // bounded retry budget and the requests were eventually deleted as
+      // RETRIES_EXHAUSTED — real input loss caused by our own downtime.
+      // Genuine chain verdicts read as verdicts either way, so they keep
+      // charging exactly as before.
+      throw new Error(
+        "[Solana] no transaction in the batch could be submitted" +
+          (failures.length > 0 ? `: ${failures.join("; ")}` : ""),
+      );
     }
     return signatures[signatures.length - 1] ?? "";
   }

--- a/packages/batcher/test/solana-infra-classification.test.ts
+++ b/packages/batcher/test/solana-infra-classification.test.ts
@@ -1,0 +1,191 @@
+// What a totally failed Solana batch tells the processor about WHY it failed.
+//
+// `BatchProcessor` decides whether a batch-wide throw is the environment's
+// fault or the inputs' fault by reading the thrown message
+// (`BatchProcessor.isInfraFailure`). An INFRASTRUCTURE verdict parks the target
+// with every retry budget untouched; anything else charges each input a retry,
+// and after `maxRetries` the rows are deleted and the requests are published
+// `failed/RETRIES_EXHAUSTED`.
+//
+// So the adapter's thrown message is not cosmetic — it is the whole input to
+// that decision. If `submitBatch` swallows the per-transaction rejection texts
+// and throws only a constant, an RPC outage of OUR OWN endpoint is read as a
+// verdict about the users' transactions and destroys them.
+//
+// These tests pin both directions, and they assert against
+// `BatchProcessor.isInfraFailure` itself rather than a copy of its regex — a
+// copy would keep passing after the real classifier drifted away from it.
+//
+// No network is touched: `connection.sendRawTransaction` is stubbed on the
+// constructed adapter, so the configured RPC URL is never contacted.
+
+import { test, expect } from "bun:test";
+import {
+  Keypair,
+  PublicKey,
+  Transaction,
+  TransactionInstruction,
+} from "@solana/web3.js";
+import bs58 from "bs58";
+
+import { SolanaAdapter } from "../adapters/solana-adapter.ts";
+import { BatchProcessor } from "../core/batch-processor.ts";
+
+// Deterministic sponsor (fee payer), so the payloads below are reproducible.
+const sponsorKeypair = Keypair.fromSeed(new Uint8Array(32).fill(7));
+const TARGET_PROGRAM_ID = Keypair.fromSeed(new Uint8Array(32).fill(5))
+  .publicKey.toBase58();
+
+// Port 1 is unroutable on purpose: if a stub ever fails to take effect, the
+// test fails loudly instead of quietly reaching a real endpoint.
+const TEST_CONFIG = {
+  rpcUrl: "http://127.0.0.1:1",
+  batcherSecretKey: bs58.encode(sponsorKeypair.secretKey),
+  targetProgramId: TARGET_PROGRAM_ID,
+} as const;
+
+// Stand-in recent blockhash (any 32-byte base58 value); nothing validates it
+// here because the submission never leaves the process.
+const RECENT_BLOCKHASH = Keypair.generate().publicKey.toBase58();
+
+/** A base64, user-partially-signed tx whose fee payer is the sponsor. */
+function sponsoredTx(): string {
+  const user = Keypair.generate();
+  const tx = new Transaction();
+  tx.feePayer = sponsorKeypair.publicKey;
+  tx.recentBlockhash = RECENT_BLOCKHASH;
+  tx.add(
+    new TransactionInstruction({
+      keys: [{ pubkey: user.publicKey, isSigner: true, isWritable: false }],
+      programId: new PublicKey(TARGET_PROGRAM_ID),
+      data: Buffer.from("memo", "utf8"),
+    }),
+  );
+  tx.partialSign(user);
+  return tx.serialize({ requireAllSignatures: false }).toString("base64");
+}
+
+/**
+ * Build an adapter whose `sendRawTransaction` is driven by `respond`, called
+ * once per transaction in submission order. `connection` is private, which is
+ * exactly why it has to be reached through a cast: the point of the test is to
+ * exercise the real `submitBatch` against a controlled RPC.
+ */
+function adapterWithSendStub(
+  respond: (call: number) => Promise<string>,
+): SolanaAdapter {
+  const adapter = new SolanaAdapter(TEST_CONFIG);
+  let call = 0;
+  // deno-lint-ignore no-explicit-any
+  (adapter as any).connection.sendRawTransaction = () => respond(call++);
+  return adapter;
+}
+
+/** Run `submitBatch` expecting a throw, and hand back what was thrown. */
+async function thrownBy(fn: () => Promise<unknown>): Promise<unknown> {
+  try {
+    await fn();
+  } catch (e) {
+    return e;
+  }
+  throw new Error("expected submitBatch to throw, but it resolved");
+}
+
+const messageOf = (e: unknown) => e instanceof Error ? e.message : String(e);
+
+// ── User Story 1: an RPC outage must park, not charge ────────────────────────
+
+test("a batch where every send fails on transport is classified as INFRASTRUCTURE", async () => {
+  const adapter = adapterWithSendStub(() =>
+    Promise.reject(new Error("connect ECONNREFUSED 127.0.0.1:8899"))
+  );
+
+  const error = await thrownBy(() =>
+    adapter.submitBatch({ transactions: [sponsoredTx(), sponsoredTx()] }, 0n)
+  );
+
+  // The whole defect in one assertion: our own RPC being down must not be
+  // charged to the users' retry budgets.
+  expect(BatchProcessor.isInfraFailure(error)).toBe(true);
+
+  // And the operator reading the parking log must still see both the
+  // batch-level context and the underlying transport text.
+  const message = messageOf(error);
+  expect(message).toContain("[Solana]");
+  expect(message).toContain("no transaction in the batch could be submitted");
+  expect(message).toContain("ECONNREFUSED");
+});
+
+test("a non-Error rejection value still reaches the classifier", async () => {
+  // Node/undici and older RPC clients reject with bare strings often enough
+  // that `String(e)` semantics are part of the contract, not an accident.
+  const adapter = adapterWithSendStub(() =>
+    Promise.reject("socket hang up") as Promise<string>
+  );
+
+  const error = await thrownBy(() =>
+    adapter.submitBatch({ transactions: [sponsoredTx()] }, 0n)
+  );
+
+  expect(BatchProcessor.isInfraFailure(error)).toBe(true);
+  expect(messageOf(error)).toContain("socket hang up");
+});
+
+// ── User Story 2: a genuine chain verdict must still charge ──────────────────
+
+test("a batch rejected by the chain itself is NOT classified as INFRASTRUCTURE", async () => {
+  const adapter = adapterWithSendStub(() =>
+    Promise.reject(
+      new Error(
+        "Transaction simulation failed: Error processing Instruction 0: custom program error: 0x1",
+      ),
+    )
+  );
+
+  const error = await thrownBy(() =>
+    adapter.submitBatch({ transactions: [sponsoredTx(), sponsoredTx()] }, 0n)
+  );
+
+  // Making outages park must not make doomed inputs park too — that trades
+  // silent input loss for a silent hang.
+  expect(BatchProcessor.isInfraFailure(error)).toBe(false);
+  expect(messageOf(error)).toContain("custom program error: 0x1");
+});
+
+// ── User Story 3: partial success is unchanged ───────────────────────────────
+
+test("one failed send does not sink a batch that also submitted successfully", async () => {
+  const adapter = adapterWithSendStub((call) =>
+    call === 0
+      ? Promise.reject(new Error("connect ECONNREFUSED 127.0.0.1:8899"))
+      : Promise.resolve("SIGNATURE_THAT_LANDED")
+  );
+
+  // Never abort mid-batch: these are independent transactions, and throwing
+  // would discard the signature of one that is already on chain.
+  const signature = await adapter.submitBatch(
+    { transactions: [sponsoredTx(), sponsoredTx()] },
+    0n,
+  );
+
+  expect(signature).toBe("SIGNATURE_THAT_LANDED");
+});
+
+// ── Edge case: nothing to report ─────────────────────────────────────────────
+
+test("an all-empty payload throws the bare batch-level error, with no dangling separator", async () => {
+  // Empty slots are skipped before any send is attempted, so there are no
+  // per-transaction texts to append — and the message must not advertise a
+  // list it does not have.
+  const adapter = adapterWithSendStub(() =>
+    Promise.reject(new Error("should never be called"))
+  );
+
+  const error = await thrownBy(() =>
+    adapter.submitBatch({ transactions: ["", ""] }, 0n)
+  );
+
+  const message = messageOf(error);
+  expect(message).toContain("no transaction in the batch could be submitted");
+  expect(/[:;,-]\s*$/.test(message)).toBe(false);
+});


### PR DESCRIPTION
## What

`SolanaAdapter.submitBatch` swallowed the RPC transport error text. The per-transaction catch logged `String(e)` and discarded it; when **every** transaction failed it threw the bare constant:

```
[Solana] no transaction in the batch could be submitted
```

`BatchProcessor.isInfraFailure` (`packages/batcher/core/batch-processor.ts:62`, call site `:129`) matches the thrown message against a transport-error regex. That constant matches nothing, so **an outage of our own RPC was classified as an input failure**: every input in the batch was charged its bounded retry budget, and after `maxRetries` the rows were deleted and the requests published `failed/RETRIES_EXHAUSTED`. Real input loss caused by our own downtime.

The fix collects each per-transaction failure message and appends the joined list to the batch-level error, so the transport text reaches the classifier at its existing call site. `isInfraFailure` itself is **not** touched — widening that regex was considered and rejected, because it would make doomed inputs park forever too (trading silent input loss for a silent hang).

- `packages/batcher/adapters/solana-adapter.ts` — `submitBatch` only: a `failures: string[]` accumulator, one `failures.push(String(e))` beside the existing (unchanged) log line, and the throw now appends `": " + failures.join("; ")`. The `failures.length > 0` guard means an all-empty payload still throws the bare constant with **no dangling separator**. Loop semantics are untouched: it still never aborts mid-batch, so already-submitted signatures are never discarded.
- `packages/batcher/test/solana-infra-classification.test.ts` — new, 5 tests asserting directly against `BatchProcessor.isInfraFailure`.

## Relationship to #885 — please read before merging

This is the **direct-to-`v-next` twin of #885**. Same defect, same fix, same tests; the two PRs differ only in base branch.

- #885 → https://github.com/effectstream/effectstream/pull/885 — base `claude/multi-batcher-sdk-v2`, commit `33b6f8ff`. Still OPEN and unmerged.
- This PR → base `v-next`, commit `f890d9eb` — a clean cherry-pick of `33b6f8ff` (no conflicts; different sha only because the parent differs).

`v-next` carries the identical defect on its own — `solana-adapter.ts:370` throws the same constant — so it was fixed here directly rather than waiting for the multi-batcher integration merge to carry it over.

**On the eventual integration merge:** `submitBatch` is currently byte-identical on both branches (the Phase 1 hunk applied to `v-next` with no fuzz), so when `claude/multi-batcher-sdk-v2` is merged into `v-next` it will meet an **already-identical file**. Expect no conflict; if git does flag one, it will be a trivial identical-content conflict — take either side. Merging both PRs is safe and intended.

## Red-first evidence — re-proven on `v-next` itself

The red run was **not** inherited from #885. The new test file was checked out alone onto the unmodified `v-next` adapter and run there, to prove the defect is live on this branch rather than an artifact of the multi-batcher context.

Against the **unmodified** `v-next` adapter (exit code `1`):

```
109 |   expect(BatchProcessor.isInfraFailure(error)).toBe(true);
error: expect(received).toBe(expected)

Expected: true
Received: false
(fail) a batch where every send fails on transport is classified as INFRASTRUCTURE

152 |   expect(messageOf(error)).toContain("custom program error: 0x1");
error: expect(received).toContain(expected)

Expected to contain: "custom program error: 0x1"
Received: "[Solana] no transaction in the batch could be submitted"
(fail) a batch rejected by the chain itself is NOT classified as INFRASTRUCTURE

 2 pass
 3 fail
 7 expect() calls
Ran 5 tests across 1 file.
```

The adapter's own log lines in that run show it *saw* `connect ECONNREFUSED 127.0.0.1:8899` and then threw the constant anyway. This matches #885's red run failure-for-failure.

After the fix (exit code `0`):

```
 5 pass
 0 fail
 11 expect() calls
Ran 5 tests across 1 file.
```

The five tests: transport-class total failure classifies `true`; chain-verdict total failure classifies `false`; partial success resolves with the successful signature (no throw); a non-`Error` rejection value is still captured; an empty payload's message has no dangling separator. The chain-verdict test passes **both before and after** — it is the guard that this fix does not widen parking to genuine verdicts.

## Full suite — `bun test packages/batcher`, base vs head, same machine and session

| Metric | `v-next` base (`01a5efcd`) | This PR | Delta |
|---|---|---|---|
| pass | 100 | 105 | **+5** = the new tests |
| fail | 0 | 0 | 0 |
| expect() calls | 237 | 248 | **+11** |
| tests / files | 100 / 11 | 105 / 12 | +5 / +1 |
| exit code | 0 | 0 | — |

Baseline plus exactly the new tests, zero failures, no pre-existing test changed state.

## Scope

Two files, both `packages/batcher/**`. `bun.lock` untouched.

Not a breaking change: the thrown error type and the `[Solana]` prefix are unchanged — the message only gains a suffix. Nothing else in the package reads the batch-level message.

## Defect record

FU-1 in `plans/00021-outage-parking-reconciliation.md` — finding **F-1.9** (the swallow and the resulting `RETRIES_EXHAUSTED` input loss), question **Q-2**, and ruling **F-1.10** (the decision that `isInfraFailure`'s regex stays as-is, which is why the fix threads the message instead of widening the classifier).

FU-2 (viem timeout text in `evm-contract` / `effectstream-l2`) is explicitly **out of scope** — separate follow-up.
