### PR TITLE
fix(orchestrator): never kill unowned port listeners

### DIFF
--- a/packages/binaries/midnight-proof-server/docker.js
+++ b/packages/binaries/midnight-proof-server/docker.js
@@ -129,22 +129,21 @@ async function runDockerContainer(
     }
     signalHandlers.clear();
   };
-  const cleanup = (stopFirst) => {
+  const cleanup = () => {
     if (cleanupPromise) return cleanupPromise;
     cleanupPromise = (async () => {
-      if (stopFirst) {
-        // An attached docker CLI exiting does not prove the container stopped.
-        // Await an explicit stop of the immutable ID before removing that ID.
-        // Keep this below the orchestrator's five-second owned-group grace
-        // window so the wrapper can finish ID-based cleanup before escalation.
-        await runtime
-          .execFile("docker", ["stop", "--timeout", "3", containerId])
-          .catch((error) => {
-            console.warn(
-              `Could not stop owned proof-server container ${containerId}: ${error.message}`,
-            );
-          });
-      }
+      // An attached docker CLI exiting does not prove the container stopped.
+      // Every cleanup trigger therefore converges on the same conservative,
+      // idempotent stop-before-remove sequence for the immutable owned ID.
+      // Keep the stop timeout below the orchestrator's five-second group grace
+      // window so the wrapper can finish ID-based cleanup before escalation.
+      await runtime
+        .execFile("docker", ["stop", "--timeout", "3", containerId])
+        .catch((error) => {
+          console.warn(
+            `Could not stop owned proof-server container ${containerId}: ${error.message}`,
+          );
+        });
       await runtime.execFile("docker", ["rm", containerId]);
     })().finally(removeSignalHandlers);
     return cleanupPromise;
@@ -152,7 +151,7 @@ async function runDockerContainer(
 
   for (const [signal, exitCode] of [["SIGINT", 130], ["SIGTERM", 143]]) {
     const handler = () => {
-      cleanup(true)
+      cleanup()
         .catch((error) => {
           console.error(
             `Failed to clean up owned proof-server container ${containerId}:`,
@@ -166,12 +165,12 @@ async function runDockerContainer(
   }
 
   child.once("exit", () => {
-    cleanup(false).catch((error) => {
+    cleanup().catch((error) => {
       console.error(`Failed to remove owned proof-server container ${containerId}:`, error);
     });
   });
   child.once("error", () => {
-    cleanup(true).catch((error) => {
+    cleanup().catch((error) => {
       console.error(`Failed to clean up owned proof-server container ${containerId}:`, error);
     });
   });

--- a/packages/binaries/midnight-proof-server/docker.js
+++ b/packages/binaries/midnight-proof-server/docker.js
@@ -1,10 +1,11 @@
-const { spawn, exec, execSync } = require("child_process");
+const { spawn, exec, execFile } = require("child_process");
+const { randomUUID } = require("crypto");
 const { promisify } = require("util");
 const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
 
 const IMAGE_NAME = "midnightntwrk/proof-server";
 const IMAGE_TAG = "9.0.0-rc.5";
-const CONTAINER_NAME = "midnight-proof-server";
 
 async function checkIfDockerExists() {
   try {
@@ -22,9 +23,7 @@ async function pullDockerImage(tag = IMAGE_TAG) {
     });
     child.on(
       "exit",
-      (
-        code,
-      ) => (code === 0
+      (code) => (code === 0
         ? resolve()
         : reject(new Error(`docker pull exited with ${code}`))),
     );
@@ -32,93 +31,157 @@ async function pullDockerImage(tag = IMAGE_TAG) {
   });
 }
 
-/**
- * Checks if a container with the given name exists (running or stopped)
- * @param {string} containerName - Name of the container to check
- * @returns {Promise<boolean>} True if container exists, false otherwise
- */
-async function checkIfContainerExists(containerName) {
-  try {
-    const { stdout } = await execAsync(
-      `docker ps -aq -f name=^${containerName}$`,
-    );
-    return stdout.trim().length > 0;
-  } catch {
-    return false;
-  }
+function defaultRuntime() {
+  return {
+    spawn,
+    execFile: execFileAsync,
+    randomUUID,
+    signalEmitter: process,
+    setExitCode(code) {
+      process.exitCode = code;
+    },
+  };
 }
 
 /**
- * Checks if a container is currently running
- * @param {string} containerName - Name of the container to check
- * @returns {Promise<boolean>} True if container is running, false otherwise
- */
-async function checkIfContainerRunning(containerName) {
-  try {
-    const { stdout } = await execAsync(
-      `docker ps -q -f name=^${containerName}$`,
-    );
-    return stdout.trim().length > 0;
-  } catch {
-    return false;
-  }
-}
-
-/**
- * Runs the proof server container. Maps port 6300 by default. Additional CLI args are passed as command args.
- * @param {Object} env Env vars to set inside container.
+ * Creates one proof-server container owned by this wrapper run. The immutable
+ * container ID is the only identity used for start, stop, and removal.
+ *
+ * @param {Object} env Env vars to set inside the container.
  * @param {Array<string>} args CLI args.
  * @param {string} tag Docker tag.
+ * @param {Object} runtime Injectable command/signal boundary for tests.
  */
 async function runDockerContainer(
   env = process.env,
   args = [],
   tag = IMAGE_TAG,
+  runtime = defaultRuntime(),
 ) {
-  const containerExists = await checkIfContainerExists(CONTAINER_NAME);
-  const containerRunning = await checkIfContainerRunning(CONTAINER_NAME);
-
-  if (containerRunning) {
-    console.log(`Container ${CONTAINER_NAME} is already running`);
-    // Attach to the running container to see logs
-    const child = spawn("docker", ["logs", "-f", CONTAINER_NAME], {
-      stdio: "inherit",
-    });
-    return child;
-  }
-
-  if (containerExists) {
-    console.log(`Starting existing container: ${CONTAINER_NAME}`);
-    const child = spawn("docker", ["start", "-a", CONTAINER_NAME], {
-      stdio: "inherit",
-    });
-    return child;
-  }
-
-  // Container doesn't exist, create and run new one
-  console.log(`Creating new container: ${CONTAINER_NAME}`);
-
+  const runId = runtime.randomUUID();
+  const containerName = `midnight-proof-server-${runId}`;
+  const hostPort = env.MIDNIGHT_PROOF_SERVER_HOST_PORT || "6300";
   const dockerArgs = [
-    "run",
+    "create",
     "--name",
-    CONTAINER_NAME,
+    containerName,
+    "--label",
+    "effectstream.owner=midnight-proof-server",
+    "--label",
+    `effectstream.run-id=${runId}`,
     "-p",
-    "6300:6300",
+    `${hostPort}:6300`,
   ];
 
-  // pass env vars
-  Object.entries(env).forEach(([k, v]) => {
-    if (v) dockerArgs.push("-e", `${k}=${v}`);
+  // Preserve the wrapper's existing environment-forwarding behavior, except
+  // for the host-only published-port selector.
+  Object.entries(env).forEach(([key, value]) => {
+    if (value && key !== "MIDNIGHT_PROOF_SERVER_HOST_PORT") {
+      dockerArgs.push("-e", `${key}=${value}`);
+    }
   });
 
   dockerArgs.push(`${IMAGE_NAME}:${tag}`);
-
   if (args.length > 0) dockerArgs.push(...args);
 
-  console.log(
-    `Running proof server with Docker: docker ${dockerArgs.join(" ")}`,
-  );
-  const child = spawn("docker", dockerArgs, { stdio: "inherit" });
+  console.log(`Creating owned proof-server container: ${containerName}`);
+  const created = await runtime.execFile("docker", dockerArgs);
+  const containerId = created.stdout.trim();
+  if (!/^[a-f0-9]{64}$/.test(containerId)) {
+    // docker create succeeded under our unique name, but did not return the
+    // immutable identity contract we require. Remove only that just-created
+    // unique name and refuse to start or attach anything.
+    await runtime.execFile("docker", ["rm", containerName]).catch(() => {});
+    throw new Error(
+      `docker create returned an invalid immutable container ID: ${containerId || "<empty>"}`,
+    );
+  }
+
+  try {
+    const inspected = await runtime.execFile(
+      "docker",
+      ["inspect", "--format={{.Id}}", containerId],
+    );
+    if (inspected.stdout.trim() !== containerId) {
+      throw new Error("created proof-server container identity changed during validation");
+    }
+  } catch (error) {
+    await runtime.execFile("docker", ["rm", containerId]).catch(() => {});
+    throw error;
+  }
+
+  console.log(`Starting owned proof-server container: ${containerId}`);
+  let child;
+  try {
+    child = runtime.spawn("docker", ["start", "-a", containerId], {
+      stdio: "inherit",
+    });
+  } catch (error) {
+    await runtime.execFile("docker", ["rm", containerId]).catch(() => {});
+    throw error;
+  }
+
+  let cleanupPromise;
+  const signalHandlers = new Map();
+  const removeSignalHandlers = () => {
+    for (const [signal, handler] of signalHandlers) {
+      runtime.signalEmitter.removeListener(signal, handler);
+    }
+    signalHandlers.clear();
+  };
+  const cleanup = (stopFirst) => {
+    if (cleanupPromise) return cleanupPromise;
+    cleanupPromise = (async () => {
+      if (stopFirst) {
+        // An attached docker CLI exiting does not prove the container stopped.
+        // Await an explicit stop of the immutable ID before removing that ID.
+        // Keep this below the orchestrator's five-second owned-group grace
+        // window so the wrapper can finish ID-based cleanup before escalation.
+        await runtime
+          .execFile("docker", ["stop", "--timeout", "3", containerId])
+          .catch((error) => {
+            console.warn(
+              `Could not stop owned proof-server container ${containerId}: ${error.message}`,
+            );
+          });
+      }
+      await runtime.execFile("docker", ["rm", containerId]);
+    })().finally(removeSignalHandlers);
+    return cleanupPromise;
+  };
+
+  for (const [signal, exitCode] of [["SIGINT", 130], ["SIGTERM", 143]]) {
+    const handler = () => {
+      cleanup(true)
+        .catch((error) => {
+          console.error(
+            `Failed to clean up owned proof-server container ${containerId}:`,
+            error,
+          );
+        })
+        .finally(() => runtime.setExitCode?.(exitCode));
+    };
+    signalHandlers.set(signal, handler);
+    runtime.signalEmitter.once(signal, handler);
+  }
+
+  child.once("exit", () => {
+    cleanup(false).catch((error) => {
+      console.error(`Failed to remove owned proof-server container ${containerId}:`, error);
+    });
+  });
+  child.once("error", () => {
+    cleanup(true).catch((error) => {
+      console.error(`Failed to clean up owned proof-server container ${containerId}:`, error);
+    });
+  });
+
+  Object.defineProperty(child, "ownedContainerId", { value: containerId });
+  Object.defineProperty(child, "cleanup", {
+    get() {
+      return cleanupPromise ?? Promise.resolve();
+    },
+  });
   return child;
 }
 

--- a/packages/binaries/midnight-proof-server/docker.test.js
+++ b/packages/binaries/midnight-proof-server/docker.test.js
@@ -67,7 +67,26 @@ describe("proof-server Docker ownership", () => {
     const rendered = fake.calls.map((call) => call.join(" ")).join("\n");
     expect(rendered).not.toContain("docker start -a midnight-proof-server");
     expect(rendered).not.toContain(UNRELATED_ID);
+    expect(rendered).toContain(`docker stop --timeout 3 ${OWNED_ID}`);
     expect(rendered).toContain(`docker rm ${OWNED_ID}`);
+  });
+
+  test("attach exit and wrapper signal coalesce into one exact-ID stop-before-remove", async () => {
+    const fake = fakeRuntime();
+    const run = await runDockerContainer({}, [], "9.0.0-rc.5", fake.runtime);
+
+    fake.child.emit("exit", 0, null);
+    fake.signals.emit("SIGTERM");
+    await run.cleanup;
+
+    const lifecycle = fake.calls.filter(
+      (call) => call[0] === "execFile" && ["stop", "rm"].includes(call[2]),
+    );
+    expect(lifecycle).toEqual([
+      ["execFile", "docker", "stop", "--timeout", "3", OWNED_ID],
+      ["execFile", "docker", "rm", OWNED_ID],
+    ]);
+    expect(fake.calls.flat()).not.toContain(UNRELATED_ID);
   });
 
   test("invalid create identity is refused and only the unique owned name is removed", async () => {

--- a/packages/binaries/midnight-proof-server/docker.test.js
+++ b/packages/binaries/midnight-proof-server/docker.test.js
@@ -1,0 +1,106 @@
+const { describe, expect, test } = require("bun:test");
+const { EventEmitter } = require("events");
+const { runDockerContainer } = require("./docker.js");
+
+const OWNED_ID = "a".repeat(64);
+const UNRELATED_ID = "b".repeat(64);
+
+function fakeRuntime() {
+  const calls = [];
+  const signals = new EventEmitter();
+  const child = new EventEmitter();
+  child.pid = 43210;
+  child.kill = () => {};
+  return {
+    calls,
+    signals,
+    child,
+    runtime: {
+      randomUUID: () => "11111111-2222-4333-8444-555555555555",
+      signalEmitter: signals,
+      spawn(command, args) {
+        calls.push(["spawn", command, ...args]);
+        return child;
+      },
+      async execFile(command, args) {
+        calls.push(["execFile", command, ...args]);
+        if (args[0] === "create") return { stdout: `${OWNED_ID}\n`, stderr: "" };
+        if (args[0] === "inspect") return { stdout: `${OWNED_ID}\n`, stderr: "" };
+        return { stdout: "", stderr: "" };
+      },
+    },
+  };
+}
+
+describe("proof-server Docker ownership", () => {
+  test("creates a unique labeled container and cleans up only its immutable ID", async () => {
+    const fake = fakeRuntime();
+    const run = await runDockerContainer({}, [], "9.0.0-rc.5", fake.runtime);
+
+    expect(run.ownedContainerId).toBe(OWNED_ID);
+    expect(fake.calls[0]).toContain("create");
+    expect(fake.calls[0]).toContain("--label");
+    expect(fake.calls[0].join(" ")).toContain("effectstream.owner=midnight-proof-server");
+    expect(fake.calls).toContainEqual(["spawn", "docker", "start", "-a", OWNED_ID]);
+
+    fake.signals.emit("SIGTERM");
+    await run.cleanup;
+
+    expect(fake.calls).toContainEqual([
+      "execFile",
+      "docker",
+      "stop",
+      "--timeout",
+      "3",
+      OWNED_ID,
+    ]);
+    expect(fake.calls).toContainEqual(["execFile", "docker", "rm", OWNED_ID]);
+    expect(fake.calls.flat()).not.toContain(UNRELATED_ID);
+  });
+
+  test("a similarly named pre-existing container is never attached or stopped", async () => {
+    const fake = fakeRuntime();
+    const run = await runDockerContainer({}, [], "9.0.0-rc.5", fake.runtime);
+    fake.child.emit("exit", 0, null);
+    await run.cleanup;
+
+    const rendered = fake.calls.map((call) => call.join(" ")).join("\n");
+    expect(rendered).not.toContain("docker start -a midnight-proof-server");
+    expect(rendered).not.toContain(UNRELATED_ID);
+    expect(rendered).toContain(`docker rm ${OWNED_ID}`);
+  });
+
+  test("invalid create identity is refused and only the unique owned name is removed", async () => {
+    const fake = fakeRuntime();
+    fake.runtime.execFile = async (command, args) => {
+      fake.calls.push(["execFile", command, ...args]);
+      if (args[0] === "create") return { stdout: "not-an-id\n", stderr: "" };
+      return { stdout: "", stderr: "" };
+    };
+
+    await expect(runDockerContainer({}, [], "9.0.0-rc.5", fake.runtime)).rejects.toThrow(
+      /invalid immutable container ID/,
+    );
+    expect(fake.calls.some((call) => call[0] === "spawn")).toBe(false);
+    expect(fake.calls).toContainEqual([
+      "execFile",
+      "docker",
+      "rm",
+      "midnight-proof-server-11111111-2222-4333-8444-555555555555",
+    ]);
+  });
+
+  test("a synchronous attach failure removes only the captured immutable ID", async () => {
+    const fake = fakeRuntime();
+    fake.runtime.spawn = (command, args) => {
+      fake.calls.push(["spawn", command, ...args]);
+      throw new Error("attach failed");
+    };
+
+    await expect(runDockerContainer({}, [], "9.0.0-rc.5", fake.runtime)).rejects.toThrow(
+      "attach failed",
+    );
+    expect(fake.calls).toContainEqual(["execFile", "docker", "rm", OWNED_ID]);
+    expect(fake.calls.flat()).not.toContain(UNRELATED_ID);
+  });
+});

--- a/packages/build-tools/orchestrator/README.md
+++ b/packages/build-tools/orchestrator/README.md
@@ -129,6 +129,30 @@ orchestrator restart midnight-node
 orchestrator stop batcher
 ```
 
+## Port ownership and safe cleanup
+
+`stopProcessAtPort` is a conflict/readiness declaration, not permission to
+kill whatever currently owns that port. Startup refuses an occupied configured
+port and reports the listener PID when the platform can identify it. Stop acts
+only on a process launched by the current live orchestrator:
+
+- macOS and Linux launches receive a dedicated process group, and stop signals
+  only that recorded group so wrapper descendants are included;
+- Windows uses the recorded direct child because POSIX process groups are not
+  available;
+- Docker-backed proof-server runs use a unique per-run container and its
+  immutable container ID; a similarly named pre-existing container is never
+  reused, attached, stopped, or removed;
+- if no daemon is reachable, `orchestrator stop` reports matching configured
+  ports/PIDs and exits with a failure instead of signaling them.
+
+Automatic orphan killing by configured port has been removed. If startup
+reports a stale listener, inspect it (for example with
+`lsof -nP -iTCP:<port> -sTCP:LISTEN` on macOS/Linux), stop the owning service
+through its own supervisor, or select another port. This fail-safe avoids
+terminating unrelated native services or Docker Desktop's shared networking
+backend.
+
 ## Inside EffectStream
 
 Every template under

--- a/packages/build-tools/orchestrator/README.md
+++ b/packages/build-tools/orchestrator/README.md
@@ -136,8 +136,11 @@ kill whatever currently owns that port. Startup refuses an occupied configured
 port and reports the listener PID when the platform can identify it. Stop acts
 only on a process launched by the current live orchestrator:
 
-- macOS and Linux launches receive a dedicated process group, and stop signals
-  only that recorded group so wrapper descendants are included;
+- macOS and Linux launches receive a dedicated process group plus a unique
+  inherited owner token. Cleanup retains authenticated descendant identities
+  after a wrapper exits and rechecks each member's launch token and process
+  start identity before TERM or KILL; it refuses escalation if identity cannot
+  be proved or a PID/PGID was reused;
 - Windows uses the recorded direct child because POSIX process groups are not
   available;
 - Docker-backed proof-server runs use a unique per-run container and its

--- a/packages/build-tools/orchestrator/src/commands/start.ts
+++ b/packages/build-tools/orchestrator/src/commands/start.ts
@@ -9,7 +9,6 @@ import {
   writeState,
   readStateConfigPath,
   clearStatePort,
-  freePort,
   DEFAULT_API_PORT,
 } from "../port-check.ts";
 import {
@@ -164,13 +163,6 @@ export async function runStartCommand(opts: StartOptions): Promise<void> {
     else logInfo("Shutting down…");
     apiServer?.stop(true);
     await manager.stopAll();
-
-    // Kill any orphan processes still occupying configured ports
-    for (const proc of config.processes) {
-      for (const port of proc.stopProcessAtPort ?? []) {
-        await freePort(port);
-      }
-    }
 
     clearStatePort();
     process.exit(reason ? 1 : 0);

--- a/packages/build-tools/orchestrator/src/commands/stop.ts
+++ b/packages/build-tools/orchestrator/src/commands/stop.ts
@@ -2,12 +2,31 @@ import type { ParsedArgs } from "../cli.ts";
 import type { ProcessConfig } from "../config.ts";
 import { OrchestratorClient } from "../api-client.ts";
 import { loadConfig, findDefaultConfig, findPackageJsonConfig } from "../load-config.ts";
-import { pidsByPort, freePort, readStateConfigPath } from "../port-check.ts";
+import { describePortListener, inspectPorts, readStateConfigPath, type PortListener } from "../port-check.ts";
 import { logInfo, logError, logWarn } from "../display.ts";
 
 type StopOptions = Pick<ParsedArgs, "positionals" | "flags"> & {
   port?: number;
 };
+
+export type ConfiguredPortListener = PortListener & { processName: string };
+
+/** Resolves configured listeners for diagnostics only; it has no signal path. */
+export async function collectConfiguredPortListeners(
+  configs: ProcessConfig[],
+  name?: string,
+): Promise<ConfiguredPortListener[]> {
+  const selected = name ? configs.filter((config) => config.name === name) : configs;
+  const configured = selected.flatMap((config) =>
+    (config.stopProcessAtPort ?? []).map((port) => ({ processName: config.name, port })),
+  );
+  const inspected = await inspectPorts(configured.map(({ port }) => port));
+  const byPort = new Map(inspected.map((listener) => [listener.port, listener]));
+  return configured.flatMap(({ processName, port }) => {
+    const listener = byPort.get(port);
+    return listener ? [{ ...listener, processName }] : [];
+  });
+}
 
 export async function runStopCommand(opts: StopOptions): Promise<void> {
   const name = opts.positionals[0]; // optional
@@ -32,8 +51,9 @@ export async function runStopCommand(opts: StopOptions): Promise<void> {
     return;
   }
 
-  // No daemon — fall back to port-based kill
-  logWarn("No orchestrator daemon detected — killing processes by port.");
+  // No daemon means there is no trusted live ownership record. Ports are
+  // diagnostic only and must never become raw signal targets.
+  logWarn("No orchestrator daemon detected — inspecting configured ports only.");
 
   const configPath =
     (opts.flags["config"] as string | undefined) ??
@@ -56,7 +76,7 @@ export async function runStopCommand(opts: StopOptions): Promise<void> {
     process.exit(1);
   }
 
-  // If a name is given, only kill that process's ports
+  // If a name is given, only inspect that process's configured ports.
   if (name) {
     const proc = configs.find((c) => c.name === name);
     if (!proc) {
@@ -65,36 +85,30 @@ export async function runStopCommand(opts: StopOptions): Promise<void> {
     }
     const ports = proc.stopProcessAtPort ?? [];
     if (ports.length === 0) {
-      logWarn(`Process "${name}" has no ports defined — nothing to kill.`);
+      logWarn(`Process "${name}" has no ports defined — nothing to inspect.`);
       return;
     }
-    for (const port of ports) {
-      const pids = pidsByPort(port);
-      if (pids.length > 0) {
-        logInfo(`Killing PID ${pids.join(", ")} on port ${port} (${name})`);
-        await freePort(port);
-      }
+    const listeners = await collectConfiguredPortListeners(configs, name);
+    if (listeners.length === 0) {
+      logInfo(`No configured listeners found for "${name}".`);
+      return;
     }
-    logInfo(`"${name}" stopped.`);
+    for (const listener of listeners) {
+      logError(`Refusing to signal ${describePortListener(listener)} for "${name}" without a live ownership record.`);
+    }
+    process.exitCode = 1;
     return;
   }
 
-  // Kill all processes that have ports defined
-  let killed = 0;
-  for (const proc of configs) {
-    for (const port of proc.stopProcessAtPort ?? []) {
-      const pids = pidsByPort(port);
-      if (pids.length > 0) {
-        logInfo(`Killing PID ${pids.join(", ")} on port ${port} (${proc.name})`);
-        await freePort(port);
-        killed++;
-      }
-    }
-  }
-
-  if (killed === 0) {
+  const listeners = await collectConfiguredPortListeners(configs);
+  if (listeners.length === 0) {
     logInfo("No processes found on any configured ports.");
-  } else {
-    logInfo(`Stopped ${killed} process(es).`);
+    return;
   }
+  for (const listener of listeners) {
+    logError(
+      `Refusing to signal ${describePortListener(listener)} configured for "${listener.processName}" without a live ownership record.`,
+    );
+  }
+  process.exitCode = 1;
 }

--- a/packages/build-tools/orchestrator/src/config.ts
+++ b/packages/build-tools/orchestrator/src/config.ts
@@ -19,7 +19,8 @@ export type ProcessConfig = {
   /** Names of processes that must complete/start before this one. */
   dependsOn?: string[];
   /**
-   * If set, these ports are freed (kill any occupying process) before launch.
+   * If set, launch fails when any port is already occupied. The orchestrator
+   * never treats a configured port as permission to signal its listener.
    * Also used by the `status` command for port-based liveness detection.
    */
   stopProcessAtPort?: number[];

--- a/packages/build-tools/orchestrator/src/port-check.ts
+++ b/packages/build-tools/orchestrator/src/port-check.ts
@@ -32,10 +32,17 @@ export function pidsByPort(port: number): number[] {
   // `-sTCP:LISTEN` restricts to the process LISTENING on the port. Without it,
   // `lsof -ti tcp:<port>` also returns CLIENTS with an open connection to the
   // port (e.g. a test harness holding a keepalive fetch to the sync API), which
-  // callers like freePort() would then wrongly SIGTERM.
-  const result = Bun.spawnSync(["lsof", "-ti", `tcp:${port}`, "-sTCP:LISTEN"], {
-    stderr: "pipe",
-  });
+  // callers would otherwise report clients as though they owned the port.
+  let result: ReturnType<typeof Bun.spawnSync>;
+  try {
+    result = Bun.spawnSync(["lsof", "-ti", `tcp:${port}`, "-sTCP:LISTEN"], {
+      stderr: "pipe",
+    });
+  } catch {
+    // Minimal containers and Windows may not provide lsof. Port occupancy is
+    // still authoritative; diagnostics explicitly report an unavailable PID.
+    return [];
+  }
   if (result.exitCode !== 0) return [];
   return result.stdout
     .toString()
@@ -45,44 +52,34 @@ export function pidsByPort(port: number): number[] {
     .filter((n) => !isNaN(n));
 }
 
-/**
- * Kills any process occupying `port` via SIGTERM, then waits for the port to free.
- * Uses `lsof` (macOS / Linux).
- */
-export async function freePort(port: number): Promise<void> {
-  if (!(await isPortInUse(port))) return;
+export type PortListener = {
+  port: number;
+  pids: number[];
+};
 
-  // `-sTCP:LISTEN` so we only kill the listener, never a client connected to
-  // the port (see pidsByPort). During shutdown a template's test process often
-  // holds an open connection to the sync API / chain ports; without this filter
-  // freePort would SIGTERM the test process (and its `bun run test` wrapper),
-  // failing an otherwise-green run with exit 143.
-  const result = Bun.spawnSync(["lsof", "-ti", `tcp:${port}`, "-sTCP:LISTEN"], {
-    stderr: "pipe",
-  });
+/** Inspects configured ports without ever signaling their listeners. */
+export async function inspectPorts(ports: number[]): Promise<PortListener[]> {
+  const listeners: PortListener[] = [];
+  for (const port of [...new Set(ports)]) {
+    if (await isPortInUse(port)) listeners.push({ port, pids: pidsByPort(port) });
+  }
+  return listeners;
+}
 
-  if (result.exitCode === 0) {
-    const pids = result.stdout
-      .toString()
-      .trim()
-      .split("\n")
-      .filter(Boolean);
+export function describePortListener(listener: PortListener): string {
+  const owners = listener.pids.length === 0
+    ? "listener PID unavailable"
+    : `PID ${listener.pids.join(", ")}`;
+  return `port ${listener.port} (${owners})`;
+}
 
-    for (const pid of pids) {
-      Bun.spawnSync(["kill", "-TERM", pid.trim()]);
-    }
-
-    // Wait up to 5 seconds for the port to free
-    let tries = 20;
-    while (tries-- > 0) {
-      if (!(await isPortInUse(port))) return;
-      await Bun.sleep(250);
-    }
-
-    // Fall back to SIGKILL
-    for (const pid of pids) {
-      Bun.spawnSync(["kill", "-KILL", pid.trim()]);
-    }
+export class PortConflictError extends Error {
+  constructor(readonly listeners: PortListener[]) {
+    super(
+      `Refusing to start: ${listeners.map(describePortListener).join("; ")} already occupied. ` +
+      "Stop the owning service explicitly or choose another port; the orchestrator will not signal an unowned listener.",
+    );
+    this.name = "PortConflictError";
   }
 }
 

--- a/packages/build-tools/orchestrator/src/process-manager.ts
+++ b/packages/build-tools/orchestrator/src/process-manager.ts
@@ -1,7 +1,7 @@
 import * as fs from "fs";
 import * as path from "path";
 import type { ProcessConfig } from "./config.ts";
-import { freePort } from "./port-check.ts";
+import { inspectPorts, PortConflictError, type PortListener } from "./port-check.ts";
 
 export type ProcessStatus = "pending" | "running" | "done" | "failed" | "stopped";
 
@@ -15,6 +15,8 @@ export type ManagedProcess = {
   startedAt: Date | null;
   endedAt: Date | null;
   exitCode: number | null;
+  /** Internal POSIX process-group ID for this launch; absent/null on Windows. */
+  processGroupId?: number | null;
   /** Absolute path to the log file, or null if logging to terminal. */
   logFile: string | null;
 };
@@ -23,6 +25,22 @@ type BunProc = ReturnType<typeof Bun.spawn>;
 type StreamReader = ReadableStreamDefaultReader<Uint8Array>;
 
 export type ChangeListener = (p: ManagedProcess) => void;
+
+type StopSignal = "SIGTERM" | "SIGKILL";
+
+export type ManagedSignal = {
+  name: string;
+  target: "process-group" | "direct-child";
+  id: number;
+  signal: StopSignal;
+};
+
+export type ProcessManagerOptions = {
+  platform?: NodeJS.Platform;
+  stopTimeoutMs?: number;
+  inspectPorts?: (ports: number[]) => Promise<PortListener[]>;
+  onSignal?: (attempt: ManagedSignal) => void;
+};
 
 export class ProcessManager {
   private processes = new Map<string, ManagedProcess>();
@@ -39,6 +57,17 @@ export class ProcessManager {
    * `<logDir>/<process-name>.log` instead of inheriting the terminal.
    */
   logDir: string | undefined;
+  private readonly platform: NodeJS.Platform;
+  private readonly stopTimeoutMs: number;
+  private readonly inspectConfiguredPorts: (ports: number[]) => Promise<PortListener[]>;
+  private readonly onSignal: ((attempt: ManagedSignal) => void) | undefined;
+
+  constructor(options: ProcessManagerOptions = {}) {
+    this.platform = options.platform ?? process.platform;
+    this.stopTimeoutMs = options.stopTimeoutMs ?? 5_000;
+    this.inspectConfiguredPorts = options.inspectPorts ?? inspectPorts;
+    this.onSignal = options.onSignal;
+  }
 
   onProcessChange(fn: ChangeListener): () => void {
     this.listeners.push(fn);
@@ -67,10 +96,8 @@ export class ProcessManager {
    * `<logDir>/<name>.log` instead of the terminal.
    */
   async launch(config: ProcessConfig): Promise<{ waitForExit: Promise<number>; logFile: string | null }> {
-    // Free any ports this process needs
-    for (const port of config.stopProcessAtPort ?? []) {
-      await freePort(port);
-    }
+    const occupied = await this.inspectConfiguredPorts(config.stopProcessAtPort ?? []);
+    if (occupied.length > 0) throw new PortConflictError(occupied);
 
     const command = config.command ?? "bun";
 
@@ -111,6 +138,9 @@ export class ProcessManager {
       stdout: usesPipe ? "pipe" : outFd,
       stderr: usesPipe ? "pipe" : outFd,
       stdin: "ignore",
+      // A POSIX detached child leads a new process group, which gives cleanup a
+      // trusted descendant boundary. Windows retains safe direct-child stop.
+      detached: this.platform !== "win32",
     });
 
     // The child has inherited the fd — safe to close the parent's copy
@@ -181,6 +211,7 @@ export class ProcessManager {
       startedAt: new Date(),
       endedAt: null,
       exitCode: null,
+      processGroupId: this.platform === "win32" ? null : proc.pid,
       logFile,
     };
 
@@ -220,17 +251,17 @@ export class ProcessManager {
       this.readers.delete(name);
     }
 
-    proc.kill("SIGTERM");
+    this.signalOwned(proc, managed, "SIGTERM");
 
-    // Wait up to 5 s for graceful exit, then SIGKILL
-    const graceful = await Promise.race([
-      proc.exited.then(() => true),
-      Bun.sleep(5000).then(() => false),
-    ]);
+    // A wrapper can exit while one of its descendants remains in the owned
+    // POSIX group. Wait for the ownership boundary itself, not only the direct
+    // child's exit promise.
+    const graceful = await this.waitForOwnedExit(proc, managed, this.stopTimeoutMs);
 
     if (!graceful) {
-      proc.kill("SIGKILL");
+      this.signalOwned(proc, managed, "SIGKILL");
       await proc.exited.catch(() => {});
+      await this.waitForOwnedExit(proc, managed, 1_000);
     }
 
     managed.status = "stopped";
@@ -239,6 +270,87 @@ export class ProcessManager {
     this.stopping.delete(name);
     this.emit(managed);
     return true;
+  }
+
+  private signalOwned(proc: BunProc, managed: ManagedProcess, signal: StopSignal): void {
+    const target = managed.processGroupId == null ? "direct-child" : "process-group";
+    const id = managed.processGroupId ?? proc.pid;
+    try {
+      if (target === "process-group") process.kill(-id, signal);
+      else proc.kill(signal);
+      this.onSignal?.({ name: managed.name, target, id, signal });
+    } catch (error: any) {
+      // An already-exited owned target makes stop idempotent. Never fall back
+      // to looking up or signaling a listener by configured port.
+      if (error?.code !== "ESRCH") throw error;
+    }
+  }
+
+  private async waitForOwnedExit(
+    proc: BunProc,
+    managed: ManagedProcess,
+    timeoutMs: number,
+  ): Promise<boolean> {
+    if (managed.processGroupId == null) {
+      return Promise.race([
+        proc.exited.then(() => true),
+        Bun.sleep(timeoutMs).then(() => false),
+      ]);
+    }
+
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      if (!this.isProcessGroupAlive(managed.processGroupId)) return true;
+      await Bun.sleep(Math.min(50, Math.max(1, deadline - Date.now())));
+    }
+    return !this.isProcessGroupAlive(managed.processGroupId);
+  }
+
+  private isProcessGroupAlive(processGroupId: number): boolean {
+    if (this.platform === "linux") {
+      try {
+        return fs.readdirSync("/proc", { withFileTypes: true })
+          .filter((entry) => entry.isDirectory() && /^\d+$/.test(entry.name))
+          .some((entry) => {
+            try {
+              const stat = fs.readFileSync(`/proc/${entry.name}/stat`, "utf8");
+              const fields = stat.slice(stat.lastIndexOf(")") + 2).split(" ");
+              const state = fields[0];
+              const group = Number(fields[2]);
+              return group === processGroupId && state !== "Z";
+            } catch {
+              return false;
+            }
+          });
+      } catch {
+        // Fall through to ps/kill probes on restricted procfs mounts.
+      }
+    }
+
+    // `kill(-pgid, 0)` also reports zombie-only groups as alive. Prefer the
+    // portable macOS/Linux `ps -axo` view so reaping latency does not force an
+    // unnecessary five-second wait or escalation.
+    try {
+      const result = Bun.spawnSync(["ps", "-axo", "pgid=,stat="], { stderr: "pipe" });
+      if (result.exitCode === 0) {
+        const hasLiveMember = result.stdout
+          .toString()
+          .split("\n")
+          .map((line) => line.trim().match(/^(\d+)\s+(\S+)/))
+          .filter((match): match is RegExpMatchArray => match !== null)
+          .some((match) => Number(match[1]) === processGroupId && !match[2].startsWith("Z"));
+        return hasLiveMember;
+      }
+    } catch {
+      // Fall through to the signal-free existence probe if ps is unavailable.
+    }
+    try {
+      process.kill(-processGroupId, 0);
+      return true;
+    } catch (error: any) {
+      if (error?.code === "ESRCH") return false;
+      throw error;
+    }
   }
 
   /** Stops and re-launches a process. Returns null if the process was never started. */

--- a/packages/build-tools/orchestrator/src/process-manager.ts
+++ b/packages/build-tools/orchestrator/src/process-manager.ts
@@ -361,6 +361,10 @@ export class ProcessManager {
         this.finishRefusedStop(name);
         return false;
       }
+      if (killed === "alive") {
+        this.finishIncompleteStop(name, managed);
+        return false;
+      }
     }
 
     this.finishStopped(name, managed);
@@ -379,6 +383,13 @@ export class ProcessManager {
   private finishRefusedStop(name: string): void {
     this.stopping.delete(name);
     console.warn(`[${name}] Refusing to signal because the recorded native ownership identity could not be authenticated.`);
+  }
+
+  private finishIncompleteStop(name: string, managed: ManagedProcess): void {
+    this.stopping.delete(name);
+    console.warn(
+      `[${name}] Stop incomplete: authenticated process group ${managed.processGroupId} remains live after SIGKILL; retaining ownership for a later retry.`,
+    );
   }
 
   private signalOwned(

--- a/packages/build-tools/orchestrator/src/process-manager.ts
+++ b/packages/build-tools/orchestrator/src/process-manager.ts
@@ -1,5 +1,6 @@
 import * as fs from "fs";
 import * as path from "path";
+import { randomUUID } from "node:crypto";
 import type { ProcessConfig } from "./config.ts";
 import { inspectPorts, PortConflictError, type PortListener } from "./port-check.ts";
 
@@ -35,16 +36,48 @@ export type ManagedSignal = {
   signal: StopSignal;
 };
 
+export type ProcessGroupMemberIdentity = {
+  pid: number;
+  processGroupId: number;
+  state: string;
+  startToken: string;
+  ownerTokenMatches: boolean;
+};
+
+const OWNER_TOKEN_ENV = "EFFECTSTREAM_ORCHESTRATOR_OWNER_TOKEN";
+
+type OwnedProcessGroup = {
+  id: number;
+  ownerToken: string;
+  memberStartTokens: Map<number, string>;
+  proc: BunProc;
+};
+
+type OwnedGroupState =
+  | { state: "empty"; members: [] }
+  | { state: "owned"; members: ProcessGroupMemberIdentity[] }
+  | { state: "untrusted"; members: ProcessGroupMemberIdentity[]; reason: string };
+
 export type ProcessManagerOptions = {
   platform?: NodeJS.Platform;
   stopTimeoutMs?: number;
   inspectPorts?: (ports: number[]) => Promise<PortListener[]>;
+  inspectProcessGroup?: (
+    processGroupId: number,
+    ownerToken: string,
+  ) => ProcessGroupMemberIdentity[];
+  signalProcessGroup?: (processGroupId: number, signal: StopSignal) => void;
+  createOwnerToken?: () => string;
   onSignal?: (attempt: ManagedSignal) => void;
 };
 
 export class ProcessManager {
   private processes = new Map<string, ManagedProcess>();
   private procs = new Map<string, BunProc>();
+  /** POSIX groups remain recorded after a direct wrapper exits while authenticated descendants live. */
+  private ownedGroups = new Map<string, OwnedProcessGroup>();
+  /** Concurrent stop requests for one name share exactly one authenticated signal sequence. */
+  private stopPromises = new Map<string, Promise<boolean>>();
   /** Active stream readers per process — cancelled on stop to release file descriptors. */
   private readers = new Map<string, StreamReader[]>();
   private listeners: ChangeListener[] = [];
@@ -60,12 +93,23 @@ export class ProcessManager {
   private readonly platform: NodeJS.Platform;
   private readonly stopTimeoutMs: number;
   private readonly inspectConfiguredPorts: (ports: number[]) => Promise<PortListener[]>;
+  private readonly inspectProcessGroup: (
+    processGroupId: number,
+    ownerToken: string,
+  ) => ProcessGroupMemberIdentity[];
+  private readonly signalProcessGroup: (processGroupId: number, signal: StopSignal) => void;
+  private readonly createOwnerToken: () => string;
   private readonly onSignal: ((attempt: ManagedSignal) => void) | undefined;
 
   constructor(options: ProcessManagerOptions = {}) {
     this.platform = options.platform ?? process.platform;
     this.stopTimeoutMs = options.stopTimeoutMs ?? 5_000;
     this.inspectConfiguredPorts = options.inspectPorts ?? inspectPorts;
+    this.inspectProcessGroup = options.inspectProcessGroup
+      ?? ((processGroupId, ownerToken) => this.inspectPosixProcessGroup(processGroupId, ownerToken));
+    this.signalProcessGroup = options.signalProcessGroup
+      ?? ((processGroupId, signal) => process.kill(-processGroupId, signal));
+    this.createOwnerToken = options.createOwnerToken ?? randomUUID;
     this.onSignal = options.onSignal;
   }
 
@@ -124,6 +168,8 @@ export class ProcessManager {
       ...process.env,
       ...config.env,
     };
+    const ownerToken = this.platform === "win32" ? null : this.createOwnerToken();
+    if (ownerToken) childEnv[OWNER_TOKEN_ENV] = ownerToken;
     if (usesPipe) {
       childEnv.FORCE_COLOR = "true";
     } else {
@@ -217,6 +263,14 @@ export class ProcessManager {
 
     this.processes.set(config.name, managed);
     this.procs.set(config.name, proc);
+    if (ownerToken) {
+      this.ownedGroups.set(config.name, {
+        id: proc.pid,
+        ownerToken,
+        memberStartTokens: new Map(),
+        proc,
+      });
+    }
     this.emit(managed);
 
     const waitForExit = proc.exited.then((code) => {
@@ -224,6 +278,16 @@ export class ProcessManager {
       managed.exitCode = code;
       managed.endedAt = new Date();
       this.procs.delete(config.name);
+      const ownedGroup = this.ownedGroups.get(config.name);
+      if (ownedGroup) {
+        const ownership = this.authenticateOwnedGroup(ownedGroup);
+        if (ownership.state === "empty") this.ownedGroups.delete(config.name);
+        if (ownership.state === "untrusted") {
+          console.warn(
+            `[${config.name}] Retaining no signal authority for process group ${ownedGroup.id}: ${ownership.reason}`,
+          );
+        }
+      }
       this.emit(managed);
       return code;
     });
@@ -236,7 +300,21 @@ export class ProcessManager {
    * Falls back to SIGKILL after 5 seconds.
    */
   async stop(name: string): Promise<boolean> {
-    const proc = this.procs.get(name);
+    const existing = this.stopPromises.get(name);
+    if (existing) return existing;
+
+    const stopping = this.stopOwned(name);
+    this.stopPromises.set(name, stopping);
+    try {
+      return await stopping;
+    } finally {
+      if (this.stopPromises.get(name) === stopping) this.stopPromises.delete(name);
+    }
+  }
+
+  private async stopOwned(name: string): Promise<boolean> {
+    const ownedGroup = this.ownedGroups.get(name);
+    const proc = this.procs.get(name) ?? ownedGroup?.proc;
     const managed = this.processes.get(name);
     if (!proc || !managed) return false;
 
@@ -251,123 +329,297 @@ export class ProcessManager {
       this.readers.delete(name);
     }
 
-    this.signalOwned(proc, managed, "SIGTERM");
+    const term = this.signalOwned(proc, managed, ownedGroup, "SIGTERM");
+    if (term === "untrusted") {
+      this.finishRefusedStop(name);
+      return false;
+    }
+    if (term === "empty") {
+      this.finishStopped(name, managed);
+      return true;
+    }
 
     // A wrapper can exit while one of its descendants remains in the owned
     // POSIX group. Wait for the ownership boundary itself, not only the direct
     // child's exit promise.
-    const graceful = await this.waitForOwnedExit(proc, managed, this.stopTimeoutMs);
+    const graceful = await this.waitForOwnedExit(proc, managed, ownedGroup, this.stopTimeoutMs);
 
-    if (!graceful) {
-      this.signalOwned(proc, managed, "SIGKILL");
-      await proc.exited.catch(() => {});
-      await this.waitForOwnedExit(proc, managed, 1_000);
+    if (graceful === "untrusted") {
+      this.finishRefusedStop(name);
+      return false;
     }
 
-    managed.status = "stopped";
-    managed.endedAt = new Date();
-    this.procs.delete(name);
-    this.stopping.delete(name);
-    this.emit(managed);
+    if (graceful === "alive") {
+      const kill = this.signalOwned(proc, managed, ownedGroup, "SIGKILL");
+      if (kill === "untrusted") {
+        this.finishRefusedStop(name);
+        return false;
+      }
+      await proc.exited.catch(() => {});
+      const killed = await this.waitForOwnedExit(proc, managed, ownedGroup, 1_000);
+      if (killed === "untrusted") {
+        this.finishRefusedStop(name);
+        return false;
+      }
+    }
+
+    this.finishStopped(name, managed);
     return true;
   }
 
-  private signalOwned(proc: BunProc, managed: ManagedProcess, signal: StopSignal): void {
-    const target = managed.processGroupId == null ? "direct-child" : "process-group";
-    const id = managed.processGroupId ?? proc.pid;
+  private finishStopped(name: string, managed: ManagedProcess): void {
+    managed.status = "stopped";
+    managed.endedAt = new Date();
+    this.procs.delete(name);
+    this.ownedGroups.delete(name);
+    this.stopping.delete(name);
+    this.emit(managed);
+  }
+
+  private finishRefusedStop(name: string): void {
+    this.stopping.delete(name);
+    console.warn(`[${name}] Refusing to signal because the recorded native ownership identity could not be authenticated.`);
+  }
+
+  private signalOwned(
+    proc: BunProc,
+    managed: ManagedProcess,
+    ownedGroup: OwnedProcessGroup | undefined,
+    signal: StopSignal,
+  ): "signaled" | "empty" | "untrusted" {
+    if (managed.processGroupId != null) {
+      if (!ownedGroup || ownedGroup.id !== managed.processGroupId) return "untrusted";
+      const ownership = this.authenticateOwnedGroup(ownedGroup);
+      if (ownership.state === "untrusted") {
+        console.warn(
+          `[${managed.name}] Refusing ${signal} for process group ${ownedGroup.id}: ${ownership.reason}`,
+        );
+        return "untrusted";
+      }
+      if (ownership.state === "empty") return "empty";
+      try {
+        this.signalProcessGroup(ownedGroup.id, signal);
+        this.onSignal?.({
+          name: managed.name,
+          target: "process-group",
+          id: ownedGroup.id,
+          signal,
+        });
+      } catch (error: any) {
+        if (error?.code !== "ESRCH") throw error;
+      }
+      return "signaled";
+    }
+
     try {
-      if (target === "process-group") process.kill(-id, signal);
-      else proc.kill(signal);
-      this.onSignal?.({ name: managed.name, target, id, signal });
+      proc.kill(signal);
+      this.onSignal?.({ name: managed.name, target: "direct-child", id: proc.pid, signal });
     } catch (error: any) {
       // An already-exited owned target makes stop idempotent. Never fall back
       // to looking up or signaling a listener by configured port.
       if (error?.code !== "ESRCH") throw error;
     }
+    return "signaled";
   }
 
   private async waitForOwnedExit(
     proc: BunProc,
     managed: ManagedProcess,
+    ownedGroup: OwnedProcessGroup | undefined,
     timeoutMs: number,
-  ): Promise<boolean> {
+  ): Promise<"exited" | "alive" | "untrusted"> {
     if (managed.processGroupId == null) {
       return Promise.race([
-        proc.exited.then(() => true),
-        Bun.sleep(timeoutMs).then(() => false),
+        proc.exited.then(() => "exited" as const),
+        Bun.sleep(timeoutMs).then(() => "alive" as const),
       ]);
     }
+    if (!ownedGroup || ownedGroup.id !== managed.processGroupId) return "untrusted";
 
     const deadline = Date.now() + timeoutMs;
     while (Date.now() < deadline) {
-      if (!this.isProcessGroupAlive(managed.processGroupId)) return true;
+      const ownership = this.authenticateOwnedGroup(ownedGroup);
+      if (ownership.state === "empty") return "exited";
+      if (ownership.state === "untrusted") {
+        // A process that is exiting can transiently expose stat membership
+        // while its environment has already disappeared. Do not signal while
+        // uncertain; give disappearance one short observation window, then
+        // fail closed if the same live identity is still unauthenticated.
+        await Bun.sleep(Math.min(10, Math.max(1, deadline - Date.now())));
+        const confirmed = this.authenticateOwnedGroup(ownedGroup);
+        if (confirmed.state === "empty") return "exited";
+        if (confirmed.state === "untrusted") return "untrusted";
+        continue;
+      }
       await Bun.sleep(Math.min(50, Math.max(1, deadline - Date.now())));
     }
-    return !this.isProcessGroupAlive(managed.processGroupId);
+    const ownership = this.authenticateOwnedGroup(ownedGroup);
+    return ownership.state === "empty"
+      ? "exited"
+      : ownership.state === "untrusted"
+        ? "untrusted"
+        : "alive";
   }
 
-  private isProcessGroupAlive(processGroupId: number): boolean {
+  private authenticateOwnedGroup(ownedGroup: OwnedProcessGroup): OwnedGroupState {
+    let members: ProcessGroupMemberIdentity[];
+    try {
+      members = this.inspectProcessGroup(ownedGroup.id, ownedGroup.ownerToken)
+        .filter((member) => member.processGroupId === ownedGroup.id && !member.state.startsWith("Z"));
+    } catch (error: any) {
+      return {
+        state: "untrusted",
+        members: [],
+        reason: `process-group inspection failed: ${error?.message ?? error}`,
+      };
+    }
+    if (members.length === 0) return { state: "empty", members: [] };
+
+    for (const member of members) {
+      if (!member.ownerTokenMatches || !member.startToken) {
+        return {
+          state: "untrusted",
+          members,
+          reason: `PID ${member.pid} does not carry the authenticated launch token/start identity`,
+        };
+      }
+      const recorded = ownedGroup.memberStartTokens.get(member.pid);
+      if (recorded !== undefined && recorded !== member.startToken) {
+        return {
+          state: "untrusted",
+          members,
+          reason: `PID ${member.pid} start identity changed from ${recorded} to ${member.startToken}`,
+        };
+      }
+    }
+    for (const member of members) {
+      ownedGroup.memberStartTokens.set(member.pid, member.startToken);
+    }
+    return { state: "owned", members };
+  }
+
+  private inspectPosixProcessGroup(
+    processGroupId: number,
+    ownerToken: string,
+  ): ProcessGroupMemberIdentity[] {
     if (this.platform === "linux") {
       try {
         return fs.readdirSync("/proc", { withFileTypes: true })
           .filter((entry) => entry.isDirectory() && /^\d+$/.test(entry.name))
-          .some((entry) => {
+          .flatMap((entry): ProcessGroupMemberIdentity[] => {
+            const pid = Number(entry.name);
+            let state = "?";
+            let group = -1;
+            let startToken = "";
             try {
               const stat = fs.readFileSync(`/proc/${entry.name}/stat`, "utf8");
               const fields = stat.slice(stat.lastIndexOf(")") + 2).split(" ");
-              const state = fields[0];
-              const group = Number(fields[2]);
-              return group === processGroupId && state !== "Z";
+              state = fields[0];
+              group = Number(fields[2]);
+              if (group !== processGroupId || state === "Z") return [];
+              startToken = fields[19] ?? "";
+              const environ = fs.readFileSync(`/proc/${entry.name}/environ`, "utf8");
+              const member = {
+                pid,
+                processGroupId: group,
+                state,
+                startToken,
+                ownerTokenMatches: environ
+                  .split("\0")
+                  .includes(`${OWNER_TOKEN_ENV}=${ownerToken}`),
+              };
+              if (member.ownerTokenMatches) return [member];
+
+              // A successful environ read can still be transiently empty as
+              // a process exits. Re-sample stat and environ before returning
+              // a stable live token mismatch to the fail-closed boundary.
+              const latest = fs.readFileSync(`/proc/${entry.name}/stat`, "utf8");
+              const latestFields = latest.slice(latest.lastIndexOf(")") + 2).split(" ");
+              const latestState = latestFields[0];
+              const latestGroup = Number(latestFields[2]);
+              if (latestGroup !== processGroupId || latestState === "Z") return [];
+              const latestEnvironment = fs.readFileSync(`/proc/${entry.name}/environ`, "utf8");
+              return [{
+                pid,
+                processGroupId: latestGroup,
+                state: latestState,
+                startToken: latestFields[19] ?? startToken,
+                ownerTokenMatches: latestEnvironment
+                  .split("\0")
+                  .includes(`${OWNER_TOKEN_ENV}=${ownerToken}`),
+              }];
             } catch {
-              return false;
+              // A member can exit between reading stat and environ. Re-sample
+              // its stat before treating an unreadable identity as a live,
+              // untrusted member; disappearance or group departure is safe.
+              try {
+                const latest = fs.readFileSync(`/proc/${entry.name}/stat`, "utf8");
+                const latestFields = latest.slice(latest.lastIndexOf(")") + 2).split(" ");
+                const latestState = latestFields[0];
+                const latestGroup = Number(latestFields[2]);
+                if (latestGroup !== processGroupId || latestState === "Z") return [];
+                return [{
+                  pid,
+                  processGroupId: latestGroup,
+                  state: latestState,
+                  startToken: latestFields[19] ?? startToken,
+                  ownerTokenMatches: false,
+                }];
+              } catch {
+                return [];
+              }
             }
           });
       } catch {
-        // Fall through to ps/kill probes on restricted procfs mounts.
+        // Fall through to the portable ps view on restricted procfs mounts.
       }
     }
 
-    // `kill(-pgid, 0)` also reports zombie-only groups as alive. Prefer the
-    // portable macOS/Linux `ps -axo` view so reaping latency does not force an
-    // unnecessary five-second wait or escalation.
-    try {
-      const result = Bun.spawnSync(["ps", "-axo", "pgid=,stat="], { stderr: "pipe" });
-      if (result.exitCode === 0) {
-        const hasLiveMember = result.stdout
-          .toString()
-          .split("\n")
-          .map((line) => line.trim().match(/^(\d+)\s+(\S+)/))
-          .filter((match): match is RegExpMatchArray => match !== null)
-          .some((match) => Number(match[1]) === processGroupId && !match[2].startsWith("Z"));
-        return hasLiveMember;
-      }
-    } catch {
-      // Fall through to the signal-free existence probe if ps is unavailable.
-    }
-    try {
-      process.kill(-processGroupId, 0);
-      return true;
-    } catch (error: any) {
-      if (error?.code === "ESRCH") return false;
-      throw error;
-    }
+    const result = Bun.spawnSync(["ps", "-axo", "pid=,pgid=,stat=,lstart="], { stderr: "pipe" });
+    if (result.exitCode !== 0) throw new Error("ps could not inspect process-group identities");
+    return result.stdout
+      .toString()
+      .split("\n")
+      .flatMap((line): ProcessGroupMemberIdentity[] => {
+        const match = line.trim().match(/^(\d+)\s+(\d+)\s+(\S+)\s+(.+)$/);
+        if (!match || Number(match[2]) !== processGroupId || match[3].startsWith("Z")) return [];
+        const pid = Number(match[1]);
+        const environment = Bun.spawnSync(
+          ["ps", "eww", "-p", String(pid), "-o", "command="],
+          { stderr: "pipe" },
+        );
+        return [{
+          pid,
+          processGroupId,
+          state: match[3],
+          startToken: match[4].trim(),
+          ownerTokenMatches: environment.exitCode === 0
+            && environment.stdout.toString().includes(`${OWNER_TOKEN_ENV}=${ownerToken}`),
+        }];
+      });
   }
 
   /** Stops and re-launches a process. Returns null if the process was never started. */
   async restart(name: string): Promise<{ waitForExit: Promise<number> } | null> {
     const managed = this.processes.get(name);
     if (!managed) return null;
-    await this.stop(name);
+    const stopped = await this.stop(name);
+    if (!stopped && this.isRunning(name)) {
+      throw new Error(
+        `Refusing to restart ${name}: the prior process-group identity could not be authenticated`,
+      );
+    }
     return this.launch(managed.config);
   }
 
   /** Stops all running processes in parallel. */
   async stopAll(): Promise<void> {
-    await Promise.all(Array.from(this.procs.keys()).map((n) => this.stop(n)));
+    const names = new Set([...this.procs.keys(), ...this.ownedGroups.keys()]);
+    await Promise.all(Array.from(names).map((n) => this.stop(n)));
   }
 
   isRunning(name: string): boolean {
-    return this.procs.has(name);
+    return this.procs.has(name) || this.ownedGroups.has(name);
   }
 
   /** Returns true if the process is being intentionally stopped (via stop/restart). */

--- a/packages/build-tools/orchestrator/test/owned-cleanup.test.ts
+++ b/packages/build-tools/orchestrator/test/owned-cleanup.test.ts
@@ -99,6 +99,29 @@ describe("ownership-safe configured ports", () => {
     ]);
   });
 
+  test("stopAll retains authenticated cleanup after the wrapper exits before its descendant", async () => {
+    const ownedPort = await randomFreePort();
+    const signals: ManagedSignal[] = [];
+    const manager = new ProcessManager({ onSignal: (signal) => signals.push(signal) });
+    managers.add(manager);
+
+    const { waitForExit } = await manager.launch(
+      fixtureConfig("early-wrapper", "wrapper-exit", ownedPort),
+    );
+    expect(await waitForPort(ownedPort, 5_000)).toBe(true);
+    expect(await waitForExit).toBe(0);
+    expect(manager.get("early-wrapper")?.status).toBe("done");
+    expect(manager.isRunning("early-wrapper")).toBe(true);
+
+    await manager.stopAll();
+
+    expect(await waitForPortToClose(ownedPort)).toBe(true);
+    expect(signals.map(({ target, signal }) => ({ target, signal }))).toEqual([
+      { target: "process-group", signal: "SIGTERM" },
+    ]);
+    expect(manager.isRunning("early-wrapper")).toBe(false);
+  });
+
   test("partial start and repeated stop signal only the live owned group", async () => {
     const ownedPort = await randomFreePort();
     const unrelated = await listenOnRandomPort();
@@ -238,6 +261,69 @@ describe("ownership-safe configured ports", () => {
     expect(signals.map(({ target, signal, id }) => ({ target, signal, id }))).toEqual([
       { target: "process-group", signal: "SIGTERM", id: signals[0]?.id },
       { target: "process-group", signal: "SIGKILL", id: signals[0]?.id },
+    ]);
+    expect(await waitForPortToClose(port)).toBe(true);
+  });
+
+  test("PGID reuse before escalation loses authorization and sends no KILL", async () => {
+    const signals: ManagedSignal[] = [];
+    let termSent = false;
+    let postTermInspections = 0;
+    const manager = new ProcessManager({
+      stopTimeoutMs: 40,
+      createOwnerToken: () => "deterministic-owner-token",
+      inspectProcessGroup: (processGroupId) => {
+        if (termSent && ++postTermInspections >= 2) {
+          return [{
+            pid: processGroupId,
+            processGroupId,
+            state: "S",
+            startToken: "reused-start-token",
+            // Even a copied/inherited owner token cannot authorize a reused
+            // numeric identity whose non-reusable start token changed.
+            ownerTokenMatches: true,
+          }];
+        }
+        return [{
+          pid: processGroupId,
+          processGroupId,
+          state: "S",
+          startToken: "owned-start-token",
+          ownerTokenMatches: true,
+        }];
+      },
+      signalProcessGroup: (_processGroupId, signal) => {
+        if (signal === "SIGTERM") termSent = true;
+      },
+      onSignal: (signal) => signals.push(signal),
+    });
+    managers.add(manager);
+
+    const { waitForExit } = await manager.launch({
+      name: "reused-group",
+      command: process.execPath,
+      args: ["-e", "setTimeout(() => process.exit(0), 150)"],
+    });
+    expect(await manager.stop("reused-group")).toBe(false);
+    expect(signals.map(({ signal }) => signal)).toEqual(["SIGTERM"]);
+    await waitForExit;
+  });
+
+  test("concurrent stops coalesce into one authenticated signal sequence", async () => {
+    const port = await randomFreePort();
+    const signals: ManagedSignal[] = [];
+    const manager = new ProcessManager({ onSignal: (signal) => signals.push(signal) });
+    managers.add(manager);
+
+    await manager.launch(fixtureConfig("coalesced", "listener", port));
+    expect(await waitForPort(port, 5_000)).toBe(true);
+    expect(await Promise.all([manager.stop("coalesced"), manager.stop("coalesced")])).toEqual([
+      true,
+      true,
+    ]);
+
+    expect(signals.map(({ target, signal }) => ({ target, signal }))).toEqual([
+      { target: "process-group", signal: "SIGTERM" },
     ]);
     expect(await waitForPortToClose(port)).toBe(true);
   });

--- a/packages/build-tools/orchestrator/test/owned-cleanup.test.ts
+++ b/packages/build-tools/orchestrator/test/owned-cleanup.test.ts
@@ -1,0 +1,263 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import * as fs from "node:fs";
+import * as net from "node:net";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { ProcessConfig } from "../src/config.ts";
+import { collectConfiguredPortListeners } from "../src/commands/stop.ts";
+import { isPortInUse, waitForPort } from "../src/port-check.ts";
+import { ProcessManager, type ManagedSignal } from "../src/process-manager.ts";
+
+const fixture = path.join(import.meta.dir, "process-tree-fixture.ts");
+const servers = new Set<net.Server>();
+const managers = new Set<ProcessManager>();
+
+async function listenOnRandomPort(): Promise<{ server: net.Server; port: number }> {
+  for (;;) {
+    const server = net.createServer((socket) => socket.end());
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", resolve);
+    });
+    const address = server.address();
+    if (typeof address !== "string" && address && address.port > 10000) {
+      servers.add(server);
+      return { server, port: address.port };
+    }
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+}
+
+async function randomFreePort(): Promise<number> {
+  const { server, port } = await listenOnRandomPort();
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+  servers.delete(server);
+  return port;
+}
+
+async function waitForPortToClose(port: number, timeoutMs = 2_000): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!(await isPortInUse(port))) return true;
+    await Bun.sleep(25);
+  }
+  return !(await isPortInUse(port));
+}
+
+async function closeServer(server: net.Server): Promise<void> {
+  if (!servers.delete(server)) return;
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+}
+
+afterEach(async () => {
+  for (const manager of managers) await manager.stopAll();
+  managers.clear();
+  for (const server of [...servers]) await closeServer(server);
+});
+
+function fixtureConfig(name: string, mode: string, port: number): ProcessConfig {
+  return {
+    name,
+    command: process.execPath,
+    args: [fixture, mode, String(port)],
+    stopProcessAtPort: [port],
+  };
+}
+
+describe("ownership-safe configured ports", () => {
+  test("an unrelated native listener causes startup refusal and remains alive", async () => {
+    const { server, port } = await listenOnRandomPort();
+    const signals: ManagedSignal[] = [];
+    const manager = new ProcessManager({ onSignal: (signal) => signals.push(signal) });
+    managers.add(manager);
+
+    await expect(manager.launch(fixtureConfig("conflict", "listener", port))).rejects.toThrow(
+      new RegExp(`port ${port}`, "i"),
+    );
+    await manager.stopAll();
+
+    expect(await isPortInUse(port)).toBe(true);
+    expect(server.listening).toBe(true);
+    expect(signals).toEqual([]);
+  });
+
+  test("owned process-group shutdown closes descendants and preserves another group", async () => {
+    const ownedPort = await randomFreePort();
+    const unrelated = await listenOnRandomPort();
+    const signals: ManagedSignal[] = [];
+    const manager = new ProcessManager({ onSignal: (signal) => signals.push(signal) });
+    managers.add(manager);
+
+    await manager.launch(fixtureConfig("wrapper", "wrapper", ownedPort));
+    expect(await waitForPort(ownedPort, 5_000)).toBe(true);
+    expect(await manager.stop("wrapper")).toBe(true);
+
+    expect(await waitForPortToClose(ownedPort)).toBe(true);
+    expect(await isPortInUse(unrelated.port)).toBe(true);
+    expect(signals.map(({ target, signal }) => ({ target, signal }))).toEqual([
+      { target: "process-group", signal: "SIGTERM" },
+    ]);
+  });
+
+  test("partial start and repeated stop signal only the live owned group", async () => {
+    const ownedPort = await randomFreePort();
+    const unrelated = await listenOnRandomPort();
+    const signals: ManagedSignal[] = [];
+    const manager = new ProcessManager({ onSignal: (signal) => signals.push(signal) });
+    managers.add(manager);
+
+    await manager.launch(fixtureConfig("owned", "listener", ownedPort));
+    expect(await waitForPort(ownedPort, 5_000)).toBe(true);
+    await expect(manager.launch(fixtureConfig("blocked", "listener", unrelated.port))).rejects.toThrow();
+    expect(await manager.stop("owned")).toBe(true);
+    expect(await manager.stop("owned")).toBe(false);
+
+    expect(signals).toHaveLength(1);
+    expect(signals[0]?.target).toBe("process-group");
+    expect(await isPortInUse(unrelated.port)).toBe(true);
+  });
+
+  test("a replacement listener cannot inherit ownership from an exited child", async () => {
+    const port = await randomFreePort();
+    const signals: ManagedSignal[] = [];
+    const manager = new ProcessManager({ onSignal: (signal) => signals.push(signal) });
+    managers.add(manager);
+    const { waitForExit } = await manager.launch({
+      name: "short",
+      command: process.execPath,
+      args: ["-e", "process.exit(0)"],
+      stopProcessAtPort: [port],
+      waitToExit: true,
+    });
+    await waitForExit;
+
+    const replacement = net.createServer((socket) => socket.end());
+    await new Promise<void>((resolve, reject) => {
+      replacement.once("error", reject);
+      replacement.listen(port, "127.0.0.1", resolve);
+    });
+    servers.add(replacement);
+
+    expect(await manager.stop("short")).toBe(false);
+    expect(signals).toEqual([]);
+    expect(await isPortInUse(port)).toBe(true);
+  });
+
+  test("missing-daemon inspection reports listeners without a signaling primitive", async () => {
+    const unrelated = await listenOnRandomPort();
+    const matches = await collectConfiguredPortListeners([
+      { name: "unrelated", args: [], stopProcessAtPort: [unrelated.port] },
+    ]);
+
+    expect(matches).toHaveLength(1);
+    expect(matches[0]?.port).toBe(unrelated.port);
+
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "orchestrator-fallback-"));
+    const configPath = path.join(tempDir, "orchestrator.config.ts");
+    const apiPort = await randomFreePort();
+    fs.writeFileSync(
+      configPath,
+      `export default { processes: [{ name: "unrelated", args: [], stopProcessAtPort: [${unrelated.port}] }] };`,
+    );
+    const cli = path.join(import.meta.dir, "../src/cli.ts");
+    try {
+      const stop = Bun.spawn(
+        [process.execPath, cli, "stop", `--config=${configPath}`, `--port=${apiPort}`],
+        { stdin: "ignore", stdout: "pipe", stderr: "pipe" },
+      );
+      const [exitCode, stdout, stderr] = await Promise.all([
+        stop.exited,
+        new Response(stop.stdout).text(),
+        new Response(stop.stderr).text(),
+      ]);
+      expect(exitCode).toBe(1);
+      expect(`${stdout}\n${stderr}`).toContain("Refusing to signal");
+      expect(`${stdout}\n${stderr}`).toContain(`port ${unrelated.port}`);
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+    expect(await isPortInUse(unrelated.port)).toBe(true);
+  });
+
+  test("an injected Docker Desktop shared listener is diagnostic-only", async () => {
+    const port = await randomFreePort();
+    const signals: ManagedSignal[] = [];
+    const health = { unrelatedContainer: "healthy" };
+    const manager = new ProcessManager({
+      inspectPorts: async () => [{ port, pids: [4242] }],
+      onSignal: (signal) => signals.push(signal),
+    });
+    managers.add(manager);
+
+    await expect(manager.launch(fixtureConfig("docker-collision", "listener", port))).rejects.toThrow(
+      /PID 4242/,
+    );
+    expect(signals).toEqual([]);
+    expect(health.unrelatedContainer).toBe("healthy");
+  });
+
+  test("top-level SIGTERM shuts down the owned group through the manager", async () => {
+    const port = await randomFreePort();
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "orchestrator-sigterm-"));
+    const configPath = path.join(tempDir, "orchestrator.config.ts");
+    const signalLog = path.join(tempDir, "signals.log");
+    fs.writeFileSync(
+      configPath,
+      `export default { processes: [{ name: "signal-child", command: ${JSON.stringify(process.execPath)}, args: [${JSON.stringify(fixture)}, "signal-listener", "${port}"], env: { TEST_SIGNAL_LOG: ${JSON.stringify(signalLog)} }, stopProcessAtPort: [${port}] }] };`,
+    );
+    const cli = path.join(import.meta.dir, "../src/cli.ts");
+    const orchestrator = Bun.spawn(
+      [process.execPath, cli, "start", configPath, "--no-api"],
+      { stdin: "ignore", stdout: "pipe", stderr: "pipe" },
+    );
+    try {
+      expect(await waitForPort(port, 5_000)).toBe(true);
+      orchestrator.kill("SIGTERM");
+      await orchestrator.exited;
+      expect(await isPortInUse(port)).toBe(false);
+      expect(fs.readFileSync(signalLog, "utf8").trim().split("\n")).toEqual(["SIGTERM"]);
+    } finally {
+      if (orchestrator.exitCode === null) orchestrator.kill("SIGKILL");
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  test("owned escalation records TERM then KILL against the same group", async () => {
+    const port = await randomFreePort();
+    const signals: ManagedSignal[] = [];
+    const manager = new ProcessManager({
+      stopTimeoutMs: 100,
+      onSignal: (signal) => signals.push(signal),
+    });
+    managers.add(manager);
+
+    await manager.launch(fixtureConfig("stubborn", "wrapper-stubborn", port));
+    expect(await waitForPort(port, 5_000)).toBe(true);
+    expect(await manager.stop("stubborn")).toBe(true);
+
+    expect(signals.map(({ target, signal, id }) => ({ target, signal, id }))).toEqual([
+      { target: "process-group", signal: "SIGTERM", id: signals[0]?.id },
+      { target: "process-group", signal: "SIGKILL", id: signals[0]?.id },
+    ]);
+    expect(await waitForPortToClose(port)).toBe(true);
+  });
+
+  test("Windows policy targets only the recorded direct child", async () => {
+    const port = await randomFreePort();
+    const signals: ManagedSignal[] = [];
+    const manager = new ProcessManager({
+      platform: "win32",
+      onSignal: (signal) => signals.push(signal),
+    });
+    managers.add(manager);
+
+    await manager.launch(fixtureConfig("windows-child", "listener", port));
+    expect(await waitForPort(port, 5_000)).toBe(true);
+    expect(await manager.stop("windows-child")).toBe(true);
+
+    expect(signals.map(({ target, signal }) => ({ target, signal }))).toEqual([
+      { target: "direct-child", signal: "SIGTERM" },
+    ]);
+    expect(await waitForPortToClose(port)).toBe(true);
+  });
+});

--- a/packages/build-tools/orchestrator/test/owned-cleanup.test.ts
+++ b/packages/build-tools/orchestrator/test/owned-cleanup.test.ts
@@ -265,6 +265,53 @@ describe("ownership-safe configured ports", () => {
     expect(await waitForPortToClose(port)).toBe(true);
   });
 
+  test("post-KILL live groups remain owned until an authenticated empty retry", async () => {
+    const signals: ManagedSignal[] = [];
+    let observedGroup: "owned" | "replacement" | "empty" = "owned";
+    const manager = new ProcessManager({
+      stopTimeoutMs: 20,
+      createOwnerToken: () => "deterministic-post-kill-owner",
+      inspectProcessGroup: (processGroupId) => {
+        if (observedGroup === "empty") return [];
+        return [{
+          pid: processGroupId,
+          processGroupId,
+          state: "S",
+          startToken: observedGroup === "owned" ? "owned-start-token" : "replacement-start-token",
+          ownerTokenMatches: observedGroup === "owned",
+        }];
+      },
+      signalProcessGroup: () => {
+        // The injected ownership boundary deliberately remains live after
+        // both signals so the post-KILL control flow is deterministic.
+      },
+      onSignal: (signal) => signals.push(signal),
+    });
+    managers.add(manager);
+
+    const { waitForExit } = await manager.launch({
+      name: "post-kill-live",
+      command: process.execPath,
+      args: ["-e", "setTimeout(() => process.exit(0), 75)"],
+    });
+
+    expect(await manager.stop("post-kill-live")).toBe(false);
+    expect(signals.map(({ signal }) => signal)).toEqual(["SIGTERM", "SIGKILL"]);
+    expect(manager.get("post-kill-live")?.status).not.toBe("stopped");
+    expect(manager.isRunning("post-kill-live")).toBe(true);
+    await waitForExit;
+
+    observedGroup = "replacement";
+    expect(await manager.stop("post-kill-live")).toBe(false);
+    expect(signals.map(({ signal }) => signal)).toEqual(["SIGTERM", "SIGKILL"]);
+    expect(manager.isRunning("post-kill-live")).toBe(true);
+
+    observedGroup = "empty";
+    expect(await manager.stop("post-kill-live")).toBe(true);
+    expect(signals.map(({ signal }) => signal)).toEqual(["SIGTERM", "SIGKILL"]);
+    expect(manager.isRunning("post-kill-live")).toBe(false);
+  });
+
   test("PGID reuse before escalation loses authorization and sends no KILL", async () => {
     const signals: ManagedSignal[] = [];
     let termSent = false;

--- a/packages/build-tools/orchestrator/test/process-tree-fixture.ts
+++ b/packages/build-tools/orchestrator/test/process-tree-fixture.ts
@@ -33,6 +33,25 @@ if (mode === "listener" || mode === "stubborn-listener" || mode === "signal-list
     { stdin: "ignore", stdout: "inherit", stderr: "inherit" },
   );
   await child.exited;
+} else if (mode === "wrapper-exit") {
+  Bun.spawn(
+    [process.execPath, import.meta.path, "listener", String(port)],
+    { stdin: "ignore", stdout: "inherit", stderr: "inherit" },
+  );
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    const opened = await new Promise<boolean>((resolve) => {
+      const socket = net.connect(port, "127.0.0.1");
+      socket.once("connect", () => {
+        socket.destroy();
+        resolve(true);
+      });
+      socket.once("error", () => resolve(false));
+    });
+    if (opened) process.exit(0);
+    await Bun.sleep(10);
+  }
+  throw new Error("wrapper-exit descendant did not open its listener");
 } else {
   throw new Error(`unknown fixture mode: ${mode}`);
 }

--- a/packages/build-tools/orchestrator/test/process-tree-fixture.ts
+++ b/packages/build-tools/orchestrator/test/process-tree-fixture.ts
@@ -1,0 +1,38 @@
+import * as fs from "node:fs";
+import * as net from "node:net";
+
+const mode = process.argv[2];
+const port = Number(process.argv[3]);
+
+if (!Number.isInteger(port) || port <= 10000) {
+  throw new Error(`fixture requires a port above 10000, received ${process.argv[3]}`);
+}
+
+if (mode === "listener" || mode === "stubborn-listener" || mode === "signal-listener") {
+  const server = net.createServer((socket) => socket.end());
+  server.listen(port, "127.0.0.1");
+  if (mode === "stubborn-listener") {
+    process.on("SIGTERM", () => {});
+  }
+  if (mode === "signal-listener") {
+    const signalLog = process.env.TEST_SIGNAL_LOG;
+    if (!signalLog) throw new Error("signal-listener requires TEST_SIGNAL_LOG");
+    process.on("SIGTERM", () => {
+      fs.appendFileSync(signalLog, "SIGTERM\n");
+      server.close(() => process.exit(0));
+    });
+  }
+} else if (mode === "wrapper" || mode === "wrapper-stubborn") {
+  const child = Bun.spawn(
+    [
+      process.execPath,
+      import.meta.path,
+      mode === "wrapper" ? "listener" : "stubborn-listener",
+      String(port),
+    ],
+    { stdin: "ignore", stdout: "inherit", stderr: "inherit" },
+  );
+  await child.exited;
+} else {
+  throw new Error(`unknown fixture mode: ${mode}`);
+}


### PR DESCRIPTION
## Summary

- make configured ports diagnostic inputs only: startup reports occupied ports and shutdown never treats a listener PID as permission to signal it
- retain authenticated native process-group ownership through wrapper exit, PID/PGID reuse checks, concurrent stops, TERM/KILL escalation, and incomplete post-KILL cleanup
- create and clean up each Midnight proof-server container through its captured immutable container ID instead of a shared fixed name

## Observable safety behavior change

Automatic stale-port killing is removed. An occupied or stale configured listener now causes a diagnostic failure and requires explicit operator remediation; the orchestrator will not kill that listener merely because it owns the configured port number.

This is an observable lifecycle safety correction. It is **not** a data or API breaking change.

## Verification

- independent delivery audit: PASS at exact clean commit `8aa754effd60ad65cd500cec9ecc216aafb743a5`, with no findings
- isolated Bun 1.3.11 Docker suite: 19 tests passed, 0 failed, 85 assertions
- owned TERM-to-KILL escalation stress: 10/10 iterations, 40 assertions
- native macOS process-group/start-token fallback: 1 test passed, 7 assertions, dynamic port above 10000
- TypeScript 5.9.2 plus `@types/bun` 1.3.11 candidate/base comparison: the same two pre-existing diagnostics and no candidate-only error
- real immutable-ID proof-server attach/cleanup gate passed; exact owned container removed and unrelated fixture unchanged
- atomic Docker Desktop collision gate passed with zero signal attempts; backend PIDs and all unrelated container state/health tuples were unchanged

All test-created containers, processes, ports, worktrees, and temporary runners were torn down by their exact owned identities.

## Delivery order

This PR must land before draft PR #889. PR #889 depends on this ownership-safe orchestrator behavior and must remain draft until that dependency is satisfied.
