### PR TITLE
test(template): guard Midnight WASM runtime identity

### DIFF
--- a/templates/evm-midnight-v2/bun.lock
+++ b/templates/evm-midnight-v2/bun.lock
@@ -182,6 +182,7 @@
         "@midnight-ntwrk/midnight-js-node-zk-config-provider": "5.0.0-beta.6",
         "@midnight-ntwrk/midnight-js-types": "5.0.0-beta.6",
         "@midnight-ntwrk/midnight-js-utils": "5.0.0-beta.6",
+        "@midnight-ntwrk/onchain-runtime": "npm:@midnightntwrk/onchain-runtime-v4@4.0.0-rc.3",
         "@midnightntwrk/ledger-v9": "1.0.0-rc.3",
         "pg": "^8.14.0",
         "playwright-core": "^1.52.0",

--- a/templates/evm-midnight-v2/packages/tests/infra/wasm-runtime-identity.test.ts
+++ b/templates/evm-midnight-v2/packages/tests/infra/wasm-runtime-identity.test.ts
@@ -1,0 +1,104 @@
+import { realpathSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import {
+  ContractState as AliasContractState,
+  StateValue as AliasStateValue,
+} from "@midnight-ntwrk/onchain-runtime";
+import {
+  ContractState as CompactContractState,
+  StateValue as CompactStateValue,
+} from "@midnight-ntwrk/compact-runtime";
+import { ledger } from "@evm-midnight/midnight-contract/contract";
+
+// Compact 0.33.0-rc.2 output for the template's counter constructor, serialized
+// as the indexer's raw contract-action state. Keeping this byte fixture fixed
+// ensures the guard enters sync's real deserialize -> generated-ledger path.
+const RAW_CONTRACT_STATE =
+  "6d69646e696768743a636f6e74726163742d73746174655b76385d3a580008400804000401000c40200204080401040c080104000c402001041404010418080104000400402010101c1c202020202020202020202008021008042408041404280403042c0004300801040434200304071010400000043815020304ff0102010403040108041408010401040108400800010802104001040000010801040401040104010c40200200010801040401040104010c40200200010801040401040104010c40200100010801040401040104010c402001000104000001040000010400000104000001040000010400000104000001040000010400000104000000002824696e6372656d656e74000c000000084044000448080104044c90030440807da5723bb9e6219c7e943cd692d2c4372b6e86c3a4f1a2350445dc04fffc586e1428203c50201003000400";
+
+function invariant(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(`Midnight WASM runtime identity guard: ${message}`);
+}
+
+async function loadMidnightFetcher(): Promise<any> {
+  // @effectstream/sync is intentionally reached through the node's production
+  // runtime dependency. This works for both a published standalone install and
+  // LINK_LOCAL=1 without adding a test-only direct sync dependency.
+  const nodeParent = path.resolve(import.meta.dir, "../../node/main.dev.ts");
+  const runtimeEntry = Bun.resolveSync("@effectstream/runtime", nodeParent);
+  const syncEntry = Bun.resolveSync("@effectstream/sync", runtimeEntry);
+  const syncRoot = path.dirname(fileURLToPath(pathToFileURL(syncEntry)));
+  const module = await import(
+    pathToFileURL(path.join(syncRoot, "sync-protocols/midnight/fetcher.ts")).href
+  );
+  return module.MidnightFetcher;
+}
+
+export async function wasmRuntimeIdentityTest(): Promise<void> {
+  const aliasEntry = Bun.resolveSync("@midnight-ntwrk/onchain-runtime", import.meta.path);
+  const compactEntry = Bun.resolveSync("@midnight-ntwrk/compact-runtime", import.meta.path);
+  const canonicalEntry = Bun.resolveSync("@midnightntwrk/onchain-runtime-v4", compactEntry);
+  const aliasRealpath = realpathSync(aliasEntry);
+  const canonicalRealpath = realpathSync(canonicalEntry);
+
+  invariant(aliasRealpath === canonicalRealpath, `two physical runtime entries: ${aliasRealpath} != ${canonicalRealpath}`);
+  invariant(AliasStateValue === CompactStateValue, "alias and Compact StateValue constructors differ");
+  invariant(AliasContractState === CompactContractState, "alias and Compact ContractState constructors differ");
+
+  const aliasValue = AliasStateValue.newNull();
+  const compactValue = CompactStateValue.newNull();
+  invariant(aliasValue instanceof CompactStateValue, "alias StateValue fails Compact instanceof");
+  invariant(compactValue instanceof AliasStateValue, "Compact StateValue fails alias instanceof");
+
+  const rawBytes = Uint8Array.from(Buffer.from(RAW_CONTRACT_STATE, "hex"));
+  const aliasState = AliasContractState.deserialize(rawBytes).data.state;
+  invariant(aliasState instanceof AliasStateValue, "alias deserializer returned an unexpected StateValue");
+  invariant(aliasState instanceof CompactStateValue, "alias-deserialized state fails Compact instanceof");
+
+  const directLedger = ledger(aliasState);
+  invariant(directLedger.round === 0n, "generated ledger rejected or misread the direct alias-origin state");
+
+  const MidnightFetcher = await loadMidnightFetcher();
+  const fetcher = Object.create(MidnightFetcher.prototype);
+  const contractAddress = "00000000000000ab";
+  const operation = fetcher.fetchContractState(
+    17,
+    undefined,
+    {
+      syncProtocol: "midnight-runtime-identity",
+      primitive: {
+        type: "Midnight:ContractState",
+        name: "counter",
+        contractAddress,
+        contract: { ledger },
+      },
+    },
+    {
+      block: {
+        transactions: [{
+          hash: "runtime-identity-fixture-tx",
+          contractActions: [{ address: "ab", state: RAW_CONTRACT_STATE }],
+        }],
+      },
+    },
+  );
+  const step = operation.next();
+  invariant(step.done, "fetchContractState unexpectedly yielded before returning its primitive");
+  const outputs = step.value as any[];
+  invariant(outputs.length === 1, "fetchContractState did not emit exactly one primitive");
+  invariant(outputs[0].output.payload.round === 0n, "fetch/decode/generated-ledger payload round mismatch");
+  invariant(
+    outputs[0].output.payload.contract_address instanceof Uint8Array,
+    "fetch/decode/generated-ledger payload did not include decoded bytes",
+  );
+
+  console.log(
+    `[PASS] Midnight WASM runtime identity guard (${aliasRealpath}; raw fixture ${rawBytes.length} bytes)`,
+  );
+}
+
+if (import.meta.main) {
+  await wasmRuntimeIdentityTest();
+}

--- a/templates/evm-midnight-v2/packages/tests/package.json
+++ b/templates/evm-midnight-v2/packages/tests/package.json
@@ -22,6 +22,7 @@
     "@midnight-ntwrk/midnight-js-types": "5.0.0-beta.6",
     "@midnight-ntwrk/midnight-js-utils": "5.0.0-beta.6",
     "@midnight-ntwrk/compact-runtime": "0.18.0-rc.1",
+    "@midnight-ntwrk/onchain-runtime": "npm:@midnightntwrk/onchain-runtime-v4@4.0.0-rc.3",
     "rxjs": "^7.8.2"
   }
 }

--- a/templates/evm-midnight-v2/packages/tests/run-tests.ts
+++ b/templates/evm-midnight-v2/packages/tests/run-tests.ts
@@ -118,6 +118,11 @@ async function test() {
   let db: Client | null = null;
   let caughtError = false;
   try {
+    // Fail before launching any infrastructure if sync and the generated
+    // Compact reader resolve different WASM class identities.
+    const { wasmRuntimeIdentityTest } = await import("./infra/wasm-runtime-identity.test.ts");
+    await wasmRuntimeIdentityTest();
+
     await startInfrastructure();
     await waitForOrchestrator();
 

--- a/templates/evm-midnight-v2/packages/tests/run-tests.ts
+++ b/templates/evm-midnight-v2/packages/tests/run-tests.ts
@@ -15,6 +15,8 @@ const DB_NAME = process.env["DB_NAME"] || "postgres";
 
 const CLI_PATH = path.resolve(import.meta.dirname!, "../../node_modules/@effectstream/orchestrator/src/cli.ts");
 const LAUNCHER_PATH = path.resolve(import.meta.dirname!, "./start.test.ts");
+const TEMPLATE_ROOT = path.resolve(import.meta.dirname!, "../..");
+const WASM_RUNTIME_IDENTITY_ONLY = process.env["WASM_RUNTIME_IDENTITY_ONLY"] === "1";
 
 let orchestratorProc: ReturnType<typeof Bun.spawn> | null = null;
 
@@ -30,12 +32,33 @@ async function startInfrastructure(): Promise<void> {
 
 async function stopInfrastructure(): Promise<void> {
   console.log("\nStopping infrastructure...");
+  if (!orchestratorProc) return;
   process.on("SIGTERM", () => {});
   try {
     await fetch(`http://localhost:${ORCHESTRATOR_PORT}/shutdown`, { method: "POST" });
   } catch { /* already down */ }
   await delay(2000);
   orchestratorProc?.kill();
+}
+
+async function runWasmRuntimeIdentityGuard(): Promise<void> {
+  // The generated Compact reader is ignored and absent from a clean checkout.
+  // Generate it before loading the guard module, but still before starting any
+  // orchestrator process or service.
+  console.log("Generating the Compact reader for the WASM identity guard...");
+  const compactBuild = Bun.spawn(["bun", "run", "build:midnight"], {
+    cwd: TEMPLATE_ROOT,
+    stdout: "inherit",
+    stderr: "inherit",
+    env: { ...process.env },
+  });
+  const compactBuildExit = await compactBuild.exited;
+  if (compactBuildExit !== 0) {
+    throw new Error(`Compact reader generation failed with code ${compactBuildExit}`);
+  }
+
+  const { wasmRuntimeIdentityTest } = await import("./infra/wasm-runtime-identity.test.ts");
+  await wasmRuntimeIdentityTest();
 }
 
 async function waitForOrchestrator(): Promise<void> {
@@ -118,10 +141,11 @@ async function test() {
   let db: Client | null = null;
   let caughtError = false;
   try {
-    // Fail before launching any infrastructure if sync and the generated
-    // Compact reader resolve different WASM class identities.
-    const { wasmRuntimeIdentityTest } = await import("./infra/wasm-runtime-identity.test.ts");
-    await wasmRuntimeIdentityTest();
+    await runWasmRuntimeIdentityGuard();
+    if (WASM_RUNTIME_IDENTITY_ONLY) {
+      console.log("WASM identity-only verification complete; infrastructure was not started.");
+      return;
+    }
 
     await startInfrastructure();
     await waitForOrchestrator();
@@ -203,7 +227,7 @@ async function test() {
     // A thrown error (e.g. an infra wait/health timeout) must fail the run even
     // if no test assertion recorded a failure — otherwise a broken deploy is
     // silently reported green (this masked evm-midnight-v2's missing managed/).
-    if (caughtError || anyError()) process.exit(1);
+    if (caughtError || (!WASM_RUNTIME_IDENTITY_ONLY && anyError())) process.exit(1);
     process.exit(0);
   }
 }


### PR DESCRIPTION
## Summary

Add a regression-only guard for Midnight WASM runtime identity in the
`evm-midnight-v2` template test path.

The suspected failure does **not** reproduce on the current supported stack:
a clean standalone install and the repository's actual linked topology both
resolve the compatibility alias and Compact's canonical runtime to one
physical `@midnightntwrk/onchain-runtime-v4@4.0.0-rc.3` module, and the actual
generated ledger reader succeeds. Accordingly, this PR does not rewrite any
production dependency or import.

Historically, the risk arises when the sync-side compatibility alias and the
Compact-generated reader load separate physical WASM runtime copies. Values
constructed by one copy can then fail the generated reader's `instanceof`
check even when package versions or bytes appear equivalent.

## What changes

- Add the exact v4 runtime compatibility alias only to the template test
  workspace.
- Add a focused identity guard that compares physical runtime entry paths,
  constructor equality, and both cross-`instanceof` directions.
- Exercise both the direct generated `ledger()` reader and the production
  `MidnightFetcher.fetchContractState` raw-state -> `decodeContractState` ->
  generated-ledger path using a pinned 330-byte raw state fixture.
- Run the guard before any infrastructure/service startup.
- Fix the clean-install ordering found during review: the committed runner now
  runs the actual `build:midnight` command to a checked successful exit before
  dynamically importing the generated-reader guard. This resolves MAJOR-1 and
  independently re-audited PASS.

## Verification

- Clean standalone Docker topology, Bun 1.3.11 frozen install: 3,347 packages;
  `src/managed` absent before the exact runner; actual Compact reader generated;
  identity/direct-ledger/production-fetcher guard passed before infrastructure.
- Actual monorepo `link.sh` topology on a native Docker volume: root frozen
  install of 3,210 packages; `link.sh` completed; `src/managed` remained absent;
  the exact runner generated the reader and the same guard passed through the
  linked monorepo v4 physical realpath before infrastructure.
- Focused Bun bundle and strict guard TypeScript check passed.
- `git diff --check` passed; all disposable Docker and temporary resources were
  removed and verified absent.

## Scope and compatibility

The diff is limited to four template-test paths:

- `templates/evm-midnight-v2/packages/tests/package.json`
- `templates/evm-midnight-v2/packages/tests/infra/wasm-runtime-identity.test.ts`
- `templates/evm-midnight-v2/packages/tests/run-tests.ts`
- `templates/evm-midnight-v2/bun.lock`

The lockfile change is one test-workspace alias declaration and adds no resolved
package or version. There are no production manifest, import, or runtime
changes. This is assessed as **non-breaking**.

## Test caveats

- The template-wide `tsc --noEmit` baseline is already non-green with 448
  errors across published Effectstream sources and existing template files;
  focused candidate checks passed.
- One extra pre-`link.sh` template frozen-install probe hit Bun cache-copy and
  native `utf-8-validate` lifecycle errors. The actual unmodified `link.sh`
  install and complete linked regression subsequently passed.
- `link.sh` printed its existing 48-dependency version-skew diagnostic and
  exited zero; the linked runtime-identity oracle still passed.

This PR is intentionally regression-only and must not be merged as part of
this delivery task.
