### PR TITLE
fix(template): align Compact toolchain checks and Quick Start prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,20 @@ This project integrates with the Midnight Network.
 
 ## Quick start
 
+Install [Bun](https://bun.sh), [Foundry](https://www.getfoundry.sh/), and the
+Compact compiler selection (`0.33.0-rc.2`) used by the EVM/Midnight template
+before starting:
+
+```sh
+curl -L https://foundry.paradigm.xyz | bash && foundryup
+curl --proto '=https' --tlsv1.2 -LsSf https://github.com/midnightntwrk/compact/releases/latest/download/compact-installer.sh | sh
+```
+
 Run a sample project:  
 ```sh
 git clone https://github.com/effectstream/effectstream.git
 cd effectstream/templates/evm-midnight-v2
+bun toolchain/compact.ts install
 bun i
 bun run dev
 ```

--- a/docs/site/docs/home/0-intro/0-intro.md
+++ b/docs/site/docs/home/0-intro/0-intro.md
@@ -25,12 +25,24 @@ EffectStream is a Web3 Engine optimized for dApps, games, gamification and auton
 
 > This is a preview of the EffectStream V2 documentation. We welcome any feedback you have on errors, missing information, or parts that aren't clear.
 
+Install [Bun](https://bun.sh), [Foundry](https://www.getfoundry.sh/), and the
+EVM/Midnight template's selected Compact compiler (`0.33.0-rc.2`) before
+starting:
+
+```sh
+curl -L https://foundry.paradigm.xyz | bash && foundryup
+curl --proto '=https' --tlsv1.2 -LsSf https://github.com/midnightntwrk/compact/releases/latest/download/compact-installer.sh | sh
+```
+
 First, clone the repository and use the `templates/evm-midnight-v2/` folder as a working template:
 
 ```sh
 # Clone and move to evm-midnight-v2 template
 git clone https://github.com/effectstream/effectstream.git
 cd effectstream/templates/evm-midnight-v2
+
+# Install the checksummed Compact selection declared by this template
+bun toolchain/compact.ts install
 
 # Install packages
 bun i

--- a/docs/site/docs/home/10-quickstart/10-quickstart.md
+++ b/docs/site/docs/home/10-quickstart/10-quickstart.md
@@ -9,11 +9,23 @@ slug: /quick-start
 
 > This is a preview of the EffectStream V2 documentation. We welcome any feedback you have on errors, missing information, or parts that aren't clear.
 
+Install [Bun](https://bun.sh), [Foundry](https://www.getfoundry.sh/), and the
+EVM/Midnight template's selected Compact compiler (`0.33.0-rc.2`) before
+starting:
+
+```sh
+curl -L https://foundry.paradigm.xyz | bash && foundryup
+curl --proto '=https' --tlsv1.2 -LsSf https://github.com/midnightntwrk/compact/releases/latest/download/compact-installer.sh | sh
+```
+
 First, clone the repository and use the `templates/evm-midnight-v2/` folder as a working template:
 
 ```sh
 git clone https://github.com/effectstream/effectstream.git
 cd effectstream/templates/evm-midnight-v2
+
+# Install the checksummed Compact selection declared by this template
+bun toolchain/compact.ts install
 
 # Install packages
 bun i

--- a/docs/site/docs/home/1200-templates/1201-evm-midnight.md
+++ b/docs/site/docs/home/1200-templates/1201-evm-midnight.md
@@ -55,11 +55,17 @@ Prerequisites beyond [Bun](https://bun.sh):
   ```sh
   curl -L https://foundry.paradigm.xyz | bash && foundryup
   ```
-- **[Compact](https://github.com/midnightntwrk/compact)** — the Midnight circuit compiler, pinned to `0.31.0`. Also checked on PATH before the Midnight processes launch.
+- **[Compact](https://github.com/midnightntwrk/compact)** — the Midnight circuit compiler. This template selects `0.33.0-rc.2` and checks that exact selection before any Midnight process launches.
   ```sh
   curl --proto '=https' --tlsv1.2 -LsSf https://github.com/midnightntwrk/compact/releases/latest/download/compact-installer.sh | sh
-  compact update 0.31.0
+  bun toolchain/compact.ts install
   ```
+
+`toolchain.json` is the template's source of truth for the Compact selection.
+The installer downloads the immutable upstream asset for the current platform
+and verifies its published checksum. The local build runner, startup preflight,
+and Docker build all read the same declaration; the documentation consistency
+test keeps the commands above aligned with it.
 
 Then:
 
@@ -97,14 +103,16 @@ bun run dev
 Individual build steps are also available on their own:
 
 ```sh
-bun run build:midnight   # compact compile +0.31.0 src/counter.compact src/managed
+bun run build:midnight   # compile with the Compact selection in toolchain.json
 bun run build:evm        # Forge + Hardhat compile, deploy, generate TS bindings
 bun run build:pgtypes    # regenerate pgtyped query types from sql/*.sql
 ```
 
 ### Docker
 
-The `Dockerfile` installs Bun, Node, Foundry and the Compact compiler, pre-warms the solc cache, and starts the same orchestrator config.
+The `Dockerfile` installs Bun, Node, Foundry and the Compact compiler selection
+from `toolchain.json`, pre-warms the solc cache, and starts the same orchestrator
+config.
 
 ```sh
 # On macOS Apple Silicon

--- a/templates/evm-midnight-v2/CLAUDE.md
+++ b/templates/evm-midnight-v2/CLAUDE.md
@@ -4,6 +4,23 @@
 
 Multi-chain Effectstream template: EVM (Hardhat/Arbitrum) + Midnight. Syncs ERC-721 events and Midnight contract state into a unified rollup. React frontend with Midnight wallet integration.
 
+## Required toolchain
+
+Install [Foundry](https://www.getfoundry.sh/) and the Compact launcher before
+starting this template, then install its exact Compact selection,
+`0.33.0-rc.2`:
+
+```bash
+curl -L https://foundry.paradigm.xyz | bash && foundryup
+curl --proto '=https' --tlsv1.2 -LsSf https://github.com/midnightntwrk/compact/releases/latest/download/compact-installer.sh | sh
+bun toolchain/compact.ts install
+```
+
+`toolchain.json` is the source of truth. Contract builds, startup preflight,
+Docker installation, and documentation consistency checks consume or validate
+that declaration. The template installer downloads an immutable upstream asset
+and verifies the per-platform checksum declared beside the version.
+
 ## Commands
 
 ```bash
@@ -11,7 +28,7 @@ bun install                          # Install deps
 bun run dev                          # Full stack: PGLite + Hardhat + Midnight + sync + batcher + frontend
 bun run start:mainnet                # Mainnet: Arbitrum One + Midnight mainnet (requires env vars)
 bun run test                         # E2E tests (packages/tests/run-tests.ts)
-bun run build:midnight               # Compile Compact contract (+0.31.0)
+bun run build:midnight               # Compile with the selection in toolchain.json
 bun run build:evm                    # Compile Solidity + generate TS bindings
 ```
 
@@ -50,12 +67,12 @@ Bun monorepo with flat `packages/*` layout. All `@effectstream/*` deps are from 
 All Midnight dependencies must be pinned to exact versions from the compatibility matrix:
 https://github.com/midnightntwrk/midnight-sdk/blob/main/COMPATIBILITY.md
 
-Never use `^` or `~` ranges. Current stable set (midnight-node 1.0.0 era, as of 2026-07-29):
-- Compact compiler `+0.31.0`, compact-runtime `0.16.0`, compact-js `2.5.1` (do NOT bump compact-js to 2.5.3+ — it targets ledger-v9)
-- midnight-js-* `4.1.1`, ledger-v8 `8.1.0`, onchain-runtime-v3 `3.0.0`
-- Wallet SDK moved scope to `@midnightntwrk/*` (no hyphen): wallet-sdk-facade `4.1.0`, wallet-sdk-hd `3.0.3`, wallet-sdk-dust-wallet `4.2.0`, wallet-sdk-shielded `3.0.2`, wallet-sdk-unshielded-wallet `3.1.0`, wallet-sdk-address-format `3.1.2`, wallet-sdk-abstractions `2.1.0`
+Never use `^` or `~` ranges. Current template set (Midnight node 2.x / Ledger 9):
+- Compact compiler `+0.33.0-rc.2` from `toolchain.json`, compact-runtime `0.18.0-rc.1`, compact-js `2.5.5-rc.7`
+- midnight-js-* `5.0.0-beta.6`, ledger-v9 `1.0.0-rc.3`, onchain-runtime-v4 `4.0.0-rc.3`
+- Wallet SDK packages use the `@midnightntwrk/*` scope and the exact beta versions pinned in `packages/frontend/package.json`.
 
-The old `@midnight-ntwrk/ledger`, `ledger-v6`, `onchain-runtime-v1`, `zswap`, and `wallet`/`wallet-api` packages are deprecated/removed — zswap types are re-exported from `ledger-v8`.
+The old `@midnight-ntwrk/ledger`, ledger-v8, onchain-runtime-v3, `zswap`, and `wallet`/`wallet-api` packages belong to the prior node-1/Ledger-8 generation and must not be mixed into this template.
 
 ## Midnight wallet SDK (v3/v4 API)
 

--- a/templates/evm-midnight-v2/Dockerfile
+++ b/templates/evm-midnight-v2/Dockerfile
@@ -6,6 +6,7 @@ FROM oven/bun:1
 
 RUN apt-get update && apt-get install -y \
     curl \
+    build-essential \
     lsof \
     iproute2 \
     xz-utils \
@@ -34,9 +35,11 @@ RUN forge --version && cast --version && anvil --version
 RUN curl --proto '=https' --tlsv1.2 -LsSf https://github.com/midnightntwrk/compact/releases/latest/download/compact-installer.sh | sh
 ENV PATH="/root/.local/bin:$PATH"
 RUN which compact
-RUN compact update 0.31.0
-RUN compact --version
-RUN compact compile --version
+COPY toolchain.json /tmp/toolchain.json
+COPY toolchain /tmp/toolchain
+RUN bun /tmp/toolchain/compact.ts install \
+    && compact --version \
+    && bun /tmp/toolchain/compact.ts check
 
 # Pre-download solc 0.8.30 into Hardhat's cache to avoid Bun's broken
 # webstreams polyfill triggering during download (known Bun bug in Docker).

--- a/templates/evm-midnight-v2/README.md
+++ b/templates/evm-midnight-v2/README.md
@@ -48,11 +48,17 @@ Prerequisites beyond [Bun](https://bun.sh):
   ```sh
   curl -L https://foundry.paradigm.xyz | bash && foundryup
   ```
-- **[Compact](https://github.com/midnightntwrk/compact)** — the Midnight circuit compiler, pinned to `0.31.0`. Also checked on PATH before the Midnight processes launch.
+- **[Compact](https://github.com/midnightntwrk/compact)** — the Midnight circuit compiler. This template selects `0.33.0-rc.2` and checks that exact selection before any Midnight process launches.
   ```sh
   curl --proto '=https' --tlsv1.2 -LsSf https://github.com/midnightntwrk/compact/releases/latest/download/compact-installer.sh | sh
-  compact update 0.31.0
+  bun toolchain/compact.ts install
   ```
+
+`toolchain.json` is the template's source of truth for the Compact selection.
+The installer downloads the immutable upstream asset for the current platform
+and verifies its published checksum. The local build runner, startup preflight,
+and Docker build all read the same declaration; the documentation consistency
+test keeps the commands above aligned with it.
 
 Then:
 
@@ -90,14 +96,16 @@ bun run dev
 Individual build steps are also available on their own:
 
 ```sh
-bun run build:midnight   # compact compile +0.31.0 src/counter.compact src/managed
+bun run build:midnight   # compile with the Compact selection in toolchain.json
 bun run build:evm        # Forge + Hardhat compile, deploy, generate TS bindings
 bun run build:pgtypes    # regenerate pgtyped query types from sql/*.sql
 ```
 
 ### Docker
 
-The `Dockerfile` installs Bun, Node, Foundry and the Compact compiler, pre-warms the solc cache, and starts the same orchestrator config.
+The `Dockerfile` installs Bun, Node, Foundry and the Compact compiler selection
+from `toolchain.json`, pre-warms the solc cache, and starts the same orchestrator
+config.
 
 ```sh
 # On macOS Apple Silicon

--- a/templates/evm-midnight-v2/packages/contracts-midnight/contract-round-value/package.json
+++ b/templates/evm-midnight-v2/packages/contracts-midnight/contract-round-value/package.json
@@ -6,7 +6,7 @@
     "./contract": "./src/managed/contract/index.js"
   },
   "scripts": {
-    "compact": "compact compile +0.33.0-rc.2 src/counter.compact src/managed",
+    "compact": "bun ../../../toolchain/compact.ts compile src/counter.compact src/managed",
     "contract:compile": "bun run compact"
   },
   "dependencies": {

--- a/templates/evm-midnight-v2/start.dev.test.ts
+++ b/templates/evm-midnight-v2/start.dev.test.ts
@@ -1,0 +1,159 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { compactSelection, compactVersion } from "./toolchain/compact";
+
+const templateRoot = import.meta.dir;
+const systemPath = "/usr/local/bin:/usr/bin:/bin";
+const configMarker = "__EVM_MIDNIGHT_CONFIG__";
+const temporaryDirectories: string[] = [];
+
+type ResolvedProcess = {
+  name: string;
+  dependsOn?: string[];
+};
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+function controlledCompact(compilerAvailable: boolean): string {
+  const directory = mkdtempSync(join(tmpdir(), "evm-midnight-config-"));
+  temporaryDirectories.push(directory);
+  const executable = join(directory, "compact");
+  writeFileSync(
+    executable,
+    `#!/bin/sh
+if [ "$1" = "--version" ]; then
+  echo "compact launcher test"
+  exit 0
+fi
+if [ "$1" = "compile" ] && [ "$2" = "${compactSelection}" ] && [ "$3" = "--version" ]; then
+  ${compilerAvailable ? 'echo "0.33.0"; exit 0' : 'echo "selection unavailable" >&2; exit 1'}
+fi
+echo "unexpected compact invocation: $*" >&2
+exit 2
+`,
+  );
+  chmodSync(executable, 0o755);
+  return `${directory}:${systemPath}`;
+}
+
+function loadActualConfig(path: string): ReturnType<typeof spawnSync> {
+  return spawnSync(
+    process.execPath,
+    [
+      "-e",
+      `const config = (await import("./start.dev.ts")).default; console.log("${configMarker}" + JSON.stringify(config.processes));`,
+    ],
+    {
+      cwd: templateRoot,
+      encoding: "utf8",
+      env: { ...process.env, PATH: path },
+    },
+  );
+}
+
+function outputOf(result: ReturnType<typeof spawnSync>): string {
+  return `${textOf(result.stdout)}${textOf(result.stderr)}`;
+}
+
+function textOf(value: string | Uint8Array | null | undefined): string {
+  if (typeof value === "string") return value;
+  return value ? Buffer.from(value).toString("utf8") : "";
+}
+
+function resolvedProcesses(
+  result: ReturnType<typeof spawnSync>,
+): ResolvedProcess[] {
+  expect(result.status, outputOf(result)).toBe(0);
+  const stdout = textOf(result.stdout);
+  const markerIndex = stdout.lastIndexOf(configMarker);
+  expect(markerIndex, stdout).toBeGreaterThanOrEqual(0);
+  return JSON.parse(
+    stdout.slice(markerIndex + configMarker.length).trim(),
+  ) as ResolvedProcess[];
+}
+
+describe("EVM/Midnight actual startup config", () => {
+  test("missing launcher fails with the template exact-selection diagnostic", () => {
+    const result = loadActualConfig(systemPath);
+    const output = outputOf(result);
+
+    expect(result.status).not.toBe(0);
+    expect(output).toContain("Compact launcher was not found on PATH");
+    expect(output).toContain(compactVersion);
+    expect(output).toContain("bun toolchain/compact.ts install");
+    expect(output).not.toContain("0.31.0");
+  });
+
+  test("missing selected compiler fails before graph construction", () => {
+    const result = loadActualConfig(controlledCompact(false));
+    const output = outputOf(result);
+
+    expect(result.status).not.toBe(0);
+    expect(output).toContain(
+      `template selection ${compactVersion} is unavailable`,
+    );
+    expect(output).toContain("bun toolchain/compact.ts install");
+    expect(output).not.toContain("0.31.0");
+  });
+
+  test("every Midnight process is gated without losing launcher edges", () => {
+    const processes = resolvedProcesses(
+      loadActualConfig(controlledCompact(true)),
+    );
+    const byName = new Map(processes.map((process) => [process.name, process]));
+    const preflight = "midnight-compact-preflight";
+    const midnightProcesses = [
+      "midnight-contract-compile",
+      "midnight-node",
+      "midnight-node-wait",
+      "midnight-indexer",
+      "midnight-indexer-wait",
+      "midnight-proof-server",
+      "midnight-proof-server-wait",
+      "midnight-contract",
+    ];
+
+    for (const name of midnightProcesses) {
+      expect(byName.has(name), `${name} must exist`).toBe(true);
+      expect(
+        byName.get(name)?.dependsOn?.[0],
+        `${name} must start after preflight`,
+      ).toBe(preflight);
+      expect(
+        byName
+          .get(name)
+          ?.dependsOn?.filter((dependency) => dependency === preflight),
+      ).toHaveLength(1);
+    }
+
+    expect(byName.get("midnight-indexer")?.dependsOn).toContain(
+      "midnight-node",
+    );
+    expect(byName.get("midnight-proof-server")?.dependsOn).toContain(
+      "midnight-node",
+    );
+    expect(byName.get("midnight-node-wait")?.dependsOn).toContain(
+      "midnight-node",
+    );
+    expect(byName.get("midnight-indexer-wait")?.dependsOn).toContain(
+      "midnight-indexer",
+    );
+    expect(byName.get("midnight-proof-server-wait")?.dependsOn).toContain(
+      "midnight-proof-server",
+    );
+    expect(byName.get("midnight-contract")?.dependsOn).toEqual([
+      preflight,
+      "midnight-node-wait",
+      "midnight-indexer-wait",
+      "midnight-proof-server-wait",
+      "midnight-contract-compile",
+    ]);
+  });
+});

--- a/templates/evm-midnight-v2/start.dev.ts
+++ b/templates/evm-midnight-v2/start.dev.ts
@@ -1,21 +1,54 @@
 import path from "node:path";
 import type { OrchestratorConfig } from "@effectstream/orchestrator/config";
-import { launchPglite, DbNames } from "@effectstream/orchestrator/launch-pglite";
+import {
+  launchPglite,
+  DbNames,
+} from "@effectstream/orchestrator/launch-pglite";
 import { launchEvm, EvmNames } from "@effectstream/orchestrator/launch-evm";
-import { launchMidnight, MidnightNames } from "@effectstream/orchestrator/launch-midnight";
-import { compactSelection } from "./toolchain/compact";
+import {
+  launchMidnight,
+  MidnightNames,
+} from "@effectstream/orchestrator/launch-midnight";
+import {
+  compactSelection,
+  validateCompactSelection,
+} from "./toolchain/compact";
 
 const root = import.meta.dirname!;
 const midnightDeps = [MidnightNames.CONTRACT_DEPLOY];
+const compactPreflight = "midnight-compact-preflight";
+
+// Validate the template's exact selection before the shared launcher performs
+// its generic executable check, then keep the runtime task as a dependency of
+// every Midnight process so partial/targeted orchestrator runs remain gated.
+validateCompactSelection();
+const midnightProcesses = launchMidnight(
+  "@evm-midnight/contracts-midnight",
+  { cwd: path.join(root, "packages/contracts-midnight") },
+  {
+    env: { MIDNIGHT_STORAGE_PASSWORD: "YourPasswordMy1!" },
+    dependsOn: ["midnight-contract-compile"],
+  },
+).map((process) => ({
+  ...process,
+  dependsOn: [
+    compactPreflight,
+    ...(process.dependsOn ?? []).filter(
+      (dependency) => dependency !== compactPreflight,
+    ),
+  ],
+}));
 
 export default {
   processes: [
-    ...launchPglite().map(p =>
-      p.name === "pglite" ? { ...p, env: { ...p.env, DEBUG_PGLITE: "0" } } : p
+    ...launchPglite().map((p) =>
+      p.name === "pglite" ? { ...p, env: { ...p.env, DEBUG_PGLITE: "0" } } : p,
     ),
-    ...launchEvm("@evm-midnight/contracts-evm", { cwd: path.join(root, "packages/contracts-evm") }),
+    ...launchEvm("@evm-midnight/contracts-evm", {
+      cwd: path.join(root, "packages/contracts-evm"),
+    }),
     {
-      name: "midnight-compact-preflight",
+      name: compactPreflight,
       description: `Validate Compact compiler selection ${compactSelection}`,
       cwd: root,
       args: ["run", "toolchain/compact.ts", "check"],
@@ -29,12 +62,9 @@ export default {
       args: ["run", "compact"],
       waitToExit: true,
       critical: true,
-      dependsOn: ["midnight-compact-preflight"],
+      dependsOn: [compactPreflight],
     },
-    ...launchMidnight("@evm-midnight/contracts-midnight", { cwd: path.join(root, "packages/contracts-midnight") }, {
-          env: { MIDNIGHT_STORAGE_PASSWORD: "YourPasswordMy1!" },
-          dependsOn: ["midnight-contract-compile"],
-    }),
+    ...midnightProcesses,
 
     {
       name: "sync",
@@ -43,11 +73,7 @@ export default {
       waitToExit: false,
       type: "system-dependency",
       env: { PGLITE: "true" },
-      dependsOn: [
-        DbNames.PGLITE_WAIT,
-        EvmNames.GENERATE_MOD,
-        ...midnightDeps,
-      ],
+      dependsOn: [DbNames.PGLITE_WAIT, EvmNames.GENERATE_MOD, ...midnightDeps],
     },
 
     {
@@ -83,6 +109,5 @@ export default {
       stopProcessAtPort: [10599],
       dependsOn: ["frontend-build"],
     },
-
   ],
 } satisfies OrchestratorConfig;

--- a/templates/evm-midnight-v2/start.dev.ts
+++ b/templates/evm-midnight-v2/start.dev.ts
@@ -3,6 +3,7 @@ import type { OrchestratorConfig } from "@effectstream/orchestrator/config";
 import { launchPglite, DbNames } from "@effectstream/orchestrator/launch-pglite";
 import { launchEvm, EvmNames } from "@effectstream/orchestrator/launch-evm";
 import { launchMidnight, MidnightNames } from "@effectstream/orchestrator/launch-midnight";
+import { compactSelection } from "./toolchain/compact";
 
 const root = import.meta.dirname!;
 const midnightDeps = [MidnightNames.CONTRACT_DEPLOY];
@@ -14,12 +15,21 @@ export default {
     ),
     ...launchEvm("@evm-midnight/contracts-evm", { cwd: path.join(root, "packages/contracts-evm") }),
     {
+      name: "midnight-compact-preflight",
+      description: `Validate Compact compiler selection ${compactSelection}`,
+      cwd: root,
+      args: ["run", "toolchain/compact.ts", "check"],
+      waitToExit: true,
+      critical: true,
+    },
+    {
       name: "midnight-contract-compile",
-      description: "Compile Compact contract (compact compile +0.33.0-rc.2)",
+      description: `Compile Compact contract (compact compile ${compactSelection})`,
       cwd: path.join(root, "packages/contracts-midnight/contract-round-value"),
       args: ["run", "compact"],
       waitToExit: true,
       critical: true,
+      dependsOn: ["midnight-compact-preflight"],
     },
     ...launchMidnight("@evm-midnight/contracts-midnight", { cwd: path.join(root, "packages/contracts-midnight") }, {
           env: { MIDNIGHT_STORAGE_PASSWORD: "YourPasswordMy1!" },

--- a/templates/evm-midnight-v2/toolchain-consistency.test.ts
+++ b/templates/evm-midnight-v2/toolchain-consistency.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from "bun:test";
+import { existsSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+const templateRoot = import.meta.dir;
+const repositoryRoot = resolve(templateRoot, "../..");
+
+const readTemplate = (path: string) =>
+  readFileSync(join(templateRoot, path), "utf8");
+const readRepository = (path: string) =>
+  readFileSync(join(repositoryRoot, path), "utf8");
+
+function selectedCompactVersion(): string {
+  const declaration = join(templateRoot, "toolchain.json");
+  if (existsSync(declaration)) {
+    return JSON.parse(readFileSync(declaration, "utf8")).compact.version;
+  }
+
+  const contractPackage = JSON.parse(
+    readTemplate("packages/contracts-midnight/contract-round-value/package.json"),
+  );
+  const match = contractPackage.scripts.compact.match(/compact compile \+([^ ]+)/);
+  if (!match) throw new Error("No Compact selection found in the baseline compile script");
+  return match[1];
+}
+
+const compactVersion = selectedCompactVersion();
+
+describe("EVM/Midnight template toolchain selection", () => {
+  test("executable paths consume one template-owned declaration", () => {
+    expect(compactVersion).toMatch(/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/);
+
+    const declaration = JSON.parse(readTemplate("toolchain.json"));
+    expect(declaration.compact.version).toBe(compactVersion);
+    expect(declaration.compact.releaseBaseUrl).toContain(compactVersion);
+    expect(Object.keys(declaration.compact.targets).sort()).toEqual([
+      "aarch64-darwin",
+      "aarch64-unknown-linux-musl",
+      "x86_64-darwin",
+      "x86_64-unknown-linux-musl",
+    ]);
+    for (const target of Object.values(declaration.compact.targets) as Array<{
+      asset: string;
+      sha256: string;
+    }>) {
+      expect(target.asset).toContain(compactVersion);
+      expect(target.sha256).toMatch(/^[0-9a-f]{64}$/);
+    }
+
+    const runner = readTemplate("toolchain/compact.ts");
+    expect(runner).toContain("toolchain.json");
+
+    const contractPackage = readTemplate(
+      "packages/contracts-midnight/contract-round-value/package.json",
+    );
+    expect(contractPackage).toContain("../../../toolchain/compact.ts compile");
+    expect(contractPackage).not.toMatch(/compact compile \+\d/);
+
+    const dockerfile = readTemplate("Dockerfile");
+    expect(dockerfile).toContain("COPY toolchain.json");
+    expect(dockerfile).toContain("toolchain/compact.ts install");
+    expect(dockerfile).not.toContain("0.31.0");
+    expect(dockerfile).not.toContain(compactVersion);
+
+    const start = readTemplate("start.dev.ts");
+    expect(start).toContain('from "./toolchain/compact"');
+    expect(start).toContain("midnight-compact-preflight");
+    expect(start).toContain("compactSelection");
+    expect(start).not.toContain(compactVersion);
+  });
+
+  test("canonical onboarding names Foundry and the selected Compact version before startup", () => {
+    const onboarding = [
+      ["root README", readRepository("README.md")],
+      ["docs intro", readRepository("docs/site/docs/home/0-intro/0-intro.md")],
+      ["docs Quick Start", readRepository("docs/site/docs/home/10-quickstart/10-quickstart.md")],
+      ["template README", readTemplate("README.md")],
+      ["generated template docs", readRepository("docs/site/docs/home/1200-templates/1201-evm-midnight.md")],
+      ["template developer note", readTemplate("CLAUDE.md")],
+    ] as const;
+
+    for (const [label, markdown] of onboarding) {
+      const firstStartup = markdown.indexOf("bun run dev");
+      expect(firstStartup, `${label} must include bun run dev`).toBeGreaterThan(-1);
+      expect(markdown.indexOf("Foundry"), `${label} must name Foundry before startup`)
+        .toBeGreaterThan(-1);
+      expect(markdown.indexOf("Foundry"), `${label} must name Foundry before startup`)
+        .toBeLessThan(firstStartup);
+      expect(markdown.indexOf(compactVersion), `${label} must name the selected Compact version before startup`)
+        .toBeGreaterThan(-1);
+      expect(markdown.indexOf(compactVersion), `${label} must name the selected Compact version before startup`)
+        .toBeLessThan(firstStartup);
+      expect(markdown, `${label} must not advertise the stale Compact selection`)
+        .not.toContain("0.31.0");
+    }
+  });
+});

--- a/templates/evm-midnight-v2/toolchain.json
+++ b/templates/evm-midnight-v2/toolchain.json
@@ -1,0 +1,24 @@
+{
+  "compact": {
+    "version": "0.33.0-rc.2",
+    "releaseBaseUrl": "https://github.com/LFDT-Minokawa/compact/releases/download/compactc-v0.33.0-rc.2",
+    "targets": {
+      "aarch64-darwin": {
+        "asset": "compactc_v0.33.0-rc.2_aarch64-darwin.zip",
+        "sha256": "35a28009c9a57d20902e4fcfd12f0ca9ea94338208954cf8bcd335652e24f382"
+      },
+      "x86_64-darwin": {
+        "asset": "compactc_v0.33.0-rc.2_x86_64-darwin.zip",
+        "sha256": "dce1a57d82ce06208fcc5d9de5343f18c48654a5ff3acf6bafabe3d17bf1ef18"
+      },
+      "aarch64-unknown-linux-musl": {
+        "asset": "compactc_v0.33.0-rc.2_aarch64-unknown-linux-musl.zip",
+        "sha256": "3aa23812b0b086dbce07da3931a40dcb01bec9676b1ceed7f2d0be370ab2dc46"
+      },
+      "x86_64-unknown-linux-musl": {
+        "asset": "compactc_v0.33.0-rc.2_x86_64-unknown-linux-musl.zip",
+        "sha256": "3055ab92bbc8d5bb0d6282b661b83761d2a0de2ee37e21cf7107e25aaf2a9aad"
+      }
+    }
+  }
+}

--- a/templates/evm-midnight-v2/toolchain/compact.test.ts
+++ b/templates/evm-midnight-v2/toolchain/compact.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "bun:test";
+import {
+  compactSelection,
+  compactVersion,
+  resolveCompactTarget,
+  validateCompactSelection,
+  type CompactInvocation,
+  type CompactRunner,
+} from "./compact";
+
+const sequenceRunner = (...results: CompactInvocation[]): {
+  calls: string[][];
+  run: CompactRunner;
+} => {
+  const calls: string[][] = [];
+  return {
+    calls,
+    run: (args) => {
+      calls.push(args);
+      const result = results.shift();
+      if (!result) throw new Error("Unexpected Compact invocation");
+      return result;
+    },
+  };
+};
+
+describe("Compact template preflight", () => {
+  test("reports a missing launcher with exact installation instructions", () => {
+    const fixture = sequenceRunner({
+      status: null,
+      error: Object.assign(new Error("spawn compact ENOENT"), { code: "ENOENT" }),
+    });
+
+    expect(() => validateCompactSelection(fixture.run)).toThrow(
+      `Compact launcher was not found on PATH.`,
+    );
+    expect(() => validateCompactSelection(sequenceRunner({
+      status: null,
+      error: Object.assign(new Error("spawn compact ENOENT"), { code: "ENOENT" }),
+    }).run)).toThrow("bun toolchain/compact.ts install");
+  });
+
+  test("reports an installed launcher whose selected compiler is missing", () => {
+    const fixture = sequenceRunner(
+      { status: 0, stdout: "compact 0.5.1\n" },
+      { status: 1, stderr: "compiler directory does not exist\n" },
+    );
+
+    expect(() => validateCompactSelection(fixture.run)).toThrow(
+      `template selection ${compactVersion} is unavailable`,
+    );
+    expect(fixture.calls).toEqual([
+      ["--version"],
+      ["compile", compactSelection, "--version"],
+    ]);
+  });
+
+  test("accepts only the declared selection and returns its compiler report", () => {
+    const fixture = sequenceRunner(
+      { status: 0, stdout: "compact 0.5.1\n" },
+      { status: 0, stdout: "0.33.0\n" },
+    );
+
+    expect(validateCompactSelection(fixture.run)).toBe("0.33.0");
+    expect(fixture.calls[1]).toEqual([
+      "compile",
+      compactSelection,
+      "--version",
+    ]);
+  });
+
+  test("maps every supported Docker and desktop platform to a pinned asset", () => {
+    expect(resolveCompactTarget("darwin", "arm64")).toBe("aarch64-darwin");
+    expect(resolveCompactTarget("darwin", "x64")).toBe("x86_64-darwin");
+    expect(resolveCompactTarget("linux", "arm64")).toBe("aarch64-unknown-linux-musl");
+    expect(resolveCompactTarget("linux", "x64")).toBe("x86_64-unknown-linux-musl");
+    expect(() => resolveCompactTarget("win32", "x64")).toThrow(
+      `has no pinned asset for win32/x64`,
+    );
+  });
+});

--- a/templates/evm-midnight-v2/toolchain/compact.ts
+++ b/templates/evm-midnight-v2/toolchain/compact.ts
@@ -1,0 +1,244 @@
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+
+type CompactTarget =
+  | "aarch64-darwin"
+  | "x86_64-darwin"
+  | "aarch64-unknown-linux-musl"
+  | "x86_64-unknown-linux-musl";
+
+type CompactToolchain = {
+  compact: {
+    version: string;
+    releaseBaseUrl: string;
+    targets: Record<CompactTarget, {
+      asset: string;
+      sha256: string;
+    }>;
+  };
+};
+
+export type CompactInvocation = {
+  status: number | null;
+  stdout?: string;
+  stderr?: string;
+  error?: NodeJS.ErrnoException;
+};
+
+export type CompactRunner = (args: string[]) => CompactInvocation;
+
+const declarationPath = resolve(import.meta.dir, "../toolchain.json");
+const declaration = JSON.parse(
+  readFileSync(declarationPath, "utf8"),
+) as CompactToolchain;
+
+export const compactVersion = declaration.compact.version;
+export const compactSelection = `+${compactVersion}`;
+
+const installationHint = [
+  "Install the Compact launcher:",
+  "  curl --proto '=https' --tlsv1.2 -LsSf https://github.com/midnightntwrk/compact/releases/latest/download/compact-installer.sh | sh",
+  `Then, from the template root, install selection ${compactVersion}:`,
+  "  bun toolchain/compact.ts install",
+].join("\n");
+
+const defaultRunner: CompactRunner = (args) => {
+  const result = spawnSync("compact", args, {
+    encoding: "utf8",
+    env: process.env,
+  });
+  return {
+    status: result.status,
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+    error: result.error,
+  };
+};
+
+export function validateCompactSelection(
+  run: CompactRunner = defaultRunner,
+): string {
+  const launcher = run(["--version"]);
+  if (launcher.error?.code === "ENOENT") {
+    throw new Error(
+      `Compact launcher was not found on PATH.\n${installationHint}`,
+    );
+  }
+  if (launcher.error || launcher.status !== 0) {
+    const detail = launcher.error?.message || launcher.stderr?.trim() || "unknown error";
+    throw new Error(
+      `Compact launcher could not run (${detail}).\n${installationHint}`,
+    );
+  }
+
+  const compiler = run(["compile", compactSelection, "--version"]);
+  if (compiler.error || compiler.status !== 0) {
+    const detail = compiler.error?.message || compiler.stderr?.trim() || "selection is not installed";
+    throw new Error(
+      `Compact is installed, but template selection ${compactVersion} is unavailable (${detail}).\n` +
+      "Install it from the template root with: bun toolchain/compact.ts install",
+    );
+  }
+
+  const reportedVersion = compiler.stdout?.trim();
+  if (!reportedVersion) {
+    throw new Error(
+      `Compact selection ${compactVersion} ran but did not report a compiler version. ` +
+      "Reinstall it from the template root with: bun toolchain/compact.ts install",
+    );
+  }
+
+  return reportedVersion;
+}
+
+export function resolveCompactTarget(
+  platform: NodeJS.Platform = process.platform,
+  architecture: string = process.arch,
+): CompactTarget {
+  if (platform === "darwin" && architecture === "arm64") return "aarch64-darwin";
+  if (platform === "darwin" && architecture === "x64") return "x86_64-darwin";
+  if (platform === "linux" && architecture === "arm64") return "aarch64-unknown-linux-musl";
+  if (platform === "linux" && architecture === "x64") return "x86_64-unknown-linux-musl";
+  throw new Error(
+    `Compact selection ${compactVersion} has no pinned asset for ${platform}/${architecture}.`,
+  );
+}
+
+export async function installCompactSelection(): Promise<string> {
+  const launcher = defaultRunner(["--version"]);
+  if (launcher.error?.code === "ENOENT") {
+    throw new Error(`Compact launcher was not found on PATH.\n${installationHint}`);
+  }
+  if (launcher.error || launcher.status !== 0) {
+    const detail = launcher.error?.message || launcher.stderr?.trim() || "unknown error";
+    throw new Error(`Compact launcher could not run (${detail}).\n${installationHint}`);
+  }
+
+  const existing = defaultRunner(["compile", compactSelection, "--version"]);
+  if (!existing.error && existing.status === 0 && existing.stdout?.trim()) {
+    return existing.stdout.trim();
+  }
+
+  const target = resolveCompactTarget();
+  const asset = declaration.compact.targets[target];
+  const compactDirectory = process.env.COMPACT_DIRECTORY || join(homedir(), ".compact");
+  const destination = join(
+    compactDirectory,
+    "versions",
+    compactVersion,
+    target,
+  );
+  if (existsSync(destination)) {
+    throw new Error(
+      `Compact selection directory exists but is unusable: ${destination}. ` +
+      "Inspect or remove that exact directory, then rerun the installer.",
+    );
+  }
+
+  const temporaryRoot = mkdtempSync(join(tmpdir(), "evm-midnight-compact-"));
+  const archivePath = join(temporaryRoot, asset.asset);
+  const extractionPath = join(temporaryRoot, "selection");
+  try {
+    const url = `${declaration.compact.releaseBaseUrl}/${asset.asset}`;
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error(`Failed to download ${url}: HTTP ${response.status}`);
+    }
+    const bytes = new Uint8Array(await response.arrayBuffer());
+    const digest = createHash("sha256").update(bytes).digest("hex");
+    if (digest !== asset.sha256) {
+      throw new Error(
+        `Checksum mismatch for ${asset.asset}: expected ${asset.sha256}, received ${digest}`,
+      );
+    }
+    writeFileSync(archivePath, bytes);
+    mkdirSync(extractionPath);
+    const unzip = spawnSync("unzip", ["-q", archivePath, "-d", extractionPath], {
+      encoding: "utf8",
+    });
+    const unzipError = unzip.error as NodeJS.ErrnoException | undefined;
+    if (unzipError?.code === "ENOENT") {
+      throw new Error("The `unzip` executable is required to install the pinned Compact selection.");
+    }
+    if (unzipError || unzip.status !== 0) {
+      throw new Error(
+        `Failed to extract ${asset.asset}: ${unzipError?.message || unzip.stderr?.trim() || "unknown error"}`,
+      );
+    }
+
+    for (const executable of [
+      "compactc",
+      "compactc.bin",
+      "fixup-compact",
+      "format-compact",
+      "zkir",
+      "zkir-v3",
+    ]) {
+      const executablePath = join(extractionPath, executable);
+      if (!existsSync(executablePath)) {
+        throw new Error(`Pinned Compact asset is missing ${executable}.`);
+      }
+      chmodSync(executablePath, 0o755);
+    }
+
+    mkdirSync(dirname(destination), { recursive: true });
+    renameSync(extractionPath, destination);
+  } finally {
+    rmSync(temporaryRoot, { recursive: true, force: true });
+  }
+
+  return validateCompactSelection();
+}
+
+function compile(args: string[]): never {
+  validateCompactSelection();
+  const result = spawnSync(
+    "compact",
+    ["compile", compactSelection, ...args],
+    { stdio: "inherit", env: process.env },
+  );
+  if (result.error) throw result.error;
+  process.exit(result.status ?? 1);
+}
+
+function check(): void {
+  const reportedVersion = validateCompactSelection();
+  console.log(
+    `Compact template selection ${compactVersion} is ready (compiler reports ${reportedVersion}).`,
+  );
+}
+
+if (import.meta.main) {
+  const [command, ...args] = process.argv.slice(2);
+  try {
+    if (command === "check") {
+      check();
+    } else if (command === "install") {
+      const reportedVersion = await installCompactSelection();
+      console.log(
+        `Installed Compact template selection ${compactVersion} (compiler reports ${reportedVersion}).`,
+      );
+    } else if (command === "compile") {
+      compile(args);
+    } else {
+      throw new Error(
+        "Usage: bun toolchain/compact.ts <install|check|compile> [compiler arguments]",
+      );
+    }
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : error);
+    process.exit(1);
+  }
+}


### PR DESCRIPTION
> [!IMPORTANT]
> Draft dependency: this PR depends on draft/unmerged PR #889. Its source
> branch is independently based on `v-next` (it is not stacked on #889).
> After #889 merges, refresh this branch from live `v-next`, resolve any
> overlap, rerun the focused/integrated/full-image/docs/lock gates, and obtain
> a new independent audit before marking this PR ready. Do not merge or mark
> ready before that post-#889 gate.

## What changed

The template currently has a split Compact story: contract compilation selects
`0.33.0-rc.2`, while Docker/onboarding still advertised `0.31.0` or only
checked for a generic `compact` executable.

- Add template-owned `toolchain.json` as the one executable source for Compact
  `0.33.0-rc.2`, with immutable per-platform assets and published SHA-256
  checksums.
- Route contract compilation, Docker installation, process descriptions, and
  exact-selection validation through that declaration. No global orchestrator
  compiler version is introduced.
- Validate the exact selection before the installed shared Midnight launcher
  can emit its stale generic guidance. The runtime preflight gates compile and
  every returned Midnight node/indexer/proof-server/wait/deploy process while
  preserving all launcher dependency edges.
- Update canonical Quick Starts and template documentation to name Foundry and
  Compact `0.33.0-rc.2` before the first `bun run dev`.

## Verification

- Independent delivery re-audit: PASS at clean
  `c5edbf5395998592c83e0f63be0248fe65e3d7df`.
- Repository-focused toolchain/onboarding tests: 6/6, 70 expectations.
- Actual config against installed `@effectstream/orchestrator@0.200.1`: 3/3,
  41 expectations, covering missing launcher, missing selected compiler, and
  the complete successful dependency graph.
- Full arm64 template image: checksummed exact compiler install, Foundry/EVM
  build, and one Compact circuit compiled; an independent in-image
  `bun run build:midnight` also compiled one circuit.
- Owned strict TypeScript, startup bundle, and Prettier gates: PASS.
- Frozen docs install/sync/check: 39/39 package docs and 18/18 template docs.
- `git diff --check`: PASS.
- Root and template `bun.lock` files are unchanged:
  - root: `6baa4985cb82cdbf61975b0917fa2510423f288e8f49fde91ebf9211fda31439`
  - template: `5e8fc681064969316fe7675a09fcdda87c6a209e2b70c213d86c9fe428f25759`

## Base-matched limitations

- Whole-template strict TypeScript remains red on existing published
  dependency/application errors; the D-owned scoped strict gate passes.
- Docusaurus production build fails in `unified` with an empty-preset error
  that reproduces identically at exact base `332503c8`; frozen docs
  sync/consistency checks pass.
- The checkout has pre-existing generated drift for
  `1205-intent-swap.md`; this PR changes only the generated EVM/Midnight page
  `1201-evm-midnight.md` in that section.

## Compatibility and ownership

Non-breaking: this changes template setup/build/start validation and
documentation, with no public API, schema, runtime package identity, or lockfile
change. Startup now fails earlier when the already-required exact compiler
selection is unavailable; that is the intended prerequisite enforcement.

PR D owns only prerequisite/toolchain headings and paragraphs in shared Quick
Start/template docs. PR F owns wallet-mode sections next, and blocked PR E owns
only DUST guide links/sections after both predecessors. Required order:
**D before F before E**.
