### PR TITLE
fix(midnight-indexer): surface child failure and bound startup readiness

### DIFF
--- a/packages/binaries/midnight-indexer/README.md
+++ b/packages/binaries/midnight-indexer/README.md
@@ -9,6 +9,21 @@ NPM wrapper that runs the [Midnight](https://midnight.network) Indexer either as
 - Used by the orchestrator's Midnight step; sits in front of `MidnightFetcher` on the sync side.
 - Maps port 8088 (Docker) or runs on localhost (binary) so the rest of the local stack reaches it the same way.
 
+## Bundled compatibility
+
+The machine-readable [`compatibility.json`](./compatibility.json) is the source
+of truth used by startup and timeout diagnostics:
+
+| Component         | Bundled version |
+| ----------------- | --------------- |
+| Midnight node     | `2.0.0-rc.4`    |
+| Ledger generation | 9               |
+| Midnight indexer  | `4.4.0-rc.1`    |
+
+Cached node state must come from the same Ledger generation. The proof server
+is deliberately excluded from this cached-chain tuple because there is no
+evidence that it owns compatible chain state.
+
 ## Install
 
 ```bash
@@ -41,14 +56,14 @@ The Docker path pulls `midnightntwrk/indexer-standalone` and maps container port
 
 ### Environment variables
 
-| Variable | Required | Docker default | Binary default | Purpose |
-| --- | --- | --- | --- | --- |
-| `APP__INFRA__SECRET` | yes | - | - | Hex-encoded 32-byte indexer secret. |
-| `LEDGER_NETWORK_ID` | no | `Undeployed` | `Undeployed` | Ledger network selector. |
-| `SUBSTRATE_NODE_WS_URL` | no | `ws://node:9944` | `ws://localhost:9944` | Substrate node WS. |
-| `FEATURES_WALLET_ENABLED` | no | `true` | `true` | Wallet features. |
-| `APP__INFRA__PROOF_SERVER__URL` | no | `http://proof-server:6300` | `http://localhost:6300` | Proof server. |
-| `APP__INFRA__NODE__URL` | no | `ws://node:9944` | `ws://localhost:9944` | Node URL. |
+| Variable                        | Required | Docker default             | Binary default          | Purpose                             |
+| ------------------------------- | -------- | -------------------------- | ----------------------- | ----------------------------------- |
+| `APP__INFRA__SECRET`            | yes      | -                          | -                       | Hex-encoded 32-byte indexer secret. |
+| `LEDGER_NETWORK_ID`             | no       | `Undeployed`               | `Undeployed`            | Ledger network selector.            |
+| `SUBSTRATE_NODE_WS_URL`         | no       | `ws://node:9944`           | `ws://localhost:9944`   | Substrate node WS.                  |
+| `FEATURES_WALLET_ENABLED`       | no       | `true`                     | `true`                  | Wallet features.                    |
+| `APP__INFRA__PROOF_SERVER__URL` | no       | `http://proof-server:6300` | `http://localhost:6300` | Proof server.                       |
+| `APP__INFRA__NODE__URL`         | no       | `ws://node:9944`           | `ws://localhost:9944`   | Node URL.                           |
 
 ### Path resolution
 
@@ -62,6 +77,11 @@ Linux amd64 and macOS arm64.
 
 The orchestrator's Midnight step starts this indexer behind `@effectstream/npm-midnight-node` + proof server. The runtime's `@effectstream/sync` `MidnightFetcher` queries it. You usually don't invoke this package by hand; you add it to your orchestrator config and the rest happens automatically.
 
+The native wrapper now waits for the indexer child and preserves its nonzero
+exit code. The orchestrator probes indexer TCP readiness directly with a
+60-second default bound rather than delegating to an unbounded template
+`wait-on` script.
+
 ## Troubleshooting
 
 A few common failures and where to look:
@@ -69,6 +89,19 @@ A few common failures and where to look:
 - `Docker is not installed or not available` - install Docker Desktop / Engine and confirm `docker --version` from the same shell.
 - `APP__INFRA__SECRET environment variable is required` - required for both modes; export it or pass inline.
 - `Failed to start midnight-indexer` - check that ports 8088, 6300, and 9944 are free and that the Midnight node is reachable.
+- `unknown readiness failure` - inspect `logs/midnight-indexer.log` and
+  `logs/midnight-node.log`. A TCP listener alone does not prove that the node is
+  usable: both a fresh chain before block one and an indexer connected to a
+  failed node can open port 8088.
+- A node log containing the exact missing
+  `ext_ledger_8_bridge_construct_distribute_treasury_system_tx_version_1`
+  import is the verified incompatible Ledger-8-cache signal for this tuple.
+  Without that exact signal, stale state is only one possible cause.
+- Indexer `--clean` removes only its SQLite data; it does not reset node chain
+  state. Under the Effectstream orchestrator, node state is kept at
+  `packages/contracts-midnight/node_modules/.cache/effectstream/midnight-node`.
+  Stop the stack first, then archive or remove only that project-local
+  directory if you choose to reset it. Startup never deletes it automatically.
 
 ## Examples
 

--- a/packages/binaries/midnight-indexer/README.md
+++ b/packages/binaries/midnight-indexer/README.md
@@ -79,8 +79,19 @@ The orchestrator's Midnight step starts this indexer behind `@effectstream/npm-m
 
 The native wrapper now waits for the indexer child and preserves its nonzero
 exit code. The orchestrator probes indexer TCP readiness directly with a
-60-second default bound rather than delegating to an unbounded template
-`wait-on` script.
+60-second default bound. Templates still pinned to orchestrator `0.200.1`
+retain a backwards-compatible, bounded `midnight-indexer:wait` script until
+their package pins advance; the new launcher does not delegate to that script.
+
+## Breaking lifecycle change and rollout order
+
+> **Breaking:** the CLI now remains attached to its native child and returns
+> the child's nonzero/signal result. Callers that previously treated wrapper
+> launch as immediate success must handle the service lifecycle result.
+
+Land the owned-process shutdown work from PR A before rolling out this change.
+PR A's ownership-safe termination semantics are operationally required before
+a newly observable node or indexer failure can trigger orchestrator shutdown.
 
 ## Troubleshooting
 
@@ -97,6 +108,11 @@ A few common failures and where to look:
   `ext_ledger_8_bridge_construct_distribute_treasury_system_tx_version_1`
   import is the verified incompatible Ledger-8-cache signal for this tuple.
   Without that exact signal, stale state is only one possible cause.
+- Under the new Effectstream launcher, the node wrapper reads this package's
+  compatibility declaration, observes the real node output, and propagates the
+  child exit. It emits the incompatible-cache label only after seeing that
+  exact signal; a successful indexer TCP connection cannot override the node
+  failure.
 - Indexer `--clean` removes only its SQLite data; it does not reset node chain
   state. Under the Effectstream orchestrator, node state is kept at
   `packages/contracts-midnight/node_modules/.cache/effectstream/midnight-node`.

--- a/packages/binaries/midnight-indexer/compatibility.json
+++ b/packages/binaries/midnight-indexer/compatibility.json
@@ -1,0 +1,19 @@
+{
+  "schemaVersion": 1,
+  "node": {
+    "version": "2.0.0-rc.4",
+    "ledgerGeneration": 9
+  },
+  "indexer": {
+    "version": "4.4.0-rc.1"
+  },
+  "cachedChain": {
+    "policy": "same-ledger-generation-only",
+    "verifiedIncompatibilitySignal": "runtime requires function imports which are not present on the host: 'env:ext_ledger_8_bridge_construct_distribute_treasury_system_tx_version_1'",
+    "projectLocalBasePath": "node_modules/.cache/effectstream/midnight-node"
+  },
+  "proofServer": {
+    "included": false,
+    "reason": "No primary evidence ties proof-server state to the node cached-chain format."
+  }
+}

--- a/packages/binaries/midnight-indexer/index.js
+++ b/packages/binaries/midnight-indexer/index.js
@@ -1,10 +1,15 @@
 const { binary, getPlatform, cleanBinaries } = require("./binary");
-const { runMidnightIndexer, waitForNodeBlock, isValidIndexerSecret } = require(
-  "./run_midnight_indexer",
-);
-const { checkIfDockerExists, pullDockerImage, runDockerContainer } = require(
-  "./docker",
-);
+const {
+  runMidnightIndexer,
+  waitForChildCompletion,
+  waitForNodeBlock,
+  isValidIndexerSecret,
+} = require("./run_midnight_indexer");
+const {
+  checkIfDockerExists,
+  pullDockerImage,
+  runDockerContainer,
+} = require("./docker");
 const fs = require("fs");
 const path = require("path");
 const readline = require("readline");
@@ -130,7 +135,8 @@ async function runWithDocker(env, args) {
     await pullDockerImage();
 
     // Run the container
-    return runDockerContainer(env, args);
+    const childProcess = runDockerContainer(env, args);
+    return waitForChildCompletion(childProcess);
   } catch (error) {
     console.error("Failed to run with Docker:", error.message);
     console.log("Falling back to binary execution...");
@@ -171,9 +177,13 @@ async function runWithBinary(env, args, forceClean = false) {
 
   // Check for required environment variable
   if (!isValidIndexerSecret(env.APP__INFRA__SECRET)) {
-    console.error("Error: APP__INFRA__SECRET must be exactly 64 hexadecimal characters");
-    console.log("Please set APP__INFRA__SECRET=<64_hex_characters> and run again");
-    process.exit(1);
+    console.error(
+      "Error: APP__INFRA__SECRET must be exactly 64 hexadecimal characters",
+    );
+    console.log(
+      "Please set APP__INFRA__SECRET=<64_hex_characters> and run again",
+    );
+    return 1;
   }
 
   if (forceClean || !checkIfBinaryExists()) {
@@ -190,9 +200,20 @@ async function runWithBinary(env, args, forceClean = false) {
 
   // Gate startup on block #1 so the bundled spo-indexer does not crash the
   // process on a fresh chain (see waitForNodeBlock for details).
-  await waitForNodeBlock(binaryEnv);
+  const nodeWaitTimeoutMs = Number(
+    binaryEnv.MIDNIGHT_INDEXER_NODE_WAIT_TIMEOUT_MS || 55000,
+  );
+  const nodeWaitIntervalMs = Number(
+    binaryEnv.MIDNIGHT_INDEXER_NODE_WAIT_INTERVAL_MS || 1000,
+  );
+  const nodeReady = await waitForNodeBlock(binaryEnv, {
+    timeoutMs: nodeWaitTimeoutMs,
+    intervalMs: nodeWaitIntervalMs,
+  });
+  if (!nodeReady) return 1;
 
-  return runMidnightIndexer(binaryEnv, args);
+  const childProcess = runMidnightIndexer(binaryEnv, args);
+  return waitForChildCompletion(childProcess);
 }
 
 async function main(args) {
@@ -202,7 +223,7 @@ async function main(args) {
   // Show help if requested
   if (flags.showHelp) {
     showUsage();
-    process.exit(0);
+    return 0;
   }
 
   // Handle --only-clean flag
@@ -214,7 +235,7 @@ async function main(args) {
     } else {
       console.log("No downloaded binaries found to delete.");
     }
-    process.exit(0);
+    return 0;
   }
 
   // If both flags are provided, show error
@@ -222,7 +243,7 @@ async function main(args) {
     console.error(
       "Error: Cannot use both --docker and --binary flags simultaneously",
     );
-    process.exit(1);
+    return 1;
   }
 
   // Validate clean flag usage
@@ -230,7 +251,7 @@ async function main(args) {
     console.error(
       "Error: --clean-binaries flag cannot be used with --docker flag",
     );
-    process.exit(1);
+    return 1;
   }
 
   // If --docker flag is explicitly provided
@@ -239,7 +260,7 @@ async function main(args) {
     if (!dockerAvailable) {
       console.error("Error: Docker is not installed or not available");
       console.log("Please install Docker or use the --binary flag");
-      process.exit(1);
+      return 1;
     }
 
     // Check for required environment variable
@@ -250,7 +271,7 @@ async function main(args) {
       console.log(
         "Please set APP__INFRA__SECRET=<64_hex_characters> when running with --docker",
       );
-      process.exit(1);
+      return 1;
     }
 
     return runWithDocker(env, flags.remainingArgs);
@@ -268,7 +289,7 @@ async function main(args) {
       console.log(
         "Please use --docker flag instead, or run without flags to use Docker automatically",
       );
-      process.exit(1);
+      return 1;
     }
     return runWithBinary(env, flags.remainingArgs, flags.cleanBinaries);
   }
@@ -289,7 +310,7 @@ async function main(args) {
       console.log(
         "Please install Docker or ensure your platform is supported for binary execution",
       );
-      process.exit(1);
+      return 1;
     }
     console.log(
       "Binary execution not supported on this platform - using Docker",
@@ -300,8 +321,10 @@ async function main(args) {
       console.error(
         "Error: APP__INFRA__SECRET must be exactly 64 hexadecimal characters",
       );
-      console.log("Please set APP__INFRA__SECRET=<64_hex_characters> and run again");
-      process.exit(1);
+      console.log(
+        "Please set APP__INFRA__SECRET=<64_hex_characters> and run again",
+      );
+      return 1;
     }
 
     return runWithDocker(env, flags.remainingArgs);
@@ -319,7 +342,7 @@ async function main(args) {
         console.log(
           "Please set APP__INFRA__SECRET=<64_hex_characters> and run again",
         );
-        process.exit(1);
+        return 1;
       }
       return runWithDocker(env, flags.remainingArgs);
     }
@@ -332,7 +355,7 @@ async function main(args) {
 // Handle unhandled promise rejections
 process.on("unhandledRejection", (error) => {
   console.error("Unhandled promise rejection:", error);
-  process.exit(1);
+  process.exitCode = 1;
 });
 
 // Handle SIGINT (Ctrl+C) gracefully
@@ -343,6 +366,17 @@ process.on("SIGINT", () => {
 
 module.exports = {
   cleanBinaries,
+  main,
+  runWithBinary,
 };
 
-main(process.argv.slice(2));
+if (require.main === module) {
+  main(process.argv.slice(2))
+    .then((exitCode) => {
+      if (typeof exitCode === "number") process.exitCode = exitCode;
+    })
+    .catch((error) => {
+      console.error("midnight-indexer startup failed:", error);
+      process.exitCode = 1;
+    });
+}

--- a/packages/binaries/midnight-indexer/run_midnight_indexer.js
+++ b/packages/binaries/midnight-indexer/run_midnight_indexer.js
@@ -7,17 +7,25 @@ const compatibility = require("./compatibility.json");
 
 const BINARY_NAME = "indexer-standalone";
 
-function logCompatibilityGuidance(prefix = "midnight-indexer") {
+function logConditionalCompatibilityContext(prefix = "midnight-indexer") {
   const localState = compatibility.cachedChain.projectLocalBasePath;
+  console.error(
+    `[${prefix}] Compatibility context: bundled node ${compatibility.node.version} / Ledger ${compatibility.node.ledgerGeneration} and indexer ${compatibility.indexer.version}. This child result alone does not prove incompatible cached state.`,
+  );
+  console.error(
+    `[${prefix}] Only the exact verified node error "${compatibility.cachedChain.verifiedIncompatibilitySignal}" proves an incompatible Ledger-8 cache; otherwise do not reset state solely because this child failed.`,
+  );
+  console.error(
+    `[${prefix}] If that exact node error is present, indexer --clean still removes only indexer SQLite data. After stopping the stack, archive or remove only the project-local node state at ${localState} if you choose to reset it; no automatic reset is performed.`,
+  );
+}
+
+function logUnknownReadinessGuidance(prefix = "midnight-indexer") {
   console.error(
     `[${prefix}] unknown startup/readiness failure for node ${compatibility.node.version} / Ledger ${compatibility.node.ledgerGeneration} and indexer ${compatibility.indexer.version}.`,
   );
-  console.error(
-    `[${prefix}] Inspect the node and indexer logs. Only the exact verified node error "${compatibility.cachedChain.verifiedIncompatibilitySignal}" proves an incompatible Ledger-8 cache; otherwise treat stale state as only one possibility.`,
-  );
-  console.error(
-    `[${prefix}] Indexer --clean removes only indexer SQLite data. After stopping the stack, archive or remove only the project-local node state at ${localState} if you choose to reset it; no automatic reset is performed.`,
-  );
+  console.error(`[${prefix}] Inspect the node and indexer logs.`);
+  logConditionalCompatibilityContext(prefix);
 }
 
 /**
@@ -57,7 +65,7 @@ function waitForChildCompletion(childProcess, options = {}) {
         console.error(
           `[${serviceName}] child process exited with nonzero code ${code}; startup cannot continue.`,
         );
-        logCompatibilityGuidance(serviceName);
+        logConditionalCompatibilityContext(serviceName);
         finish(code || 1);
         return;
       }
@@ -65,7 +73,7 @@ function waitForChildCompletion(childProcess, options = {}) {
       console.error(
         `[${serviceName}] child process terminated by signal ${signal || "unknown"}; startup cannot continue.`,
       );
-      logCompatibilityGuidance(serviceName);
+      logConditionalCompatibilityContext(serviceName);
       finish(1);
     });
   });
@@ -130,7 +138,7 @@ async function waitForNodeBlock(env, opts = {}) {
   console.error(
     `[midnight-indexer] missing block-one readiness: node ${compatibility.node.version} / Ledger ${compatibility.node.ledgerGeneration} did not produce block #${minBlock} within ${timeoutMs}ms; indexer startup is stopping.`,
   );
-  logCompatibilityGuidance("midnight-indexer");
+  logUnknownReadinessGuidance("midnight-indexer");
   return false;
 }
 

--- a/packages/binaries/midnight-indexer/run_midnight_indexer.js
+++ b/packages/binaries/midnight-indexer/run_midnight_indexer.js
@@ -3,8 +3,73 @@ const path = require("path");
 const fs = require("fs");
 const yaml = require("js-yaml");
 const axios = require("axios");
+const compatibility = require("./compatibility.json");
 
 const BINARY_NAME = "indexer-standalone";
+
+function logCompatibilityGuidance(prefix = "midnight-indexer") {
+  const localState = compatibility.cachedChain.projectLocalBasePath;
+  console.error(
+    `[${prefix}] unknown startup/readiness failure for node ${compatibility.node.version} / Ledger ${compatibility.node.ledgerGeneration} and indexer ${compatibility.indexer.version}.`,
+  );
+  console.error(
+    `[${prefix}] Inspect the node and indexer logs. Only the exact verified node error "${compatibility.cachedChain.verifiedIncompatibilitySignal}" proves an incompatible Ledger-8 cache; otherwise treat stale state as only one possibility.`,
+  );
+  console.error(
+    `[${prefix}] Indexer --clean removes only indexer SQLite data. After stopping the stack, archive or remove only the project-local node state at ${localState} if you choose to reset it; no automatic reset is performed.`,
+  );
+}
+
+/**
+ * Waits for a spawned service process and converts every completion mode to a
+ * CLI-compatible exit code. The launcher itself remains synchronous and keeps
+ * returning the ChildProcess for existing API consumers.
+ *
+ * @param {import("child_process").ChildProcess} childProcess
+ * @param {{ serviceName?: string }} [options]
+ * @returns {Promise<number>}
+ */
+function waitForChildCompletion(childProcess, options = {}) {
+  const serviceName = options.serviceName || "midnight-indexer";
+
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (exitCode) => {
+      if (settled) return;
+      settled = true;
+      resolve(exitCode);
+    };
+
+    childProcess.once("error", (error) => {
+      console.error(
+        `[${serviceName}] child process failed to start: ${error.message}`,
+      );
+      finish(1);
+    });
+
+    childProcess.once("exit", (code, signal) => {
+      if (code === 0) {
+        finish(0);
+        return;
+      }
+
+      if (typeof code === "number") {
+        console.error(
+          `[${serviceName}] child process exited with nonzero code ${code}; startup cannot continue.`,
+        );
+        logCompatibilityGuidance(serviceName);
+        finish(code || 1);
+        return;
+      }
+
+      console.error(
+        `[${serviceName}] child process terminated by signal ${signal || "unknown"}; startup cannot continue.`,
+      );
+      logCompatibilityGuidance(serviceName);
+      finish(1);
+    });
+  });
+}
 
 function isValidIndexerSecret(secret) {
   return typeof secret === "string" && /^[0-9a-fA-F]{64}$/.test(secret);
@@ -16,44 +81,57 @@ function isValidIndexerSecret(secret) {
  * The v4.4.0-rc.1 indexer bundles an spo-indexer that, on a fresh DB, reads block #1
  * to anchor the first epoch and exits(1) — killing the whole indexer — if that
  * block does not exist yet. Gating startup on block #1 avoids that startup race.
- * 
+ *
  * @param {Object} env - Environment variables (used to resolve the node URL)
  * @param {Object} [opts]
  * @param {number} [opts.minBlock=1] - Block number that must exist
- * @param {number} [opts.timeoutMs=120000] - Give up (and proceed) after this
+ * @param {number} [opts.timeoutMs=55000] - Give up before the outer 60s readiness bound
  * @param {number} [opts.intervalMs=1000] - Poll interval
- * @returns {Promise<void>}
+ * @returns {Promise<boolean>} Whether block readiness was observed
  */
 async function waitForNodeBlock(env, opts = {}) {
-  const { minBlock = 1, timeoutMs = 120000, intervalMs = 1000 } = opts;
-  const wsUrl = env.SUBSTRATE_NODE_WS_URL ||
+  const { minBlock = 1, timeoutMs = 55000, intervalMs = 1000 } = opts;
+  const wsUrl =
+    env.SUBSTRATE_NODE_WS_URL ||
     env.APP__INFRA__NODE__URL ||
     "ws://localhost:9944";
   const httpUrl = wsUrl.replace(/^ws:/, "http:").replace(/^wss:/, "https:");
 
   const deadline = Date.now() + timeoutMs;
   console.log(
-    `Waiting for node to produce block #${minBlock} at ${httpUrl} (spo-indexer startup guard)...`,
+    `Waiting for node ${compatibility.node.version} / Ledger ${compatibility.node.ledgerGeneration} to produce block #${minBlock} at ${httpUrl} (indexer ${compatibility.indexer.version} startup guard)...`,
   );
   while (Date.now() < deadline) {
     try {
       const { data } = await axios.post(
         httpUrl,
-        { jsonrpc: "2.0", id: 1, method: "chain_getBlockHash", params: [minBlock] },
-        { headers: { "Content-Type": "application/json" }, timeout: 5000 },
+        {
+          jsonrpc: "2.0",
+          id: 1,
+          method: "chain_getBlockHash",
+          params: [minBlock],
+        },
+        {
+          headers: { "Content-Type": "application/json" },
+          timeout: Math.min(5000, Math.max(1, deadline - Date.now())),
+        },
       );
       if (data && data.result) {
-        console.log(`Node has block #${minBlock} (${data.result}); starting indexer.`);
-        return;
+        console.log(
+          `Node has block #${minBlock} (${data.result}); starting indexer.`,
+        );
+        return true;
       }
     } catch {
       // node not reachable yet; keep polling
     }
     await new Promise((r) => setTimeout(r, intervalMs));
   }
-  console.warn(
-    `Timed out waiting for node block #${minBlock} after ${timeoutMs}ms; starting indexer anyway.`,
+  console.error(
+    `[midnight-indexer] missing block-one readiness: node ${compatibility.node.version} / Ledger ${compatibility.node.ledgerGeneration} did not produce block #${minBlock} within ${timeoutMs}ms; indexer startup is stopping.`,
   );
+  logCompatibilityGuidance("midnight-indexer");
+  return false;
 }
 
 /**
@@ -87,7 +165,8 @@ function ensureConfigExists(configPath, env) {
   );
 
   const networkId = env.LEDGER_NETWORK_ID || "Undeployed";
-  const nodeUrl = env.SUBSTRATE_NODE_WS_URL ||
+  const nodeUrl =
+    env.SUBSTRATE_NODE_WS_URL ||
     env.APP__INFRA__NODE__URL ||
     "ws://localhost:9944";
   const cnnUrl = env.APP__INFRA__STORAGE__CNN_URL || "./data/indexer.sqlite";
@@ -284,11 +363,7 @@ function handleCleanFlag(env, workingDir) {
  * @returns {ChildProcess} The spawned child process
  */
 function runMidnightIndexer(env = process.env, args = []) {
-  const binaryPath = path.join(
-    __dirname,
-    "indexer-standalone",
-    BINARY_NAME,
-  );
+  const binaryPath = path.join(__dirname, "indexer-standalone", BINARY_NAME);
   const workingDir = path.join(__dirname, "indexer-standalone");
 
   const configPath = resolveConfigPath(env, workingDir);
@@ -337,8 +412,10 @@ function runMidnightIndexer(env = process.env, args = []) {
 }
 
 module.exports = {
+  compatibility,
   ensureConfigExists,
   isValidIndexerSecret,
   runMidnightIndexer,
+  waitForChildCompletion,
   waitForNodeBlock,
 };

--- a/packages/binaries/midnight-indexer/run_midnight_indexer.test.js
+++ b/packages/binaries/midnight-indexer/run_midnight_indexer.test.js
@@ -1,14 +1,22 @@
 const fs = require("fs");
 const os = require("os");
 const path = require("path");
+const { EventEmitter } = require("events");
 
-const { describe, expect, test } = require("bun:test");
+const { describe, expect, spyOn, test } = require("bun:test");
 const yaml = require("js-yaml");
 
 const {
+  compatibility,
   ensureConfigExists,
   isValidIndexerSecret,
+  waitForChildCompletion,
+  waitForNodeBlock,
 } = require("./run_midnight_indexer");
+
+function fakeChild() {
+  return new EventEmitter();
+}
 
 function expectRc1Schema(config) {
   expect(config.application.gc_bound).toBe("200ms");
@@ -18,7 +26,32 @@ function expectRc1Schema(config) {
   expect(config.infra.api.subscription.progress_cache.time_to_live).toBe("5s");
 }
 
+function pinnedBinaryVersion(source) {
+  return source.match(/CURRENT_BINARY_VERSION\s*=\s*"v?([^"]+)"/)?.[1];
+}
+
 describe("indexer 4.4.0-rc.1 configuration", () => {
+  test("the machine-readable compatibility tuple matches binary pins", () => {
+    const nodeSource = fs.readFileSync(
+      path.join(__dirname, "../midnight-node/binary.js"),
+      "utf8",
+    );
+    const indexerSource = fs.readFileSync(
+      path.join(__dirname, "binary.js"),
+      "utf8",
+    );
+
+    expect(compatibility.node.version).toBe(pinnedBinaryVersion(nodeSource));
+    expect(compatibility.indexer.version).toBe(
+      pinnedBinaryVersion(indexerSource),
+    );
+    expect(compatibility.node.ledgerGeneration).toBe(9);
+    expect(compatibility.cachedChain.policy).toBe(
+      "same-ledger-generation-only",
+    );
+    expect(compatibility.proofServer.included).toBe(false);
+  });
+
   test("accepts exactly a hex-encoded 32-byte application secret", () => {
     expect(isValidIndexerSecret("ab".repeat(32))).toBe(true);
     expect(isValidIndexerSecret("mysecret")).toBe(false);
@@ -37,7 +70,9 @@ describe("indexer 4.4.0-rc.1 configuration", () => {
   });
 
   test("a generated config uses the rc.1 schema and caller endpoints", () => {
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "midnight-indexer-config-"));
+    const dir = fs.mkdtempSync(
+      path.join(os.tmpdir(), "midnight-indexer-config-"),
+    );
     const configPath = path.join(dir, "config.yaml");
     try {
       ensureConfigExists(configPath, {
@@ -54,6 +89,107 @@ describe("indexer 4.4.0-rc.1 configuration", () => {
       expect(config.infra.api.port).toBe(15502);
     } finally {
       fs.rmSync(dir, { force: true, recursive: true });
+    }
+  });
+});
+
+describe("midnight-indexer child completion", () => {
+  test("preserves a successful child exit", async () => {
+    const child = fakeChild();
+    const completed = waitForChildCompletion(child);
+    child.emit("exit", 0, null);
+    expect(await completed).toBe(0);
+  });
+
+  test("propagates a nonzero child exit", async () => {
+    const child = fakeChild();
+    const completed = waitForChildCompletion(child);
+    child.emit("exit", 42, null);
+    expect(await completed).toBe(42);
+  });
+
+  test("maps a spawn error to a nonzero wrapper result", async () => {
+    const child = fakeChild();
+    const completed = waitForChildCompletion(child);
+    child.emit("error", new Error("ENOENT"));
+    expect(await completed).toBe(1);
+  });
+
+  test("maps signal termination to a nonzero wrapper result", async () => {
+    const child = fakeChild();
+    const completed = waitForChildCompletion(child);
+    child.emit("exit", null, "SIGTERM");
+    expect(await completed).toBe(1);
+  });
+
+  test("the binary CLI path preserves an actual native exit 42", async () => {
+    const binaryPath = path.join(
+      __dirname,
+      "indexer-standalone",
+      "indexer-standalone",
+    );
+    const rpcPort = Number(process.env.MIDNIGHT_INDEXER_TEST_RPC_PORT || 18775);
+    const rpc = Bun.serve({
+      hostname: "127.0.0.1",
+      port: rpcPort,
+      fetch() {
+        return Response.json({
+          jsonrpc: "2.0",
+          id: 1,
+          result: `0x${"12".repeat(32)}`,
+        });
+      },
+    });
+
+    expect(fs.existsSync(binaryPath)).toBe(false);
+    fs.writeFileSync(binaryPath, "#!/bin/sh\nexit 42\n", { mode: 0o755 });
+
+    try {
+      const { runWithBinary } = require("./index.js");
+      const exitCode = await runWithBinary(
+        {
+          ...process.env,
+          APP__INFRA__SECRET: "ab".repeat(32),
+          SUBSTRATE_NODE_WS_URL: `ws://127.0.0.1:${rpcPort}`,
+        },
+        [],
+      );
+
+      expect(exitCode).toBe(42);
+    } finally {
+      fs.rmSync(binaryPath, { force: true });
+      rpc.stop(true);
+    }
+  });
+});
+
+describe("node block-one startup guard", () => {
+  test("fails with a missing-block-one classification at its bound", async () => {
+    const rpcPort = Number(
+      process.env.MIDNIGHT_INDEXER_TEST_EMPTY_RPC_PORT || 18776,
+    );
+    const rpc = Bun.serve({
+      hostname: "127.0.0.1",
+      port: rpcPort,
+      fetch() {
+        return Response.json({ jsonrpc: "2.0", id: 1, result: null });
+      },
+    });
+    const errors = spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      const ready = await waitForNodeBlock(
+        { SUBSTRATE_NODE_WS_URL: `ws://127.0.0.1:${rpcPort}` },
+        { timeoutMs: 20, intervalMs: 5 },
+      );
+      expect(ready).toBe(false);
+      const output = errors.mock.calls.flat().join("\n");
+      expect(output).toContain("missing block-one readiness");
+      expect(output).toContain("node 2.0.0-rc.4 / Ledger 9");
+      expect(output).toContain("no automatic reset is performed");
+    } finally {
+      errors.mockRestore();
+      rpc.stop(true);
     }
   });
 });

--- a/packages/binaries/midnight-indexer/run_midnight_indexer.test.js
+++ b/packages/binaries/midnight-indexer/run_midnight_indexer.test.js
@@ -103,9 +103,19 @@ describe("midnight-indexer child completion", () => {
 
   test("propagates a nonzero child exit", async () => {
     const child = fakeChild();
-    const completed = waitForChildCompletion(child);
-    child.emit("exit", 42, null);
-    expect(await completed).toBe(42);
+    const errors = spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const completed = waitForChildCompletion(child);
+      child.emit("exit", 42, null);
+      expect(await completed).toBe(42);
+      const output = errors.mock.calls.flat().join("\n");
+      expect(output).toContain("child process exited with nonzero code 42");
+      expect(output).toContain("Compatibility context");
+      expect(output).toContain("This child result alone does not prove");
+      expect(output).not.toContain("unknown startup/readiness failure");
+    } finally {
+      errors.mockRestore();
+    }
   });
 
   test("maps a spawn error to a nonzero wrapper result", async () => {
@@ -140,6 +150,7 @@ describe("midnight-indexer child completion", () => {
         });
       },
     });
+    const errors = spyOn(console, "error").mockImplementation(() => {});
 
     expect(fs.existsSync(binaryPath)).toBe(false);
     fs.writeFileSync(binaryPath, "#!/bin/sh\nexit 42\n", { mode: 0o755 });
@@ -156,7 +167,11 @@ describe("midnight-indexer child completion", () => {
       );
 
       expect(exitCode).toBe(42);
+      expect(errors.mock.calls.flat().join("\n")).not.toContain(
+        "unknown startup/readiness failure",
+      );
     } finally {
+      errors.mockRestore();
       fs.rmSync(binaryPath, { force: true });
       rpc.stop(true);
     }
@@ -185,6 +200,7 @@ describe("node block-one startup guard", () => {
       expect(ready).toBe(false);
       const output = errors.mock.calls.flat().join("\n");
       expect(output).toContain("missing block-one readiness");
+      expect(output).toContain("unknown startup/readiness failure");
       expect(output).toContain("node 2.0.0-rc.4 / Ledger 9");
       expect(output).toContain("no automatic reset is performed");
     } finally {

--- a/packages/binaries/midnight-node/README.md
+++ b/packages/binaries/midnight-node/README.md
@@ -21,6 +21,13 @@ state made the node exit nonzero with a missing
 import. Do not label other startup failures incompatible without that exact
 evidence.
 
+The current Effectstream launcher supplies the installed indexer package's
+single compatibility declaration to this wrapper. The wrapper tees the native
+node output, waits for the child, and propagates its nonzero/signal result. It
+emits the incompatible-cache diagnosis only when it observes the declaration's
+exact verified signal; otherwise the result remains a known node child failure
+with an instruction to inspect the node log.
+
 The Effectstream orchestrator passes an explicit project-local `BASE_PATH`:
 `packages/contracts-midnight/node_modules/.cache/effectstream/midnight-node`.
 If a reset is necessary, stop the stack, archive or remove only that directory,

--- a/packages/binaries/midnight-node/README.md
+++ b/packages/binaries/midnight-node/README.md
@@ -11,6 +11,22 @@ the EffectStream orchestrator and templates.
 - Consumed by `@effectstream/sync`'s `MidnightFetcher`.
 - Templates: `evm-midnight-v2`, `night-bitcoin`, `zswap-da`, `zk-cardano`.
 
+## Cached-chain compatibility
+
+This node is the Ledger-9 member of the bundled tuple declared by
+`@effectstream/npm-midnight-indexer/compatibility.json`. Node-1/Ledger-8 chain
+state is not reusable by node `2.0.0-rc.4`. In the pinned reproduction, that
+state made the node exit nonzero with a missing
+`ext_ledger_8_bridge_construct_distribute_treasury_system_tx_version_1` host
+import. Do not label other startup failures incompatible without that exact
+evidence.
+
+The Effectstream orchestrator passes an explicit project-local `BASE_PATH`:
+`packages/contracts-midnight/node_modules/.cache/effectstream/midnight-node`.
+If a reset is necessary, stop the stack, archive or remove only that directory,
+then restart. The orchestrator and indexer never reset it automatically, and
+indexer `--clean` does not affect it.
+
 ## Install
 
 ```bash

--- a/packages/binaries/midnight-node/index.js
+++ b/packages/binaries/midnight-node/index.js
@@ -1,5 +1,8 @@
 const { binary, cleanBinaries } = require("./binary");
-const { runMidnightNode } = require("./run_midnight_node");
+const {
+  runMidnightNode,
+  waitForNodeCompletion,
+} = require("./run_midnight_node");
 const fs = require("fs");
 const path = require("path");
 
@@ -50,7 +53,7 @@ async function main(args) {
 
   if (flags.showHelp) {
     showUsage();
-    process.exit(0);
+    return 0;
   }
 
   if (flags.onlyClean) {
@@ -61,7 +64,7 @@ async function main(args) {
     } else {
       console.log("No downloaded binaries found to delete.");
     }
-    process.exit(0);
+    return 0;
   }
 
   if (flags.cleanBinaries || !checkIfBinaryExists()) {
@@ -71,11 +74,22 @@ async function main(args) {
     }
     await binary();
   }
-  runMidnightNode(process.env, flags.remainingArgs);
+  const childProcess = runMidnightNode(process.env, flags.remainingArgs);
+  return waitForNodeCompletion(childProcess);
 }
 
 module.exports = {
   cleanBinaries,
+  main,
 };
 
-main(process.argv.slice(2));
+if (require.main === module) {
+  main(process.argv.slice(2))
+    .then((exitCode) => {
+      if (typeof exitCode === "number") process.exitCode = exitCode;
+    })
+    .catch((error) => {
+      console.error("midnight-node startup failed:", error);
+      process.exitCode = 1;
+    });
+}

--- a/packages/binaries/midnight-node/run_midnight_node.js
+++ b/packages/binaries/midnight-node/run_midnight_node.js
@@ -1,5 +1,9 @@
 const { spawn } = require("child_process");
+const fs = require("fs");
 const path = require("path");
+
+const COMPATIBILITY_FILE_ENV = "EFFECTSTREAM_MIDNIGHT_COMPATIBILITY_FILE";
+const evidenceByChild = new WeakMap();
 
 /**
  * Applies default environment variables for midnight-node if not already set
@@ -21,6 +25,145 @@ function applyDefaultEnv(env) {
 }
 
 /**
+ * Loads the one compatibility declaration supplied by the orchestrator. The
+ * node package does not own or duplicate the compatibility policy.
+ *
+ * @param {Object} env
+ * @returns {null | {
+ *   compatibility: Object,
+ *   signal: string,
+ *   matched: boolean,
+ *   tail: string,
+ *   statePath: string,
+ * }}
+ */
+function loadCompatibilityEvidence(env) {
+  const compatibilityFile = env[COMPATIBILITY_FILE_ENV];
+  if (!compatibilityFile) return null;
+
+  try {
+    const compatibility = JSON.parse(
+      fs.readFileSync(compatibilityFile, "utf8"),
+    );
+    const signal = compatibility?.cachedChain?.verifiedIncompatibilitySignal;
+    if (
+      compatibility?.schemaVersion !== 1 ||
+      typeof compatibility?.node?.version !== "string" ||
+      typeof compatibility?.node?.ledgerGeneration !== "number" ||
+      typeof signal !== "string" ||
+      signal.length === 0 ||
+      typeof compatibility?.cachedChain?.projectLocalBasePath !== "string"
+    ) {
+      throw new Error("invalid node/cached-chain compatibility declaration");
+    }
+
+    return {
+      compatibility,
+      signal,
+      matched: false,
+      tail: "",
+      statePath:
+        env.BASE_PATH ||
+        path.resolve(
+          process.cwd(),
+          compatibility.cachedChain.projectLocalBasePath,
+        ),
+    };
+  } catch (error) {
+    console.error(
+      `[midnight-node] compatibility evidence unavailable from ${compatibilityFile}: ${error.message}`,
+    );
+    return null;
+  }
+}
+
+function observeCompatibilityEvidence(evidence, chunk) {
+  if (!evidence || evidence.matched) return;
+  const text = evidence.tail + chunk.toString();
+  if (text.includes(evidence.signal)) evidence.matched = true;
+  evidence.tail = text.slice(-Math.max(0, evidence.signal.length - 1));
+}
+
+function forwardAndObserve(stream, destination, evidence) {
+  if (!stream) return;
+  stream.on("data", (chunk) => {
+    observeCompatibilityEvidence(evidence, chunk);
+    destination.write(chunk);
+  });
+}
+
+function logVerifiedIncompatibility(evidence) {
+  const { compatibility, signal, statePath } = evidence;
+  console.error(
+    `[midnight-node] verified incompatible cached-chain state for node ${compatibility.node.version} / Ledger ${compatibility.node.ledgerGeneration}.`,
+  );
+  console.error(
+    `[midnight-node] Observed the exact verified node error "${signal}".`,
+  );
+  console.error(
+    `[midnight-node] Stop the stack, then archive or remove only ${statePath} if you choose to reset this project-local node state; no data is reset automatically.`,
+  );
+}
+
+/**
+ * Preserves the native node's completion code and emits the strongest
+ * evidence-supported classification after all captured output has closed.
+ *
+ * @param {import("child_process").ChildProcess} childProcess
+ * @param {{ evidence?: ReturnType<typeof loadCompatibilityEvidence> }} [options]
+ * @returns {Promise<number>}
+ */
+function waitForNodeCompletion(childProcess, options = {}) {
+  const evidence =
+    options.evidence === undefined
+      ? evidenceByChild.get(childProcess)
+      : options.evidence;
+
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (exitCode) => {
+      if (settled) return;
+      settled = true;
+      resolve(exitCode);
+    };
+
+    childProcess.once("error", (error) => {
+      console.error(
+        `[midnight-node] child process failed to start: ${error.message}`,
+      );
+      finish(1);
+    });
+
+    childProcess.once("close", (code, signal) => {
+      if (code === 0) {
+        finish(0);
+        return;
+      }
+
+      if (typeof code === "number") {
+        console.error(
+          `[midnight-node] child process exited with nonzero code ${code}; startup cannot continue.`,
+        );
+        if (evidence?.matched) {
+          logVerifiedIncompatibility(evidence);
+        } else if (evidence) {
+          console.error(
+            `[midnight-node] The declaration-owned incompatibility signal was not observed; no incompatible-cache classification was made. Inspect the node log.`,
+          );
+        }
+        finish(code || 1);
+        return;
+      }
+
+      console.error(
+        `[midnight-node] child process terminated by signal ${signal || "unknown"}; startup cannot continue.`,
+      );
+      finish(1);
+    });
+  });
+}
+
+/**
  * Executes the midnight-node binary as a child process
  * @param {Object} env - Environment variables to pass to the child process
  * @param {Array} args - Optional arguments to pass to the binary
@@ -28,6 +171,7 @@ function applyDefaultEnv(env) {
  */
 function runMidnightNode(env = process.env, args = []) {
   const newEnv = applyDefaultEnv(env);
+  const evidence = loadCompatibilityEvidence(newEnv);
 
   const binaryName = "midnight-node";
   const binaryPath = path.join(__dirname, "midnight-node", binaryName);
@@ -38,9 +182,15 @@ function runMidnightNode(env = process.env, args = []) {
 
   const childProcess = spawn(binaryPath, args, {
     env: newEnv,
-    stdio: "inherit", // Inherit stdin, stdout, stderr from parent process
+    stdio: evidence ? ["inherit", "pipe", "pipe"] : "inherit",
     cwd: path.join(__dirname, "midnight-node"), // Run from inside the midnight-node directory
   });
+
+  if (evidence) {
+    evidenceByChild.set(childProcess, evidence);
+    forwardAndObserve(childProcess.stdout, process.stdout, evidence);
+    forwardAndObserve(childProcess.stderr, process.stderr, evidence);
+  }
 
   childProcess.on("spawn", () => {
     console.log(`midnight-node process spawned with PID: ${childProcess.pid}`);
@@ -61,4 +211,11 @@ function runMidnightNode(env = process.env, args = []) {
   return childProcess;
 }
 
-module.exports = { applyDefaultEnv, runMidnightNode };
+module.exports = {
+  COMPATIBILITY_FILE_ENV,
+  applyDefaultEnv,
+  loadCompatibilityEvidence,
+  observeCompatibilityEvidence,
+  runMidnightNode,
+  waitForNodeCompletion,
+};

--- a/packages/binaries/midnight-node/run_midnight_node.test.js
+++ b/packages/binaries/midnight-node/run_midnight_node.test.js
@@ -1,6 +1,38 @@
-const { describe, expect, test } = require("bun:test");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const { EventEmitter } = require("events");
+const { describe, expect, spyOn, test } = require("bun:test");
 const registrations = require("./local-mock.json");
-const { applyDefaultEnv } = require("./run_midnight_node");
+const { main } = require("./index.js");
+const {
+  COMPATIBILITY_FILE_ENV,
+  applyDefaultEnv,
+  loadCompatibilityEvidence,
+  observeCompatibilityEvidence,
+  waitForNodeCompletion,
+} = require("./run_midnight_node");
+
+const VERIFIED_SIGNAL =
+  "runtime requires function imports which are not present on the host: 'env:ext_ledger_8_bridge_construct_distribute_treasury_system_tx_version_1'";
+
+function writeCompatibility(dir) {
+  const compatibilityFile = path.join(dir, "compatibility.json");
+  fs.writeFileSync(
+    compatibilityFile,
+    JSON.stringify({
+      schemaVersion: 1,
+      node: { version: "2.0.0-rc.4", ledgerGeneration: 9 },
+      indexer: { version: "4.4.0-rc.1" },
+      cachedChain: {
+        policy: "same-ledger-generation-only",
+        verifiedIncompatibilitySignal: VERIFIED_SIGNAL,
+        projectLocalBasePath: "node_modules/.cache/effectstream/midnight-node",
+      },
+    }),
+  );
+  return compatibilityFile;
+}
 
 describe("midnight-node 2.x local defaults", () => {
   test("enables the main-chain follower mock with its registrations file", () => {
@@ -17,9 +49,7 @@ describe("midnight-node 2.x local defaults", () => {
       MC__SLOT_DURATION_MILLIS: "2500",
     });
     expect(env.USE_MAIN_CHAIN_FOLLOWER_MOCK).toBe("false");
-    expect(env.MOCK_REGISTRATIONS_FILE).toBe(
-      "/tmp/custom-registrations.json",
-    );
+    expect(env.MOCK_REGISTRATIONS_FILE).toBe("/tmp/custom-registrations.json");
     expect(env.MC__SLOT_DURATION_MILLIS).toBe("2500");
   });
 
@@ -31,5 +61,95 @@ describe("midnight-node 2.x local defaults", () => {
     expect(registrations[0].permissioned[0].registration_utxo).toBe(
       "d3600cf1032b2f147d592332032975bc70aff78f78b5be96e4311c0b0b28d7d6#0",
     );
+  });
+
+  test("loads and observes only the declaration-owned exact signal", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "midnight-node-tuple-"));
+    try {
+      const compatibilityFile = writeCompatibility(dir);
+      const evidence = loadCompatibilityEvidence({
+        [COMPATIBILITY_FILE_ENV]: compatibilityFile,
+        BASE_PATH: "/tmp/project-node-state",
+      });
+
+      expect(evidence).not.toBeNull();
+      observeCompatibilityEvidence(evidence, VERIFIED_SIGNAL.slice(0, 60));
+      expect(evidence.matched).toBe(false);
+      observeCompatibilityEvidence(evidence, VERIFIED_SIGNAL.slice(60));
+      expect(evidence.matched).toBe(true);
+      expect(evidence.statePath).toBe("/tmp/project-node-state");
+    } finally {
+      fs.rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  test("keeps a known non-matching child exit distinct from incompatibility", async () => {
+    const child = new EventEmitter();
+    const errors = spyOn(console, "error").mockImplementation(() => {});
+    const evidence = {
+      compatibility: {
+        node: { version: "2.0.0-rc.4", ledgerGeneration: 9 },
+      },
+      signal: VERIFIED_SIGNAL,
+      matched: false,
+      statePath: "/tmp/project-node-state",
+    };
+
+    try {
+      const completion = waitForNodeCompletion(child, { evidence });
+      child.emit("close", 42, null);
+      expect(await completion).toBe(42);
+      const output = errors.mock.calls.flat().join("\n");
+      expect(output).toContain("child process exited with nonzero code 42");
+      expect(output).toContain("no incompatible-cache classification was made");
+      expect(output).not.toContain("verified incompatible cached-chain state");
+      expect(output).not.toContain("unknown readiness failure");
+    } finally {
+      errors.mockRestore();
+    }
+  });
+
+  test("the top-level CLI propagates exit 1 and classifies the exact signal", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "midnight-node-cli-"));
+    const binaryDir = path.join(__dirname, "midnight-node");
+    const binaryPath = path.join(binaryDir, "midnight-node");
+    const previousCompatibility = process.env[COMPATIBILITY_FILE_ENV];
+    const previousBasePath = process.env.BASE_PATH;
+    const errors = spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      expect(fs.existsSync(binaryPath)).toBe(false);
+      fs.mkdirSync(binaryDir, { recursive: true });
+      fs.writeFileSync(
+        binaryPath,
+        `#!/bin/sh\nprintf '%s\\n' "${VERIFIED_SIGNAL}" >&2\nexit 1\n`,
+        { mode: 0o755 },
+      );
+      process.env[COMPATIBILITY_FILE_ENV] = writeCompatibility(dir);
+      process.env.BASE_PATH = "/tmp/project-node-state";
+
+      expect(await main(["--dev"])).toBe(1);
+      const output = errors.mock.calls.flat().join("\n");
+      expect(output).toContain("verified incompatible cached-chain state");
+      expect(output).toContain("node 2.0.0-rc.4 / Ledger 9");
+      expect(output).toContain("Observed the exact verified node error");
+      expect(output).toContain("/tmp/project-node-state");
+      expect(output).toContain("no data is reset automatically");
+    } finally {
+      errors.mockRestore();
+      fs.rmSync(binaryPath, { force: true });
+      fs.rmSync(binaryDir, { force: true, recursive: true });
+      fs.rmSync(dir, { force: true, recursive: true });
+      if (previousCompatibility === undefined) {
+        delete process.env[COMPATIBILITY_FILE_ENV];
+      } else {
+        process.env[COMPATIBILITY_FILE_ENV] = previousCompatibility;
+      }
+      if (previousBasePath === undefined) {
+        delete process.env.BASE_PATH;
+      } else {
+        process.env.BASE_PATH = previousBasePath;
+      }
+    }
   });
 });

--- a/packages/build-tools/orchestrator/scripts/launch-midnight.ts
+++ b/packages/build-tools/orchestrator/scripts/launch-midnight.ts
@@ -5,6 +5,8 @@ import type { ProcessConfig } from "../src/config.ts";
 import { resolvePackageDir, type ResolveLocation } from "./resolve-package.ts";
 
 const waitTcpScript = new URL("./wait-tcp.ts", import.meta.url).pathname;
+export const MIDNIGHT_COMPATIBILITY_FILE_ENV =
+  "EFFECTSTREAM_MIDNIGHT_COMPATIBILITY_FILE";
 
 /**
  * Midnight's `compact` compiler is required to compile the Compact contracts
@@ -62,6 +64,26 @@ export function projectLocalMidnightNodeState(cwd: string): string {
   return join(cwd, "node_modules", ".cache", "effectstream", "midnight-node");
 }
 
+export function buildMidnightNodeProcess(
+  cwd: string,
+  packageName: string,
+  compatibilityFile: string,
+): ProcessConfig {
+  return {
+    name: MidnightNames.NODE,
+    description: `Start Midnight node (${packageName} midnight-node:start)`,
+    cwd,
+    stopProcessAtPort: [9944, 30333],
+    args: ["run", "midnight-node:start"],
+    env: {
+      BASE_PATH: projectLocalMidnightNodeState(cwd),
+      [MIDNIGHT_COMPATIBILITY_FILE_ENV]: compatibilityFile,
+    },
+    waitToExit: false,
+    critical: true,
+  };
+}
+
 export function buildMidnightIndexerWaitProcess(
   cwd: string,
   compatibilityFile: string,
@@ -103,7 +125,6 @@ export function launchMidnight(
   );
   assertCompactInstalled();
   const compatibilityFile = resolveMidnightCompatibilityFile(cwd);
-  const projectLocalNodeState = projectLocalMidnightNodeState(cwd);
   const deployEnv: Record<string, string> = {};
   if (opts?.env?.MIDNIGHT_STORAGE_PASSWORD) {
     deployEnv.MIDNIGHT_STORAGE_PASSWORD = opts.env.MIDNIGHT_STORAGE_PASSWORD;
@@ -111,16 +132,7 @@ export function launchMidnight(
   const extraDeps = opts?.dependsOn ?? [];
 
   return [
-    {
-      name: MidnightNames.NODE,
-      description: `Start Midnight node (${packageName} midnight-node:start)`,
-      cwd,
-      stopProcessAtPort: [9944, 30333],
-      args: ["run", "midnight-node:start"],
-      env: { BASE_PATH: projectLocalNodeState },
-      waitToExit: false,
-      critical: true,
-    },
+    buildMidnightNodeProcess(cwd, packageName, compatibilityFile),
     {
       name: MidnightNames.INDEXER,
       description: `Start Midnight indexer (${packageName} midnight-indexer:start)`,

--- a/packages/build-tools/orchestrator/scripts/launch-midnight.ts
+++ b/packages/build-tools/orchestrator/scripts/launch-midnight.ts
@@ -1,6 +1,10 @@
 import { spawnSync } from "node:child_process";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
 import type { ProcessConfig } from "../src/config.ts";
 import { resolvePackageDir, type ResolveLocation } from "./resolve-package.ts";
+
+const waitTcpScript = new URL("./wait-tcp.ts", import.meta.url).pathname;
 
 /**
  * Midnight's `compact` compiler is required to compile the Compact contracts
@@ -40,11 +44,48 @@ const REQUIRED_SCRIPTS = {
   "midnight-node:start": "Start the Midnight substrate node",
   "midnight-node:wait": "Wait for the Midnight node RPC (e.g. tcp:9944)",
   "midnight-indexer:start": "Start the Midnight indexer",
-  "midnight-indexer:wait": "Wait for the Midnight indexer (e.g. tcp:8088)",
   "midnight-proof-server:start": "Start the Midnight proof server",
-  "midnight-proof-server:wait": "Wait for the Midnight proof server (e.g. tcp:6300)",
+  "midnight-proof-server:wait":
+    "Wait for the Midnight proof server (e.g. tcp:6300)",
   "midnight-contract:deploy": "Deploy Midnight contracts (Compact-compiled)",
 } as const;
+
+export function resolveMidnightCompatibilityFile(cwd: string): string {
+  const requireFromProject = createRequire(join(cwd, "package.json"));
+  const packageJson = requireFromProject.resolve(
+    "@effectstream/npm-midnight-indexer/package.json",
+  );
+  return join(dirname(packageJson), "compatibility.json");
+}
+
+export function projectLocalMidnightNodeState(cwd: string): string {
+  return join(cwd, "node_modules", ".cache", "effectstream", "midnight-node");
+}
+
+export function buildMidnightIndexerWaitProcess(
+  cwd: string,
+  compatibilityFile: string,
+): ProcessConfig {
+  return {
+    name: MidnightNames.INDEXER_WAIT,
+    description: "Wait up to 60 seconds for the Midnight indexer",
+    cwd,
+    args: [
+      waitTcpScript,
+      "8088",
+      "--service",
+      "Midnight indexer",
+      "--timeout-ms",
+      "60000",
+      "--log-hint",
+      "inspect logs/midnight-indexer.log and logs/midnight-node.log",
+      "--compatibility-file",
+      compatibilityFile,
+    ],
+    waitToExit: true,
+    dependsOn: [MidnightNames.INDEXER],
+  };
+}
 
 export function launchMidnight(
   packageName: string,
@@ -54,8 +95,15 @@ export function launchMidnight(
     dependsOn?: string[];
   },
 ): ProcessConfig[] {
-  const cwd = resolvePackageDir("launchMidnight", packageName, location, REQUIRED_SCRIPTS);
+  const cwd = resolvePackageDir(
+    "launchMidnight",
+    packageName,
+    location,
+    REQUIRED_SCRIPTS,
+  );
   assertCompactInstalled();
+  const compatibilityFile = resolveMidnightCompatibilityFile(cwd);
+  const projectLocalNodeState = projectLocalMidnightNodeState(cwd);
   const deployEnv: Record<string, string> = {};
   if (opts?.env?.MIDNIGHT_STORAGE_PASSWORD) {
     deployEnv.MIDNIGHT_STORAGE_PASSWORD = opts.env.MIDNIGHT_STORAGE_PASSWORD;
@@ -69,6 +117,7 @@ export function launchMidnight(
       cwd,
       stopProcessAtPort: [9944, 30333],
       args: ["run", "midnight-node:start"],
+      env: { BASE_PATH: projectLocalNodeState },
       waitToExit: false,
       critical: true,
     },
@@ -100,14 +149,7 @@ export function launchMidnight(
       waitToExit: true,
       dependsOn: [MidnightNames.NODE],
     },
-    {
-      name: MidnightNames.INDEXER_WAIT,
-      description: `Wait for Midnight indexer (${packageName} midnight-indexer:wait)`,
-      cwd,
-      args: ["run", "midnight-indexer:wait"],
-      waitToExit: true,
-      dependsOn: [MidnightNames.INDEXER],
-    },
+    buildMidnightIndexerWaitProcess(cwd, compatibilityFile),
     {
       name: MidnightNames.PROOF_SERVER_WAIT,
       description: `Wait for Midnight proof server (${packageName} midnight-proof-server:wait)`,

--- a/packages/build-tools/orchestrator/scripts/wait-tcp.ts
+++ b/packages/build-tools/orchestrator/scripts/wait-tcp.ts
@@ -1,30 +1,225 @@
-const port = Number(process.argv.at(-1));
-if (!port || isNaN(port)) {
-  console.error("Usage: bun wait-tcp.ts <port>");
-  process.exit(1);
-}
+import { resolve } from "node:path";
 
-for (let i = 0; i < 120; i++) {
-  try {
-    const connected = await new Promise<boolean>((resolve) => {
-      Bun.connect({
-        hostname: "127.0.0.1",
-        port,
-        socket: {
-          open(socket) { socket.end(); resolve(true); },
-          data() {},
-          error() { resolve(false); },
-          close() {},
-          connectError() { resolve(false); },
+export const DEFAULT_TCP_TIMEOUT_MS = 60_000;
+export const DEFAULT_TCP_INTERVAL_MS = 500;
+
+type CompatibilityTuple = {
+  schemaVersion: number;
+  node: { version: string; ledgerGeneration: number };
+  indexer: { version: string };
+  cachedChain: {
+    policy: string;
+    verifiedIncompatibilitySignal: string;
+    projectLocalBasePath: string;
+  };
+};
+
+export type WaitTcpOptions = {
+  port: number;
+  host?: string;
+  service?: string;
+  timeoutMs?: number;
+  intervalMs?: number;
+  logHint?: string;
+  compatibilityFile?: string;
+  connect?: () => Promise<boolean>;
+  now?: () => number;
+  sleep?: (milliseconds: number) => Promise<void>;
+};
+
+export type WaitTcpResult = {
+  ok: boolean;
+  elapsedMs: number;
+};
+
+async function connectTcp(host: string, port: number): Promise<boolean> {
+  return new Promise<boolean>((resolveConnection) => {
+    let settled = false;
+    const finish = (connected: boolean) => {
+      if (settled) return;
+      settled = true;
+      resolveConnection(connected);
+    };
+
+    Bun.connect({
+      hostname: host,
+      port,
+      socket: {
+        open(socket) {
+          finish(true);
+          socket.end();
         },
-      }).catch(() => resolve(false));
-    });
-    if (connected) process.exit(0);
-  } catch {
-    // fallthrough to retry
-  }
-  await Bun.sleep(500);
+        data() {},
+        error() {
+          finish(false);
+        },
+        close() {
+          finish(false);
+        },
+        connectError() {
+          finish(false);
+        },
+      },
+    }).catch(() => finish(false));
+  });
 }
 
-console.error(`Timed out waiting for tcp:${port}`);
-process.exit(1);
+async function readCompatibility(
+  compatibilityFile: string,
+): Promise<CompatibilityTuple> {
+  const parsed = await Bun.file(compatibilityFile).json();
+  if (
+    parsed?.schemaVersion !== 1 ||
+    typeof parsed?.node?.version !== "string" ||
+    typeof parsed?.node?.ledgerGeneration !== "number" ||
+    typeof parsed?.indexer?.version !== "string" ||
+    typeof parsed?.cachedChain?.policy !== "string" ||
+    typeof parsed?.cachedChain?.verifiedIncompatibilitySignal !== "string" ||
+    typeof parsed?.cachedChain?.projectLocalBasePath !== "string"
+  ) {
+    throw new Error(`invalid compatibility tuple: ${compatibilityFile}`);
+  }
+  return parsed as CompatibilityTuple;
+}
+
+async function printTimeoutDiagnostics(
+  options: Required<
+    Pick<WaitTcpOptions, "host" | "port" | "service" | "timeoutMs" | "logHint">
+  > &
+    Pick<WaitTcpOptions, "compatibilityFile">,
+  elapsedMs: number,
+): Promise<void> {
+  console.error(
+    `Timed out waiting for ${options.service} at tcp://${options.host}:${options.port} after ${elapsedMs}ms (unknown readiness failure).`,
+  );
+  console.error(`Next action: ${options.logHint}`);
+
+  if (!options.compatibilityFile) return;
+
+  try {
+    const compatibility = await readCompatibility(options.compatibilityFile);
+    const localState = resolve(
+      process.cwd(),
+      compatibility.cachedChain.projectLocalBasePath,
+    );
+    console.error(
+      `Bundled compatibility: node ${compatibility.node.version}, Ledger ${compatibility.node.ledgerGeneration}, indexer ${compatibility.indexer.version}; cached-chain policy ${compatibility.cachedChain.policy}.`,
+    );
+    console.error(
+      `Possible stale state: only the exact node-log signal "${compatibility.cachedChain.verifiedIncompatibilitySignal}" proves an incompatible Ledger-8 cache. Without it, this remains an unknown readiness failure.`,
+    );
+    console.error(
+      `Indexer --clean removes only indexer SQLite data. After stopping the stack, archive or remove only ${localState} if you choose a project-local node reset; no data is reset automatically.`,
+    );
+  } catch (error) {
+    console.error(
+      `Compatibility diagnostics unavailable: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+}
+
+export async function waitForTcp(
+  options: WaitTcpOptions,
+): Promise<WaitTcpResult> {
+  const host = options.host ?? "127.0.0.1";
+  const service = options.service ?? `tcp:${options.port}`;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TCP_TIMEOUT_MS;
+  const intervalMs = options.intervalMs ?? DEFAULT_TCP_INTERVAL_MS;
+  const logHint = options.logHint ?? "inspect the owning service log";
+  const now = options.now ?? Date.now;
+  const sleep = options.sleep ?? Bun.sleep;
+  const connect = options.connect ?? (() => connectTcp(host, options.port));
+
+  if (
+    !Number.isInteger(options.port) ||
+    options.port < 1 ||
+    options.port > 65_535
+  ) {
+    throw new Error(`invalid TCP port: ${options.port}`);
+  }
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    throw new Error(`invalid timeout: ${timeoutMs}`);
+  }
+  if (!Number.isFinite(intervalMs) || intervalMs <= 0) {
+    throw new Error(`invalid interval: ${intervalMs}`);
+  }
+
+  const startedAt = now();
+  while (now() - startedAt < timeoutMs) {
+    if (await connect()) {
+      return { ok: true, elapsedMs: now() - startedAt };
+    }
+    const remaining = timeoutMs - (now() - startedAt);
+    if (remaining > 0) await sleep(Math.min(intervalMs, remaining));
+  }
+
+  const elapsedMs = now() - startedAt;
+  await printTimeoutDiagnostics(
+    {
+      host,
+      port: options.port,
+      service,
+      timeoutMs,
+      logHint,
+      compatibilityFile: options.compatibilityFile,
+    },
+    elapsedMs,
+  );
+  return { ok: false, elapsedMs };
+}
+
+function requireValue(args: string[], index: number, flag: string): string {
+  const value = args[index + 1];
+  if (!value) throw new Error(`${flag} requires a value`);
+  return value;
+}
+
+export function parseWaitTcpArgs(args: string[]): WaitTcpOptions {
+  const port = Number(args[0]);
+  if (!Number.isInteger(port) || port < 1 || port > 65_535) {
+    throw new Error(
+      "Usage: bun wait-tcp.ts <port> [--host <host>] [--service <label>] [--timeout-ms <milliseconds>] [--log-hint <hint>] [--compatibility-file <path>]",
+    );
+  }
+
+  const options: WaitTcpOptions = { port };
+  for (let index = 1; index < args.length; index += 1) {
+    const flag = args[index];
+    if (flag === "--host") {
+      options.host = requireValue(args, index, flag);
+      index += 1;
+    } else if (flag === "--service") {
+      options.service = requireValue(args, index, flag);
+      index += 1;
+    } else if (flag === "--timeout-ms") {
+      options.timeoutMs = Number(requireValue(args, index, flag));
+      index += 1;
+    } else if (flag === "--interval-ms") {
+      options.intervalMs = Number(requireValue(args, index, flag));
+      index += 1;
+    } else if (flag === "--log-hint") {
+      options.logHint = requireValue(args, index, flag);
+      index += 1;
+    } else if (flag === "--compatibility-file") {
+      options.compatibilityFile = requireValue(args, index, flag);
+      index += 1;
+    } else {
+      throw new Error(`unknown argument: ${flag}`);
+    }
+  }
+  return options;
+}
+
+export async function runWaitTcpCli(args: string[]): Promise<number> {
+  try {
+    const result = await waitForTcp(parseWaitTcpArgs(args));
+    return result.ok ? 0 : 1;
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    return 1;
+  }
+}
+
+if (import.meta.main) {
+  process.exitCode = await runWaitTcpCli(process.argv.slice(2));
+}

--- a/packages/build-tools/orchestrator/test/launch-midnight.test.ts
+++ b/packages/build-tools/orchestrator/test/launch-midnight.test.ts
@@ -1,20 +1,18 @@
 import { describe, expect, test } from "bun:test";
-import {
-  mkdirSync,
-  mkdtempSync,
-  readFileSync,
-  rmSync,
-  symlinkSync,
-  writeFileSync,
-} from "node:fs";
-import { tmpdir } from "node:os";
+import { existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import {
+  buildMidnightNodeProcess,
   buildMidnightIndexerWaitProcess,
+  MIDNIGHT_COMPATIBILITY_FILE_ENV,
   MidnightNames,
   projectLocalMidnightNodeState,
-  resolveMidnightCompatibilityFile,
 } from "../scripts/launch-midnight.ts";
+
+const repoRoot = resolve(import.meta.dir, "../../../..");
+const BOUNDED_EFFECTSTREAM_WAIT =
+  "wait-on --timeout ${MIDNIGHT_INDEXER_WAIT_TIMEOUT_MS:-60000} tcp:${MIDNIGHT_INDEXER_PORT:-8088}";
+const BOUNDED_PAIMA_WAIT = `bunx ${BOUNDED_EFFECTSTREAM_WAIT}`;
 
 describe("Midnight startup configuration", () => {
   test("uses one project-local ignored node state directory", () => {
@@ -23,29 +21,21 @@ describe("Midnight startup configuration", () => {
     );
   });
 
-  test("resolves the installed indexer compatibility declaration", () => {
-    const project = mkdtempSync(resolve(tmpdir(), "midnight-compatibility-"));
-    const scope = resolve(project, "node_modules/@effectstream");
-    const indexerPackage = resolve(
-      import.meta.dir,
-      "../../../binaries/midnight-indexer",
+  test("hands the one installed compatibility declaration to the node wrapper", () => {
+    const process = buildMidnightNodeProcess(
+      "/workspace/contracts-midnight",
+      "@example/contracts-midnight",
+      "/workspace/indexer/compatibility.json",
     );
 
-    try {
-      mkdirSync(scope, { recursive: true });
-      writeFileSync(resolve(project, "package.json"), "{}\n");
-      symlinkSync(
-        indexerPackage,
-        resolve(scope, "npm-midnight-indexer"),
-        "dir",
-      );
-
-      expect(resolveMidnightCompatibilityFile(project)).toBe(
-        resolve(indexerPackage, "compatibility.json"),
-      );
-    } finally {
-      rmSync(project, { force: true, recursive: true });
-    }
+    expect(process.name).toBe(MidnightNames.NODE);
+    expect(process.env).toEqual({
+      BASE_PATH:
+        "/workspace/contracts-midnight/node_modules/.cache/effectstream/midnight-node",
+      [MIDNIGHT_COMPATIBILITY_FILE_ENV]:
+        "/workspace/indexer/compatibility.json",
+    });
+    expect(process.critical).toBe(true);
   });
 
   test("uses the bounded packaged probe instead of a template wait script", () => {
@@ -64,22 +54,81 @@ describe("Midnight startup configuration", () => {
     expect(process.args).not.toContain("midnight-indexer:wait");
   });
 
-  test("Midnight templates no longer expose an unbounded indexer wait script", () => {
-    const repoRoot = resolve(import.meta.dir, "../../../..");
-    const manifests = [
-      "templates/evm-midnight-v2/packages/contracts-midnight/package.json",
-      "templates/night-bitcoin-v2/packages/contracts-midnight/package.json",
-      "templates/zk-cardano/packages/contracts-midnight/package.json",
-      "templates/multi-chain-token-transfer/packages/shared/contracts/midnight/package.json",
+  test("0.200.1 templates retain the old launcher's bounded script contract", () => {
+    const templates = [
+      "templates/evm-midnight-v2",
+      "templates/night-bitcoin-v2",
+      "templates/zk-cardano",
     ];
 
-    for (const manifest of manifests) {
-      const parsed = JSON.parse(
-        readFileSync(resolve(repoRoot, manifest), "utf8"),
+    for (const template of templates) {
+      const rootManifest = JSON.parse(
+        readFileSync(resolve(repoRoot, template, "package.json"), "utf8"),
       );
-      expect(parsed.scripts["midnight-indexer:wait"]).toBeUndefined();
-      expect(parsed.scripts["midnight-node:wait"]).toBeString();
-      expect(parsed.scripts["midnight-proof-server:wait"]).toBeString();
+      const contractsManifest = JSON.parse(
+        readFileSync(
+          resolve(
+            repoRoot,
+            template,
+            "packages/contracts-midnight/package.json",
+          ),
+          "utf8",
+        ),
+      );
+      const lock = readFileSync(
+        resolve(repoRoot, template, "bun.lock"),
+        "utf8",
+      );
+
+      expect(rootManifest.dependencies["@effectstream/orchestrator"]).toBe(
+        "0.200.1",
+      );
+      expect(
+        contractsManifest.dependencies["@effectstream/npm-midnight-indexer"],
+      ).toBe("0.200.1");
+      expect(contractsManifest.scripts["midnight-indexer:wait"]).toBe(
+        BOUNDED_EFFECTSTREAM_WAIT,
+      );
+      expect(lock).toContain('"@effectstream/orchestrator@0.200.1"');
+      expect(lock).toContain('"@effectstream/npm-midnight-indexer@0.200.1"');
+      expect(lock).toContain('"wait-on@8.0.3"');
     }
+  });
+
+  test("multi-chain retains its bounded legacy @paimaexample contract", () => {
+    const template = resolve(repoRoot, "templates/multi-chain-token-transfer");
+    const startSource = readFileSync(
+      resolve(template, "packages/client/node/scripts/start.ts"),
+      "utf8",
+    );
+    const nodeManifest = JSON.parse(
+      readFileSync(
+        resolve(template, "packages/client/node/package.json"),
+        "utf8",
+      ),
+    );
+    const contractsManifest = JSON.parse(
+      readFileSync(
+        resolve(template, "packages/shared/contracts/midnight/package.json"),
+        "utf8",
+      ),
+    );
+
+    expect(startSource).toContain(
+      'from "@paimaexample/orchestrator/start-midnight"',
+    );
+    expect(nodeManifest.dependencies["@paimaexample/orchestrator"]).toBe(
+      "0.3.116",
+    );
+    expect(
+      contractsManifest.dependencies["@paimaexample/npm-midnight-indexer"],
+    ).toBe("0.3.116");
+    expect(contractsManifest.scripts["midnight-indexer:wait"]).toBe(
+      BOUNDED_PAIMA_WAIT,
+    );
+    expect(contractsManifest.dependencies).not.toHaveProperty(
+      "@effectstream/npm-midnight-indexer",
+    );
+    expect(existsSync(resolve(template, "bun.lock"))).toBe(false);
   });
 });

--- a/packages/build-tools/orchestrator/test/launch-midnight.test.ts
+++ b/packages/build-tools/orchestrator/test/launch-midnight.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "bun:test";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import {
+  buildMidnightIndexerWaitProcess,
+  MidnightNames,
+  projectLocalMidnightNodeState,
+  resolveMidnightCompatibilityFile,
+} from "../scripts/launch-midnight.ts";
+
+describe("Midnight startup configuration", () => {
+  test("uses one project-local ignored node state directory", () => {
+    expect(projectLocalMidnightNodeState("/workspace/contracts-midnight")).toBe(
+      "/workspace/contracts-midnight/node_modules/.cache/effectstream/midnight-node",
+    );
+  });
+
+  test("resolves the installed indexer compatibility declaration", () => {
+    const project = mkdtempSync(resolve(tmpdir(), "midnight-compatibility-"));
+    const scope = resolve(project, "node_modules/@effectstream");
+    const indexerPackage = resolve(
+      import.meta.dir,
+      "../../../binaries/midnight-indexer",
+    );
+
+    try {
+      mkdirSync(scope, { recursive: true });
+      writeFileSync(resolve(project, "package.json"), "{}\n");
+      symlinkSync(
+        indexerPackage,
+        resolve(scope, "npm-midnight-indexer"),
+        "dir",
+      );
+
+      expect(resolveMidnightCompatibilityFile(project)).toBe(
+        resolve(indexerPackage, "compatibility.json"),
+      );
+    } finally {
+      rmSync(project, { force: true, recursive: true });
+    }
+  });
+
+  test("uses the bounded packaged probe instead of a template wait script", () => {
+    const process = buildMidnightIndexerWaitProcess(
+      "/workspace/contracts-midnight",
+      "/workspace/indexer/compatibility.json",
+    );
+
+    expect(process.name).toBe(MidnightNames.INDEXER_WAIT);
+    expect(process.waitToExit).toBe(true);
+    expect(process.dependsOn).toEqual([MidnightNames.INDEXER]);
+    expect(process.args.at(0)).toEndWith("/wait-tcp.ts");
+    expect(process.args).toContain("60000");
+    expect(process.args).toContain("Midnight indexer");
+    expect(process.args).toContain("/workspace/indexer/compatibility.json");
+    expect(process.args).not.toContain("midnight-indexer:wait");
+  });
+
+  test("Midnight templates no longer expose an unbounded indexer wait script", () => {
+    const repoRoot = resolve(import.meta.dir, "../../../..");
+    const manifests = [
+      "templates/evm-midnight-v2/packages/contracts-midnight/package.json",
+      "templates/night-bitcoin-v2/packages/contracts-midnight/package.json",
+      "templates/zk-cardano/packages/contracts-midnight/package.json",
+      "templates/multi-chain-token-transfer/packages/shared/contracts/midnight/package.json",
+    ];
+
+    for (const manifest of manifests) {
+      const parsed = JSON.parse(
+        readFileSync(resolve(repoRoot, manifest), "utf8"),
+      );
+      expect(parsed.scripts["midnight-indexer:wait"]).toBeUndefined();
+      expect(parsed.scripts["midnight-node:wait"]).toBeString();
+      expect(parsed.scripts["midnight-proof-server:wait"]).toBeString();
+    }
+  });
+});

--- a/packages/build-tools/orchestrator/test/wait-tcp.test.ts
+++ b/packages/build-tools/orchestrator/test/wait-tcp.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, spyOn, test } from "bun:test";
+import {
+  DEFAULT_TCP_TIMEOUT_MS,
+  parseWaitTcpArgs,
+  waitForTcp,
+} from "../scripts/wait-tcp.ts";
+
+describe("bounded TCP readiness", () => {
+  test("uses a 60-second default and parses diagnostic fields", () => {
+    expect(DEFAULT_TCP_TIMEOUT_MS).toBe(60_000);
+    expect(
+      parseWaitTcpArgs([
+        "18771",
+        "--service",
+        "Midnight indexer",
+        "--timeout-ms",
+        "2500",
+        "--log-hint",
+        "inspect logs/midnight-indexer.log",
+        "--compatibility-file",
+        "/tmp/compatibility.json",
+      ]),
+    ).toEqual({
+      port: 18771,
+      service: "Midnight indexer",
+      timeoutMs: 2500,
+      logHint: "inspect logs/midnight-indexer.log",
+      compatibilityFile: "/tmp/compatibility.json",
+    });
+  });
+
+  test("returns immediately when the listener is ready", async () => {
+    let attempts = 0;
+    const result = await waitForTcp({
+      port: 18772,
+      connect: async () => {
+        attempts += 1;
+        return true;
+      },
+    });
+    expect(result.ok).toBe(true);
+    expect(attempts).toBe(1);
+  });
+
+  test("connects to a real listener above port 10000", async () => {
+    const port = Number(process.env.WAIT_TCP_TEST_LISTENER_PORT || 18777);
+    const server = Bun.serve({
+      hostname: "127.0.0.1",
+      port,
+      fetch() {
+        return new Response("ok");
+      },
+    });
+    try {
+      const result = await waitForTcp({
+        port,
+        service: "test listener",
+        timeoutMs: 1000,
+        intervalMs: 10,
+      });
+      expect(result.ok).toBe(true);
+      expect(result.elapsedMs).toBeLessThan(1000);
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test("fails at the configured bound with labeled next action", async () => {
+    let clock = 0;
+    const errors = spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const result = await waitForTcp({
+        port: 18773,
+        service: "Midnight indexer",
+        timeoutMs: 100,
+        intervalMs: 25,
+        logHint: "inspect logs/midnight-indexer.log",
+        connect: async () => false,
+        now: () => clock,
+        sleep: async (milliseconds) => {
+          clock += milliseconds;
+        },
+      });
+
+      expect(result).toEqual({ ok: false, elapsedMs: 100 });
+      const output = errors.mock.calls.flat().join("\n");
+      expect(output).toContain("Midnight indexer");
+      expect(output).toContain("tcp://127.0.0.1:18773");
+      expect(output).toContain("after 100ms");
+      expect(output).toContain("unknown readiness failure");
+      expect(output).toContain("inspect logs/midnight-indexer.log");
+    } finally {
+      errors.mockRestore();
+    }
+  });
+
+  test("reads the compatibility tuple without overclaiming a timeout", async () => {
+    let clock = 0;
+    const errors = spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const compatibilityFile = new URL(
+        "../../../binaries/midnight-indexer/compatibility.json",
+        import.meta.url,
+      ).pathname;
+      const result = await waitForTcp({
+        port: 18774,
+        service: "Midnight indexer",
+        timeoutMs: 10,
+        intervalMs: 10,
+        logHint: "inspect both service logs",
+        compatibilityFile,
+        connect: async () => false,
+        now: () => clock,
+        sleep: async (milliseconds) => {
+          clock += milliseconds;
+        },
+      });
+
+      expect(result.ok).toBe(false);
+      const output = errors.mock.calls.flat().join("\n");
+      expect(output).toContain("node 2.0.0-rc.4");
+      expect(output).toContain("Ledger 9");
+      expect(output).toContain("indexer 4.4.0-rc.1");
+      expect(output).toContain("only the exact node-log signal");
+      expect(output).toContain(
+        "Without it, this remains an unknown readiness failure",
+      );
+      expect(output).toContain(
+        "Indexer --clean removes only indexer SQLite data",
+      );
+      expect(output).toContain("no data is reset automatically");
+    } finally {
+      errors.mockRestore();
+    }
+  });
+});

--- a/templates/evm-midnight-v2/packages/contracts-midnight/package.json
+++ b/templates/evm-midnight-v2/packages/contracts-midnight/package.json
@@ -6,7 +6,6 @@
     "midnight-node:start": "MIDNIGHT_STORAGE_PASSWORD=YourPasswordMy1! CFG_PRESET=dev bun ./node_modules/.bin/npm-midnight-node --dev --rpc-port 9944 --port 30333 --state-pruning archive --blocks-pruning archive --public-addr /ip4/127.0.0.1 --unsafe-rpc-external",
     "midnight-node:wait": "wait-on tcp:9944",
     "midnight-indexer:start": "RUST_BACKTRACE=1 LEDGER_NETWORK_ID=\"Undeployed\" SUBSTRATE_NODE_WS_URL=\"ws://localhost:9944\" APP__INFRA__SECRET=$(openssl rand -hex 32 | tr 'a-f' 'A-F') FEATURES_WALLET_ENABLED=\"true\" APP__INFRA__NODE__URL=\"ws://localhost:9944\" bun ./node_modules/.bin/npm-midnight-indexer --binary --clean",
-    "midnight-indexer:wait": "wait-on tcp:8088",
     "midnight-proof-server:start": "RUST_BACKTRACE=full SUBSTRATE_NODE_WS_URL=\"ws://localhost:9944\" bun ./node_modules/.bin/npm-midnight-proof-server",
     "midnight-proof-server:wait": "wait-on tcp:6300",
     "midnight-contract:clean": "rm -rf midnight-level-db && rm -f contract.json contract-round-value.undeployed.json",

--- a/templates/evm-midnight-v2/packages/contracts-midnight/package.json
+++ b/templates/evm-midnight-v2/packages/contracts-midnight/package.json
@@ -6,6 +6,7 @@
     "midnight-node:start": "MIDNIGHT_STORAGE_PASSWORD=YourPasswordMy1! CFG_PRESET=dev bun ./node_modules/.bin/npm-midnight-node --dev --rpc-port 9944 --port 30333 --state-pruning archive --blocks-pruning archive --public-addr /ip4/127.0.0.1 --unsafe-rpc-external",
     "midnight-node:wait": "wait-on tcp:9944",
     "midnight-indexer:start": "RUST_BACKTRACE=1 LEDGER_NETWORK_ID=\"Undeployed\" SUBSTRATE_NODE_WS_URL=\"ws://localhost:9944\" APP__INFRA__SECRET=$(openssl rand -hex 32 | tr 'a-f' 'A-F') FEATURES_WALLET_ENABLED=\"true\" APP__INFRA__NODE__URL=\"ws://localhost:9944\" bun ./node_modules/.bin/npm-midnight-indexer --binary --clean",
+    "midnight-indexer:wait": "wait-on --timeout ${MIDNIGHT_INDEXER_WAIT_TIMEOUT_MS:-60000} tcp:${MIDNIGHT_INDEXER_PORT:-8088}",
     "midnight-proof-server:start": "RUST_BACKTRACE=full SUBSTRATE_NODE_WS_URL=\"ws://localhost:9944\" bun ./node_modules/.bin/npm-midnight-proof-server",
     "midnight-proof-server:wait": "wait-on tcp:6300",
     "midnight-contract:clean": "rm -rf midnight-level-db && rm -f contract.json contract-round-value.undeployed.json",

--- a/templates/multi-chain-token-transfer/packages/shared/contracts/midnight/package.json
+++ b/templates/multi-chain-token-transfer/packages/shared/contracts/midnight/package.json
@@ -8,6 +8,7 @@
     "midnight-node:start": "CFG_PRESET=dev bunx @paimaexample/npm-midnight-node --dev --rpc-port 9944 --state-pruning archive --blocks-pruning archive --public-addr /ip4/127.0.0.1 --unsafe-rpc-external",
     "midnight-node:wait": "bunx wait-on tcp:9944",
     "midnight-indexer:start": "CONFIG_FILE=`pwd`/indexer-standalone/config.yaml LEDGER_NETWORK_ID=\"Undeployed\" SUBSTRATE_NODE_WS_URL=\"ws://localhost:9944\" APP__INFRA__SECRET=$(openssl rand -hex 32 | tr 'a-f' 'A-F') FEATURES_WALLET_ENABLED=\"true\" APP__INFRA__NODE__URL=\"ws://localhost:9944\" bunx @paimaexample/npm-midnight-indexer --binary --clean",
+    "midnight-indexer:wait": "bunx wait-on --timeout ${MIDNIGHT_INDEXER_WAIT_TIMEOUT_MS:-60000} tcp:${MIDNIGHT_INDEXER_PORT:-8088}",
     "midnight-proof-server:start": "LEDGER_NETWORK_ID=\"Undeployed\" RUST_BACKTRACE=full SUBSTRATE_NODE_WS_URL=\"ws://localhost:9944\" bunx @paimaexample/npm-midnight-proof-server",
     "midnight-proof-server:wait": "bunx wait-on tcp:6300",
     "midnight-contract:clean": "rm -rf midnight-level-db && rm -rf contract.json",

--- a/templates/multi-chain-token-transfer/packages/shared/contracts/midnight/package.json
+++ b/templates/multi-chain-token-transfer/packages/shared/contracts/midnight/package.json
@@ -8,7 +8,6 @@
     "midnight-node:start": "CFG_PRESET=dev bunx @paimaexample/npm-midnight-node --dev --rpc-port 9944 --state-pruning archive --blocks-pruning archive --public-addr /ip4/127.0.0.1 --unsafe-rpc-external",
     "midnight-node:wait": "bunx wait-on tcp:9944",
     "midnight-indexer:start": "CONFIG_FILE=`pwd`/indexer-standalone/config.yaml LEDGER_NETWORK_ID=\"Undeployed\" SUBSTRATE_NODE_WS_URL=\"ws://localhost:9944\" APP__INFRA__SECRET=$(openssl rand -hex 32 | tr 'a-f' 'A-F') FEATURES_WALLET_ENABLED=\"true\" APP__INFRA__NODE__URL=\"ws://localhost:9944\" bunx @paimaexample/npm-midnight-indexer --binary --clean",
-    "midnight-indexer:wait": "bunx wait-on tcp:8088",
     "midnight-proof-server:start": "LEDGER_NETWORK_ID=\"Undeployed\" RUST_BACKTRACE=full SUBSTRATE_NODE_WS_URL=\"ws://localhost:9944\" bunx @paimaexample/npm-midnight-proof-server",
     "midnight-proof-server:wait": "bunx wait-on tcp:6300",
     "midnight-contract:clean": "rm -rf midnight-level-db && rm -rf contract.json",

--- a/templates/night-bitcoin-v2/packages/contracts-midnight/package.json
+++ b/templates/night-bitcoin-v2/packages/contracts-midnight/package.json
@@ -8,7 +8,6 @@
     "midnight-node:start": "MIDNIGHT_STORAGE_PASSWORD=YourPasswordMy1! CFG_PRESET=dev bun ./node_modules/.bin/npm-midnight-node --dev --rpc-port 9944 --port 30333 --state-pruning archive --blocks-pruning archive --public-addr /ip4/127.0.0.1 --unsafe-rpc-external",
     "midnight-node:wait": "wait-on tcp:9944",
     "midnight-indexer:start": "RUST_BACKTRACE=1 LEDGER_NETWORK_ID=\"Undeployed\" SUBSTRATE_NODE_WS_URL=\"ws://localhost:9944\" APP__INFRA__SECRET=$(openssl rand -hex 32 | tr 'a-f' 'A-F') FEATURES_WALLET_ENABLED=\"true\" APP__INFRA__NODE__URL=\"ws://localhost:9944\" bun ./node_modules/.bin/npm-midnight-indexer --binary --clean",
-    "midnight-indexer:wait": "wait-on tcp:8088",
     "midnight-proof-server:start": "RUST_BACKTRACE=full SUBSTRATE_NODE_WS_URL=\"ws://localhost:9944\" bun ./node_modules/.bin/npm-midnight-proof-server",
     "midnight-proof-server:wait": "wait-on tcp:6300",
     "midnight-contract:clean": "rm -rf midnight-level-db && rm -f contract.json erc7683.undeployed.json unshielded-erc20.undeployed.json",

--- a/templates/night-bitcoin-v2/packages/contracts-midnight/package.json
+++ b/templates/night-bitcoin-v2/packages/contracts-midnight/package.json
@@ -8,6 +8,7 @@
     "midnight-node:start": "MIDNIGHT_STORAGE_PASSWORD=YourPasswordMy1! CFG_PRESET=dev bun ./node_modules/.bin/npm-midnight-node --dev --rpc-port 9944 --port 30333 --state-pruning archive --blocks-pruning archive --public-addr /ip4/127.0.0.1 --unsafe-rpc-external",
     "midnight-node:wait": "wait-on tcp:9944",
     "midnight-indexer:start": "RUST_BACKTRACE=1 LEDGER_NETWORK_ID=\"Undeployed\" SUBSTRATE_NODE_WS_URL=\"ws://localhost:9944\" APP__INFRA__SECRET=$(openssl rand -hex 32 | tr 'a-f' 'A-F') FEATURES_WALLET_ENABLED=\"true\" APP__INFRA__NODE__URL=\"ws://localhost:9944\" bun ./node_modules/.bin/npm-midnight-indexer --binary --clean",
+    "midnight-indexer:wait": "wait-on --timeout ${MIDNIGHT_INDEXER_WAIT_TIMEOUT_MS:-60000} tcp:${MIDNIGHT_INDEXER_PORT:-8088}",
     "midnight-proof-server:start": "RUST_BACKTRACE=full SUBSTRATE_NODE_WS_URL=\"ws://localhost:9944\" bun ./node_modules/.bin/npm-midnight-proof-server",
     "midnight-proof-server:wait": "wait-on tcp:6300",
     "midnight-contract:clean": "rm -rf midnight-level-db && rm -f contract.json erc7683.undeployed.json unshielded-erc20.undeployed.json",

--- a/templates/zk-cardano/packages/contracts-midnight/package.json
+++ b/templates/zk-cardano/packages/contracts-midnight/package.json
@@ -6,7 +6,6 @@
     "midnight-node:start": "MIDNIGHT_STORAGE_PASSWORD=YourPasswordMy1! CFG_PRESET=dev bun ./node_modules/.bin/npm-midnight-node --dev --rpc-port 9944 --port 30333 --state-pruning archive --blocks-pruning archive --public-addr /ip4/127.0.0.1 --unsafe-rpc-external",
     "midnight-node:wait": "wait-on tcp:9944",
     "midnight-indexer:start": "RUST_BACKTRACE=1 LEDGER_NETWORK_ID=\"Undeployed\" SUBSTRATE_NODE_WS_URL=\"ws://localhost:9944\" APP__INFRA__SECRET=$(openssl rand -hex 32 | tr 'a-f' 'A-F') FEATURES_WALLET_ENABLED=\"true\" APP__INFRA__NODE__URL=\"ws://localhost:9944\" bun ./node_modules/.bin/npm-midnight-indexer --binary --clean",
-    "midnight-indexer:wait": "wait-on tcp:8088",
     "midnight-proof-server:start": "RUST_BACKTRACE=full SUBSTRATE_NODE_WS_URL=\"ws://localhost:9944\" bun ./node_modules/.bin/npm-midnight-proof-server",
     "midnight-proof-server:wait": "wait-on tcp:6300",
     "midnight-contract:clean": "rm -rf midnight-level-db && rm -f contract.json contract-ballot.undeployed.json",

--- a/templates/zk-cardano/packages/contracts-midnight/package.json
+++ b/templates/zk-cardano/packages/contracts-midnight/package.json
@@ -6,6 +6,7 @@
     "midnight-node:start": "MIDNIGHT_STORAGE_PASSWORD=YourPasswordMy1! CFG_PRESET=dev bun ./node_modules/.bin/npm-midnight-node --dev --rpc-port 9944 --port 30333 --state-pruning archive --blocks-pruning archive --public-addr /ip4/127.0.0.1 --unsafe-rpc-external",
     "midnight-node:wait": "wait-on tcp:9944",
     "midnight-indexer:start": "RUST_BACKTRACE=1 LEDGER_NETWORK_ID=\"Undeployed\" SUBSTRATE_NODE_WS_URL=\"ws://localhost:9944\" APP__INFRA__SECRET=$(openssl rand -hex 32 | tr 'a-f' 'A-F') FEATURES_WALLET_ENABLED=\"true\" APP__INFRA__NODE__URL=\"ws://localhost:9944\" bun ./node_modules/.bin/npm-midnight-indexer --binary --clean",
+    "midnight-indexer:wait": "wait-on --timeout ${MIDNIGHT_INDEXER_WAIT_TIMEOUT_MS:-60000} tcp:${MIDNIGHT_INDEXER_PORT:-8088}",
     "midnight-proof-server:start": "RUST_BACKTRACE=full SUBSTRATE_NODE_WS_URL=\"ws://localhost:9944\" bun ./node_modules/.bin/npm-midnight-proof-server",
     "midnight-proof-server:wait": "wait-on tcp:6300",
     "midnight-contract:clean": "rm -rf midnight-level-db && rm -f contract.json contract-ballot.undeployed.json",


### PR DESCRIPTION
## Summary

- propagate native Midnight indexer and node child failures to the owning startup task instead of allowing their wrappers to report success;
- replace the indexer's delegated unbounded readiness wait with a labeled, direct 60-second probe and a 55-second block-one startup guard;
- carry one installed node/indexer compatibility declaration into node startup, and classify cached-chain incompatibility only after observing its exact verified Ledger-8 signal;
- retain backwards-compatible bounded wait scripts for templates that still install older launcher contracts.

## Verified failure evidence

- On the audited baseline, a disposable native indexer child exited `42` and the wrapper logged that exit, but the wrapper itself returned `0` in `0.39s`.
- EVM-Midnight, Night-Bitcoin, zk-Cardano, and multi-chain-token-transfer exposed `midnight-indexer:wait` as `wait-on tcp:8088` / `bunx wait-on tcp:8088` with no timeout. The launcher delegated startup to that package script, so `bun run dev` could remain pending after a service failure.
- A checksummed node-1/Ledger-8 snapshot produced block one under `midnightntwrk/midnight-node:1.0.0@sha256:ede01da35e982b6a4b85461ad8492ae2753ef14246fba33c8039b782aa8e39fb`. Exact current node `2.0.0-rc.4@sha256:caf93d6f9fb3630c906ef3e714c151655377f3d28f907d17545de1870514da2e` then exited `1` with:

  ```text
  runtime requires function imports which are not present on the host: 'env:ext_ledger_8_bridge_construct_distribute_treasury_system_tx_version_1'
  ```

  Exact current indexer `4.4.0-rc.1@sha256:5d79f3a20da9ed86236c7f7dc9d93b1beeb0b0c47c9c43a791041322eb80b74e` could still open TCP 8088 after that node failure. TCP readiness alone is therefore insufficient.

## Bounded, evidence-qualified behavior

- Wrapper CLIs remain attached to the native child and preserve nonzero results. Known child exits/signals remain known; they are not relabeled as unknown readiness failures.
- The new launcher invokes the packaged indexer probe directly with a finite 60-second default. Timeout output names the service, endpoint, elapsed timeout, log next action, bundled node-2/Ledger-9 tuple, and project-local state path.
- The indexer waits up to 55 seconds for node block one before starting. A fresh compatible chain may become ready within that allowance; a missing block or TCP timeout remains an unknown readiness failure with conditional compatibility context.
- The launcher resolves the single `compatibility.json` from the installed indexer package and supplies it to the node wrapper. Only a nonzero node child that emits the declaration-owned exact Ledger-8 signal above receives the verified incompatible-cache classification. Bare TCP, arbitrary child exits, and generic timeouts cannot trigger it.
- No code automatically deletes, migrates, or resets chain state. Indexer `--clean` removes only indexer SQLite data. If the exact signal is observed, stop the stack and archive or remove only the named project-local node state if you deliberately choose to reset it.

## Template compatibility strategy

- EVM-Midnight, Night-Bitcoin, and zk-Cardano still pin `@effectstream/orchestrator` and `@effectstream/npm-midnight-indexer` `0.200.1`. They retain an environment-overridable bounded `midnight-indexer:wait` script for that released launcher's validation/execution contract. Frozen installs verified the real unchanged locks resolve orchestrator/indexer `0.200.1` and `wait-on 8.0.3`.
- The new `0.200.2` launcher does not delegate to those scripts; it uses the richer packaged probe.
- Multi-chain-token-transfer remains on its real `@paimaexample` `0.3.116` launcher/wrapper topology and retains its required bounded `bunx wait-on` script. It does **not** consume the new Effectstream tuple or child-wrapper changes.
- The retired `@paimaexample` `0.3.116` full graph is no longer registry-reproducible: the primary npm registry returns `404` / no matching version for packages including its orchestrator/indexer graph. This limitation is not counted as a passing install. The committed legacy import/dependency/no-lock shape and its actual bounded package script were tested without fabricated package links.

## ⚠️ BREAKING lifecycle behavior and required merge order

**BREAKING lifecycle behavior:** the Midnight indexer and node CLIs now remain attached to their native children and return the child's nonzero/signal result. Callers that previously treated wrapper launch as immediate success must handle the service lifecycle result.

**PR A MUST MERGE FIRST. This PR MUST NOT MERGE before PR A.** PR A is the ownership-safe shutdown change in [PR #890](https://github.com/effectstream/effectstream/pull/890). A newly observable node/indexer failure can trigger orchestrator shutdown, so PR A's owned-process/container termination semantics are an operational prerequisite.

This PR is intentionally opened as a draft and must not be merged as part of this delivery step.

## Verification

- pinned Bun `1.3.11` node wrapper suite: `6/6` tests, `27` expectations;
- pinned Bun indexer suite: `10/10` tests, `38` expectations;
- focused orchestrator/template suite: `11/11` tests, `59` expectations;
- copied frozen-lock installs for EVM-Midnight, Night-Bitcoin, and zk-Cardano, including real installed `0.200.1` manifests and live-success/`250ms` unused-port bounded failures;
- real committed multi-chain `bunx wait-on` package script: live success plus `250ms` unused-port bounded failure; full retired graph limitation retained as described above;
- Prettier `3.6.2`, Bun builds, faithful node/indexer pack dry-runs, `compatibility.json` package inclusion, and a real tarball-installed declaration handoff;
- actual old-snapshot top-level current-node failure: exact signal observed, exit `1` propagated, verified diagnosis emitted, and the read-only original checksum unchanged;
- healthy current node/indexer, retained-state restart, and fresh-before-block controls passed;
- exact Docker/container/network/volume/image/port teardown passed.

Independent delivery re-audit: **PASS** at exact clean commit `c173bd01d9e515c1aa1be1c9cdb31bcab8c632ca`.
