### PR TITLE
fix(wallets): use MidnightLocal facade and guard public genesis seed

### DIFF
--- a/docs/site/docs/home/1200-templates/1201-evm-midnight.md
+++ b/docs/site/docs/home/1200-templates/1201-evm-midnight.md
@@ -378,7 +378,7 @@ Each row carries the token, its owner, one property, and the block heights of bo
 
 ### Frontend flow
 
-`packages/frontend/client/src/components/WalletDemo.tsx` drives the demo end to end. Minting calls the ERC-721 directly on the local Hardhat chain with viem; adding a property goes through `packages/frontend/client/src/increment.ts`, which logs in with the high-level `MidnightLocal` full facade, joins the deployed contract with `findDeployedContract`, and invokes the circuit with fixed-width ASCII arguments:
+`packages/frontend/client/src/components/WalletDemo.tsx` drives the demo end to end. Minting calls the ERC-721 directly on the local Hardhat chain with viem; adding a property goes through `packages/frontend/client/src/increment.ts`, which connects through the published public `@effectstream/wallets/midnight-local` full-facade connector, joins the deployed contract with `findDeployedContract`, and invokes the circuit with fixed-width ASCII arguments:
 
 ```ts
 const toEncodedString = (str: string, length = 32) =>
@@ -437,7 +437,7 @@ Most values are set by `start.dev.ts` and need no attention.
 
 Midnight endpoints for the backend come from `@effectstream/midnight-contracts/midnight-env`, which is driven entirely by environment variables. Setting `MIDNIGHT_NETWORK_ID` selects those backend endpoints; individual URLs can be overridden with `MIDNIGHT_INDEXER_HTTP`, `MIDNIGHT_INDEXER_WS`, `MIDNIGHT_NODE_HTTP`, and `MIDNIGHT_PROOF_SERVER_URL`.
 
-The current browser transaction path is deliberately local-only. It calls high-level `walletLogin` in `MidnightLocal` mode with `syncMode: "all"` and the exact indexer HTTP, indexer WebSocket, node, and proof-server URLs derived from the frontend's four `VITE_MIDNIGHT_*` variables. The deterministic undeployed genesis fixture is resolved only after an exact `VITE_MIDNIGHT_NETWORK_ID=undeployed` check.
+The current browser transaction path is deliberately local-only. It calls the published public `MidnightLocalConnector.connectFromSeed` export with `syncMode: "all"` and the exact indexer HTTP, indexer WebSocket, node, and proof-server URLs derived from the frontend's four `VITE_MIDNIGHT_*` variables. The deterministic undeployed genesis fixture is resolved only after an exact `VITE_MIDNIGHT_NETWORK_ID=undeployed` check. This path is provided by the template's pinned `@effectstream/wallets@0.200.1` artifact.
 
 Selecting `preview`, `preprod`, `mainnet`, or any other public network ID stops before seed derivation, endpoint resolution, wallet startup, provider construction, or network access. Public contract submission requires a supported external signer/profile, which this template does not yet provide; this is not a Lace or 1AM compatibility claim.
 

--- a/docs/site/docs/home/1200-templates/1201-evm-midnight.md
+++ b/docs/site/docs/home/1200-templates/1201-evm-midnight.md
@@ -378,7 +378,7 @@ Each row carries the token, its owner, one property, and the block heights of bo
 
 ### Frontend flow
 
-`packages/frontend/client/src/components/WalletDemo.tsx` drives the demo end to end. Minting calls the ERC-721 directly on the local Hardhat chain with viem; adding a property goes through `packages/frontend/client/src/increment.ts`, which builds a Midnight wallet in the browser (`WalletFacade.init`), joins the deployed contract with `findDeployedContract`, and invokes the circuit with fixed-width ASCII arguments:
+`packages/frontend/client/src/components/WalletDemo.tsx` drives the demo end to end. Minting calls the ERC-721 directly on the local Hardhat chain with viem; adding a property goes through `packages/frontend/client/src/increment.ts`, which logs in with the high-level `MidnightLocal` full facade, joins the deployed contract with `findDeployedContract`, and invokes the circuit with fixed-width ASCII arguments:
 
 ```ts
 const toEncodedString = (str: string, length = 32) =>
@@ -433,11 +433,15 @@ Most values are set by `start.dev.ts` and need no attention.
 | `NTP_START_TIME` | No | NTP epoch in ms; otherwise recovered from the database, then `Date.now()` |
 | `EVM_PRIVATE_KEY` | Yes | Signs the batcher's Arbitrum transactions |
 
-### Pointing at another Midnight network
+### Midnight wallet and network boundary
 
-Midnight endpoints come from `@effectstream/midnight-contracts/midnight-env`, which is driven entirely by environment variables. Setting `MIDNIGHT_NETWORK_ID` to anything other than `undeployed` (`testnet`, `preview`, `mainnet`, …) switches the defaults to `https://indexer.<id>.midnight.network` and `https://rpc.<id>.midnight.network`; the proof server stays local unless overridden. Individual URLs can be overridden with `MIDNIGHT_INDEXER_HTTP`, `MIDNIGHT_INDEXER_WS`, `MIDNIGHT_NODE_HTTP` and `MIDNIGHT_PROOF_SERVER_URL`, and the wallet with `MIDNIGHT_WALLET_SEED` or `MIDNIGHT_WALLET_MNEMONIC` (the local genesis seed is only used on `undeployed`).
+Midnight endpoints for the backend come from `@effectstream/midnight-contracts/midnight-env`, which is driven entirely by environment variables. Setting `MIDNIGHT_NETWORK_ID` selects those backend endpoints; individual URLs can be overridden with `MIDNIGHT_INDEXER_HTTP`, `MIDNIGHT_INDEXER_WS`, `MIDNIGHT_NODE_HTTP`, and `MIDNIGHT_PROOF_SERVER_URL`.
 
-The frontend reads its endpoints from `VITE_*` variables in `.env.dev` / `.env.mainnet`:
+The current browser transaction path is deliberately local-only. It calls high-level `walletLogin` in `MidnightLocal` mode with `syncMode: "all"` and the exact indexer HTTP, indexer WebSocket, node, and proof-server URLs derived from the frontend's four `VITE_MIDNIGHT_*` variables. The deterministic undeployed genesis fixture is resolved only after an exact `VITE_MIDNIGHT_NETWORK_ID=undeployed` check.
+
+Selecting `preview`, `preprod`, `mainnet`, or any other public network ID stops before seed derivation, endpoint resolution, wallet startup, provider construction, or network access. Public contract submission requires a supported external signer/profile, which this template does not yet provide; this is not a Lace or 1AM compatibility claim.
+
+The frontend build commands read their endpoints from `.env.dev` / `.env.mainnet`:
 
 ```sh
 bun run --filter @evm-midnight/frontend build:dev       # uses .env.dev

--- a/docs/site/docs/home/500-packages/510-sdk/wallets.md
+++ b/docs/site/docs/home/500-packages/510-sdk/wallets.md
@@ -112,6 +112,53 @@ wallet.result.walletAddress; // addr_test1...
 const signature = await signMessage(wallet.result, "hello effectstream");
 ```
 
+`MidnightLocal` has two high-level modes. With no endpoints it is a
+signing-only wallet: it derives the unshielded identity and performs no network
+I/O.
+
+```typescript
+const signingOnly = await walletLogin({
+  mode: WalletMode.MidnightLocal,
+  seed: "<64-character development seed>",
+  networkId: "undeployed",
+});
+```
+
+Supplying all four `networkUrls` builds the already-supported full Midnight
+facade (shielded, unshielded, and DUST wallets) and exposes both the facade and
+its complete wallet result through the returned provider. Use `syncMode: "all"`
+for contract transactions; `"dust-only"` stops the auxiliary shielded and
+unshielded sync workers after startup and is intended for fee-wallet flows.
+
+```typescript
+import type { MidnightLocalApi } from "@effectstream/wallets/midnight-local";
+
+const connected = await walletLogin({
+  mode: WalletMode.MidnightLocal,
+  seed: "<64-character undeployed development seed>",
+  networkId: "undeployed",
+  networkUrls: {
+    indexer: "http://127.0.0.1:8088/api/v3/graphql",
+    indexerWS: "ws://127.0.0.1:8088/api/v3/graphql/ws",
+    node: "http://127.0.0.1:9944",
+    proofServer: "http://127.0.0.1:6300",
+  },
+  syncMode: "all",
+});
+if (!connected.success) throw new Error(connected.errorMessage);
+
+const localApi = connected.result.provider.getConnection()
+  .api as unknown as MidnightLocalApi;
+if (localApi.walletFacade == null || localApi.walletResult == null) {
+  throw new Error("MidnightLocal full facade was not initialized");
+}
+```
+
+The full-facade example is an undeployed/local development path. It does not
+claim compatibility for any injected wallet. A public Preview, Preprod, or
+Mainnet application must use a supported external signer/profile and must not
+reuse an undeployed genesis seed.
+
 These modes need no browser extension (no `window.ethereum`, no CIP-30) -
 the key material is created client-side and never touches a server. Pair a
 local key with the account-linking delegation (`&linkAddress`) so a real

--- a/packages/effectstream-sdk/wallets/README.md
+++ b/packages/effectstream-sdk/wallets/README.md
@@ -104,6 +104,53 @@ wallet.result.walletAddress; // addr_test1...
 const signature = await signMessage(wallet.result, "hello effectstream");
 ```
 
+`MidnightLocal` has two high-level modes. With no endpoints it is a
+signing-only wallet: it derives the unshielded identity and performs no network
+I/O.
+
+```typescript
+const signingOnly = await walletLogin({
+  mode: WalletMode.MidnightLocal,
+  seed: "<64-character development seed>",
+  networkId: "undeployed",
+});
+```
+
+Supplying all four `networkUrls` builds the already-supported full Midnight
+facade (shielded, unshielded, and DUST wallets) and exposes both the facade and
+its complete wallet result through the returned provider. Use `syncMode: "all"`
+for contract transactions; `"dust-only"` stops the auxiliary shielded and
+unshielded sync workers after startup and is intended for fee-wallet flows.
+
+```typescript
+import type { MidnightLocalApi } from "@effectstream/wallets/midnight-local";
+
+const connected = await walletLogin({
+  mode: WalletMode.MidnightLocal,
+  seed: "<64-character undeployed development seed>",
+  networkId: "undeployed",
+  networkUrls: {
+    indexer: "http://127.0.0.1:8088/api/v3/graphql",
+    indexerWS: "ws://127.0.0.1:8088/api/v3/graphql/ws",
+    node: "http://127.0.0.1:9944",
+    proofServer: "http://127.0.0.1:6300",
+  },
+  syncMode: "all",
+});
+if (!connected.success) throw new Error(connected.errorMessage);
+
+const localApi = connected.result.provider.getConnection()
+  .api as unknown as MidnightLocalApi;
+if (localApi.walletFacade == null || localApi.walletResult == null) {
+  throw new Error("MidnightLocal full facade was not initialized");
+}
+```
+
+The full-facade example is an undeployed/local development path. It does not
+claim compatibility for any injected wallet. A public Preview, Preprod, or
+Mainnet application must use a supported external signer/profile and must not
+reuse an undeployed genesis seed.
+
 These modes need no browser extension (no `window.ethereum`, no CIP-30) -
 the key material is created client-side and never touches a server. Pair a
 local key with the account-linking delegation (`&linkAddress`) so a real

--- a/packages/effectstream-sdk/wallets/src/midnight/wrapper-local.test.ts
+++ b/packages/effectstream-sdk/wallets/src/midnight/wrapper-local.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { AddressType } from "@effectstream/utils/types";
+import type { IProvider } from "../IProvider.ts";
+import type { LoginInfo } from "../wallet-modes.ts";
+import { walletLogin } from "../wallets.ts";
+import { WalletMode } from "../utils.ts";
+import {
+  MidnightLocalConnector,
+  type MidnightLocalApi,
+} from "./local.ts";
+
+const SEED =
+  "0000000000000000000000000000000000000000000000000000000000000001";
+
+const networkUrls = {
+  indexer: "http://127.0.0.1:18088/api/v3/graphql",
+  indexerWS: "ws://127.0.0.1:18088/api/v3/graphql/ws",
+  node: "http://127.0.0.1:19944",
+  proofServer: "http://127.0.0.1:16300",
+};
+
+describe("walletLogin MidnightLocal forwarding", () => {
+  afterEach(() => {
+    mock.restore();
+  });
+
+  function mockConnector() {
+    const walletFacade = { kind: "facade" };
+    const walletResult = { kind: "result", wallet: walletFacade };
+    const api = { walletFacade, walletResult };
+    const provider = {
+      getAddress: () => ({
+        type: AddressType.MIDNIGHT,
+        address: "mn_addr_undeployed1test",
+      }),
+      getConnection: () => ({
+        api,
+        metadata: { name: "midnight-local", displayName: "Midnight local" },
+      }),
+      signMessage: mock(async () => "signature|verifying-key"),
+    } as unknown as IProvider<unknown>;
+    const connectFromSeed = mock(async () => provider);
+    spyOn(MidnightLocalConnector, "instance").mockReturnValue({
+      connectFromSeed,
+    } as unknown as MidnightLocalConnector);
+
+    return { api, connectFromSeed, provider, walletFacade, walletResult };
+  }
+
+  test("keeps the signing-only high-level login compatible when URLs are omitted", async () => {
+    const { connectFromSeed, provider } = mockConnector();
+    const loginInfo = {
+      mode: WalletMode.MidnightLocal,
+      seed: SEED,
+      networkId: "undeployed",
+    } satisfies LoginInfo;
+
+    const result = await walletLogin(loginInfo);
+
+    expect(result.success).toBe(true);
+    expect(connectFromSeed).toHaveBeenCalledWith({
+      seed: SEED,
+      networkId: "undeployed",
+    });
+    if (result.success) {
+      expect(result.result.provider).toBe(provider);
+    }
+  });
+
+  test("forwards full-facade URLs and sync mode through the high-level login", async () => {
+    const { connectFromSeed, provider, walletFacade, walletResult } =
+      mockConnector();
+
+    const loginInfo = {
+      mode: WalletMode.MidnightLocal,
+      seed: SEED,
+      networkId: "undeployed",
+      networkUrls,
+      syncMode: "dust-only",
+    } satisfies LoginInfo;
+    const result = await walletLogin(loginInfo);
+
+    expect(result.success).toBe(true);
+    expect(connectFromSeed).toHaveBeenCalledTimes(1);
+    expect(connectFromSeed).toHaveBeenCalledWith({
+      seed: SEED,
+      networkId: "undeployed",
+      networkUrls,
+      syncMode: "dust-only",
+    });
+    if (result.success) {
+      expect(result.result.provider).toBe(provider);
+      const api = result.result.provider.getConnection()
+        .api as unknown as MidnightLocalApi;
+      expect(api.walletFacade).toBe(walletFacade);
+      expect(api.walletResult).toBe(walletResult);
+    }
+  });
+
+  test.each([
+    [
+      "missing proof server",
+      { ...networkUrls, proofServer: undefined },
+      "networkUrls.proofServer is required",
+    ],
+    [
+      "invalid indexer URL",
+      { ...networkUrls, indexer: "not-a-url" },
+      "networkUrls.indexer must be an absolute URL",
+    ],
+    [
+      "wrong websocket protocol",
+      { ...networkUrls, indexerWS: "https://127.0.0.1:18088/graphql" },
+      "networkUrls.indexerWS must use ws: or wss:",
+    ],
+  ])("rejects %s before invoking the connector", async (_name, urls, message) => {
+    const { connectFromSeed } = mockConnector();
+    const result = await walletLogin({
+      mode: WalletMode.MidnightLocal,
+      seed: SEED,
+      networkId: "undeployed",
+      networkUrls: urls,
+      syncMode: "all",
+    } as LoginInfo);
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.errorMessage).toContain(message);
+    }
+    expect(connectFromSeed).toHaveBeenCalledTimes(0);
+  });
+});

--- a/packages/effectstream-sdk/wallets/src/midnight/wrapper-local.ts
+++ b/packages/effectstream-sdk/wallets/src/midnight/wrapper-local.ts
@@ -2,17 +2,27 @@ import type { Result } from "@effectstream/utils/types";
 import type { IProvider } from "../IProvider.ts";
 import type { WalletMode, ApiForMode } from "../utils.ts";
 import type { LoginInfoMap } from "../wallet-modes.ts";
-import { MidnightLocalConnector } from "./local.ts";
+import {
+  MidnightLocalConnector,
+  type MidnightLocalNetworkUrls,
+} from "./local.ts";
 import { formatError } from "../helpers/format-error.ts";
 
 export async function midnightLocalLoginWrapper(
   loginInfo: LoginInfoMap[WalletMode.MidnightLocal],
 ): Promise<Result<IProvider<ApiForMode<WalletMode.MidnightLocal>>>> {
   try {
+    if (loginInfo.networkUrls != null) {
+      assertValidNetworkUrls(loginInfo.networkUrls);
+    }
     console.log("midnightLocalLoginWrapper: deriving unshielded keystore from seed");
     const provider = await MidnightLocalConnector.instance().connectFromSeed({
       seed: loginInfo.seed,
       networkId: loginInfo.networkId,
+      ...(loginInfo.networkUrls == null
+        ? {}
+        : { networkUrls: loginInfo.networkUrls }),
+      ...(loginInfo.syncMode == null ? {} : { syncMode: loginInfo.syncMode }),
     });
     return {
       success: true,
@@ -26,5 +36,41 @@ export async function midnightLocalLoginWrapper(
       success: false,
       errorMessage: formatError(err),
     };
+  }
+}
+
+function assertValidNetworkUrls(networkUrls: MidnightLocalNetworkUrls): void {
+  const protocols: Record<keyof Omit<MidnightLocalNetworkUrls, "id">, string[]> = {
+    indexer: ["http:", "https:"],
+    indexerWS: ["ws:", "wss:"],
+    node: ["http:", "https:", "ws:", "wss:"],
+    proofServer: ["http:", "https:"],
+  };
+
+  for (const [field, allowedProtocols] of Object.entries(protocols) as Array<
+    [keyof typeof protocols, string[]]
+  >) {
+    const value = networkUrls[field];
+    if (typeof value !== "string" || value.trim() === "") {
+      throw new Error(`MidnightLocal networkUrls.${field} is required.`);
+    }
+
+    let parsed: URL;
+    try {
+      parsed = new URL(value);
+    } catch {
+      throw new Error(
+        `MidnightLocal networkUrls.${field} must be an absolute URL.`,
+      );
+    }
+    if (!allowedProtocols.includes(parsed.protocol)) {
+      throw new Error(
+        `MidnightLocal networkUrls.${field} must use ${allowedProtocols.join(" or ")}.`,
+      );
+    }
+  }
+
+  if (networkUrls.id != null && networkUrls.id.trim() === "") {
+    throw new Error("MidnightLocal networkUrls.id must not be empty.");
   }
 }

--- a/packages/effectstream-sdk/wallets/src/wallet-modes.ts
+++ b/packages/effectstream-sdk/wallets/src/wallet-modes.ts
@@ -22,7 +22,7 @@ import {
 import { AddressType } from "@effectstream/utils/types";
 import { formatError } from "./helpers/format-error.ts";
 import type { MidnightApi } from "./midnight/midnight.ts";
-import type {} from "./midnight/local.ts";
+import type { MidnightLocalConnectArgs } from "./midnight/local.ts";
 import type { SolanaApi } from "./solana/solana.ts";
 import type { Chain } from "viem/chains";
 import { Wallet } from "ethers";
@@ -78,12 +78,7 @@ export type LoginInfoMap = {
   [WalletMode.Midnight]: BaseLoginInfo<MidnightApi> & {
     networkId?: string;
   };
-  [WalletMode.MidnightLocal]: {
-    /** 64-char hex seed. Generated when omitted. */
-    seed?: string;
-    /** Midnight network id ("undeployed" | "testnet" | …) — sets the bech32 prefix. */
-    networkId: string;
-  };
+  [WalletMode.MidnightLocal]: MidnightLocalConnectArgs;
   [WalletMode.Solana]: BaseLoginInfo<SolanaApi>;
 };
 

--- a/templates/evm-midnight-v2/README.md
+++ b/templates/evm-midnight-v2/README.md
@@ -371,7 +371,7 @@ Each row carries the token, its owner, one property, and the block heights of bo
 
 ### Frontend flow
 
-`packages/frontend/client/src/components/WalletDemo.tsx` drives the demo end to end. Minting calls the ERC-721 directly on the local Hardhat chain with viem; adding a property goes through `packages/frontend/client/src/increment.ts`, which logs in with the high-level `MidnightLocal` full facade, joins the deployed contract with `findDeployedContract`, and invokes the circuit with fixed-width ASCII arguments:
+`packages/frontend/client/src/components/WalletDemo.tsx` drives the demo end to end. Minting calls the ERC-721 directly on the local Hardhat chain with viem; adding a property goes through `packages/frontend/client/src/increment.ts`, which connects through the published public `@effectstream/wallets/midnight-local` full-facade connector, joins the deployed contract with `findDeployedContract`, and invokes the circuit with fixed-width ASCII arguments:
 
 ```ts
 const toEncodedString = (str: string, length = 32) =>
@@ -430,7 +430,7 @@ Most values are set by `start.dev.ts` and need no attention.
 
 Midnight endpoints for the backend come from `@effectstream/midnight-contracts/midnight-env`, which is driven entirely by environment variables. Setting `MIDNIGHT_NETWORK_ID` selects those backend endpoints; individual URLs can be overridden with `MIDNIGHT_INDEXER_HTTP`, `MIDNIGHT_INDEXER_WS`, `MIDNIGHT_NODE_HTTP`, and `MIDNIGHT_PROOF_SERVER_URL`.
 
-The current browser transaction path is deliberately local-only. It calls high-level `walletLogin` in `MidnightLocal` mode with `syncMode: "all"` and the exact indexer HTTP, indexer WebSocket, node, and proof-server URLs derived from the frontend's four `VITE_MIDNIGHT_*` variables. The deterministic undeployed genesis fixture is resolved only after an exact `VITE_MIDNIGHT_NETWORK_ID=undeployed` check.
+The current browser transaction path is deliberately local-only. It calls the published public `MidnightLocalConnector.connectFromSeed` export with `syncMode: "all"` and the exact indexer HTTP, indexer WebSocket, node, and proof-server URLs derived from the frontend's four `VITE_MIDNIGHT_*` variables. The deterministic undeployed genesis fixture is resolved only after an exact `VITE_MIDNIGHT_NETWORK_ID=undeployed` check. This path is provided by the template's pinned `@effectstream/wallets@0.200.1` artifact.
 
 Selecting `preview`, `preprod`, `mainnet`, or any other public network ID stops before seed derivation, endpoint resolution, wallet startup, provider construction, or network access. Public contract submission requires a supported external signer/profile, which this template does not yet provide; this is not a Lace or 1AM compatibility claim.
 

--- a/templates/evm-midnight-v2/README.md
+++ b/templates/evm-midnight-v2/README.md
@@ -371,7 +371,7 @@ Each row carries the token, its owner, one property, and the block heights of bo
 
 ### Frontend flow
 
-`packages/frontend/client/src/components/WalletDemo.tsx` drives the demo end to end. Minting calls the ERC-721 directly on the local Hardhat chain with viem; adding a property goes through `packages/frontend/client/src/increment.ts`, which builds a Midnight wallet in the browser (`WalletFacade.init`), joins the deployed contract with `findDeployedContract`, and invokes the circuit with fixed-width ASCII arguments:
+`packages/frontend/client/src/components/WalletDemo.tsx` drives the demo end to end. Minting calls the ERC-721 directly on the local Hardhat chain with viem; adding a property goes through `packages/frontend/client/src/increment.ts`, which logs in with the high-level `MidnightLocal` full facade, joins the deployed contract with `findDeployedContract`, and invokes the circuit with fixed-width ASCII arguments:
 
 ```ts
 const toEncodedString = (str: string, length = 32) =>
@@ -426,11 +426,15 @@ Most values are set by `start.dev.ts` and need no attention.
 | `NTP_START_TIME` | No | NTP epoch in ms; otherwise recovered from the database, then `Date.now()` |
 | `EVM_PRIVATE_KEY` | Yes | Signs the batcher's Arbitrum transactions |
 
-### Pointing at another Midnight network
+### Midnight wallet and network boundary
 
-Midnight endpoints come from `@effectstream/midnight-contracts/midnight-env`, which is driven entirely by environment variables. Setting `MIDNIGHT_NETWORK_ID` to anything other than `undeployed` (`testnet`, `preview`, `mainnet`, …) switches the defaults to `https://indexer.<id>.midnight.network` and `https://rpc.<id>.midnight.network`; the proof server stays local unless overridden. Individual URLs can be overridden with `MIDNIGHT_INDEXER_HTTP`, `MIDNIGHT_INDEXER_WS`, `MIDNIGHT_NODE_HTTP` and `MIDNIGHT_PROOF_SERVER_URL`, and the wallet with `MIDNIGHT_WALLET_SEED` or `MIDNIGHT_WALLET_MNEMONIC` (the local genesis seed is only used on `undeployed`).
+Midnight endpoints for the backend come from `@effectstream/midnight-contracts/midnight-env`, which is driven entirely by environment variables. Setting `MIDNIGHT_NETWORK_ID` selects those backend endpoints; individual URLs can be overridden with `MIDNIGHT_INDEXER_HTTP`, `MIDNIGHT_INDEXER_WS`, `MIDNIGHT_NODE_HTTP`, and `MIDNIGHT_PROOF_SERVER_URL`.
 
-The frontend reads its endpoints from `VITE_*` variables in `.env.dev` / `.env.mainnet`:
+The current browser transaction path is deliberately local-only. It calls high-level `walletLogin` in `MidnightLocal` mode with `syncMode: "all"` and the exact indexer HTTP, indexer WebSocket, node, and proof-server URLs derived from the frontend's four `VITE_MIDNIGHT_*` variables. The deterministic undeployed genesis fixture is resolved only after an exact `VITE_MIDNIGHT_NETWORK_ID=undeployed` check.
+
+Selecting `preview`, `preprod`, `mainnet`, or any other public network ID stops before seed derivation, endpoint resolution, wallet startup, provider construction, or network access. Public contract submission requires a supported external signer/profile, which this template does not yet provide; this is not a Lace or 1AM compatibility claim.
+
+The frontend build commands read their endpoints from `.env.dev` / `.env.mainnet`:
 
 ```sh
 bun run --filter @evm-midnight/frontend build:dev       # uses .env.dev

--- a/templates/evm-midnight-v2/packages/frontend/client/src/config.ts
+++ b/templates/evm-midnight-v2/packages/frontend/client/src/config.ts
@@ -2,21 +2,50 @@ const BASE_URL_API = import.meta.env.VITE_API_URL || "http://127.0.0.1:9999";
 const BASE_URL_BATCHER = import.meta.env.VITE_BATCHER_URL || "http://localhost:3334";
 const BASE_URL_DOCS = "http://127.0.0.1:10600";
 
-// These can be overridden by env vars if needed
-export const BASE_URL_MIDNIGHT_INDEXER = import.meta.env.VITE_MIDNIGHT_INDEXER_HTTP || `http://127.0.0.1:8088`;
-export const BASE_WS_MIDNIGHT_INDEXER = import.meta.env.VITE_MIDNIGHT_INDEXER_WS || `ws://127.0.0.1:8088`;
-export const BASE_URL_MIDNIGHT_NODE = import.meta.env.VITE_MIDNIGHT_NODE_HTTP || `http://127.0.0.1:9944`;
-export const BASE_URL_PROOF_SERVER = import.meta.env.VITE_MIDNIGHT_PROOF_SERVER_URL || `http://127.0.0.1:6300`;
 export const MIDNIGHT_NETWORK_ID = import.meta.env.VITE_MIDNIGHT_NETWORK_ID || "undeployed";
 
-export const getMidnightNodeUrl = async (): Promise<string> => {
-  return BASE_URL_MIDNIGHT_NODE;
+export type MidnightFrontendNetworkUrls = {
+  indexer: string;
+  indexerWS: string;
+  node: string;
+  proofServer: string;
 };
 
-export const BASE_URL_MIDNIGHT_INDEXER_API =
-  `${BASE_URL_MIDNIGHT_INDEXER}/api/v3/graphql`;
-export const BASE_URL_MIDNIGHT_INDEXER_WS =
-  `${BASE_WS_MIDNIGHT_INDEXER}/api/v3/graphql/ws`;
+export function resolveMidnightLocalNetworkUrls(): MidnightFrontendNetworkUrls {
+  // Resolve these lazily. `connectMidnightLocalWallet` calls this only after
+  // rejecting every public network ID, so public selections never read or
+  // construct endpoints for the deterministic local wallet.
+  const indexer = import.meta.env.VITE_MIDNIGHT_INDEXER_HTTP ||
+    "http://127.0.0.1:8088";
+  const indexerWS = import.meta.env.VITE_MIDNIGHT_INDEXER_WS ||
+    "ws://127.0.0.1:8088";
+
+  return {
+    indexer: `${indexer}/api/v3/graphql`,
+    indexerWS: `${indexerWS}/api/v3/graphql/ws`,
+    node: import.meta.env.VITE_MIDNIGHT_NODE_HTTP || "http://127.0.0.1:9944",
+    proofServer: import.meta.env.VITE_MIDNIGHT_PROOF_SERVER_URL ||
+      "http://127.0.0.1:6300",
+  };
+}
+
+const UNDEPLOYED_GENESIS_MINT_WALLET_SEED =
+  "0000000000000000000000000000000000000000000000000000000000000001";
+
+export function assertMidnightLocalUndeployed(
+  networkId: string,
+): asserts networkId is "undeployed" {
+  if (networkId !== "undeployed") {
+    throw new Error(
+      `MidnightLocal supports only the undeployed local network. Selected "${networkId}" requires a supported external signer/profile; no public-network signer is configured.`,
+    );
+  }
+}
+
+export function resolveUndeployedGenesisSeed(networkId: string): string {
+  assertMidnightLocalUndeployed(networkId);
+  return UNDEPLOYED_GENESIS_MINT_WALLET_SEED;
+}
 
 export const CONFIG_ENDPOINT = `${BASE_URL_API}/config`;
 export const PRIMITIVES_ENDPOINT = `${BASE_URL_API}/primitives`;

--- a/templates/evm-midnight-v2/packages/frontend/client/src/increment.ts
+++ b/templates/evm-midnight-v2/packages/frontend/client/src/increment.ts
@@ -30,18 +30,8 @@ import {
 import * as Rx from "rxjs";
 import { levelPrivateStateProvider } from "@midnight-ntwrk/midnight-js-level-private-state-provider";
 import { assertIsContractAddress } from "@midnight-ntwrk/midnight-js-utils";
+import { MIDNIGHT_NETWORK_ID } from "./config.ts";
 import {
-  setNetworkId,
-} from "@midnight-ntwrk/midnight-js-network-id";
-import {
-  BASE_URL_MIDNIGHT_INDEXER_API,
-  BASE_URL_MIDNIGHT_INDEXER_WS,
-  BASE_URL_PROOF_SERVER,
-  MIDNIGHT_NETWORK_ID,
-  getMidnightNodeUrl,
-} from "./config.ts";
-import {
-  LedgerParameters,
   ZswapSecretKeys,
   DustSecretKey,
   shieldedToken,
@@ -49,24 +39,10 @@ import {
   type EncPublicKey,
   type FinalizedTransaction,
 } from "@midnightntwrk/ledger-v9";
-
-// Modular SDK imports
-import { HDWallet, Roles } from "@midnightntwrk/wallet-sdk-hd";
-import { type DefaultConfiguration, WalletFacade } from "@midnightntwrk/wallet-sdk-facade";
-import { ShieldedWallet } from "@midnightntwrk/wallet-sdk-shielded";
-import { DustWallet } from "@midnightntwrk/wallet-sdk-dust-wallet";
-import {
-  UnshieldedWallet,
-  createKeystore,
-  PublicKey,
-  type UnshieldedKeystore,
-} from "@midnightntwrk/wallet-sdk-unshielded-wallet";
-import {
-  InMemoryTransactionHistoryStorage,
-  NetworkId,
-  TransactionHistoryStorage,
-} from "@midnightntwrk/wallet-sdk-abstractions";
-import { Buffer } from "buffer";
+import type { WalletFacade } from "@midnightntwrk/wallet-sdk-facade";
+import type { UnshieldedKeystore } from "@midnightntwrk/wallet-sdk-unshielded-wallet";
+import type { WalletResult } from "@effectstream/midnight-contracts/types";
+import { connectMidnightLocalWallet } from "./midnight-wallet.ts";
 
 // ============================================================================
 // Constants
@@ -74,12 +50,6 @@ import { Buffer } from "buffer";
 
 /** Transaction TTL duration in milliseconds (1 hour) */
 const TTL_DURATION_MS = 60 * 60 * 1000;
-
-/** Additional fee overhead for dust transactions (in smallest unit) */
-const DUST_FEE_OVERHEAD = 300_000_000_000_000n;
-
-/** Fee blocks margin for dust wallet */
-const DUST_FEE_BLOCKS_MARGIN = 5;
 
 // Throttle on the wallet state observable, applied before the isSynced filter.
 // Keep short in-browser — large values delay connect even on already-synced chains.
@@ -110,131 +80,14 @@ type DeployedCounterContract =
   | FoundContract<CounterContract>;
 
 interface Config {
-  readonly logDir: string;
   readonly indexer: string;
   readonly indexerWS: string;
   readonly node: string;
   readonly proofServer: string;
 }
 
-class StandaloneConfig implements Config {
-  logDir = `standalone-${new Date().toISOString()}.log`;
-  indexer = BASE_URL_MIDNIGHT_INDEXER_API;
-  indexerWS = BASE_URL_MIDNIGHT_INDEXER_WS;
-  node: string;
-  proofServer = BASE_URL_PROOF_SERVER;
-  constructor(nodeUrl: string) {
-    this.node = nodeUrl;
-    setNetworkId(MIDNIGHT_NETWORK_ID as any);
-  }
-}
-
-/**
- * This seed gives access to tokens minted in the genesis block of a local development node - only
- * used in standalone networks to build a wallet with initial funds.
- */
-const GENESIS_MINT_WALLET_SEED =
-  "0000000000000000000000000000000000000000000000000000000000000001";
-
-// ============================================================================
-// Wallet Logic (Adapted from get-wallet-info.ts)
-// ============================================================================
-
-export interface NetworkUrls {
-  indexer: string;
-  indexerWS: string;
-  node: string;
-  proofServer: string;
-}
-
-export interface WalletResult {
-  wallet: WalletFacade;
-  zswapSecretKeys: ZswapSecretKeys;
-  walletZswapSecretKeys: ZswapSecretKeys;
-  dustSecretKey: DustSecretKey;
-  walletDustSecretKey: DustSecretKey;
-  dustAddress: string;
-  unshieldedAddress: string;
-  unshieldedKeystore: UnshieldedKeystore;
-}
-
 function createTtl(): Date {
   return new Date(Date.now() + TTL_DURATION_MS);
-}
-
-export function createWalletConfiguration(
-  networkUrls: Required<NetworkUrls>,
-  networkId: NetworkId.NetworkId,
-): DefaultConfiguration {
-  return {
-    indexerClientConnection: {
-      indexerHttpUrl: networkUrls.indexer,
-      indexerWsUrl: networkUrls.indexerWS,
-    },
-    provingServerUrl: new URL(networkUrls.proofServer),
-    relayURL: new URL(networkUrls.node.replace("http", "ws")),
-    networkId: networkId,
-    costParameters: {
-      feeBlocksMargin: DUST_FEE_BLOCKS_MARGIN,
-    },
-    txHistoryStorage: new InMemoryTransactionHistoryStorage(
-      TransactionHistoryStorage.TransactionHistoryCommonSchema,
-    ),
-  };
-}
-
-export async function buildWalletFacade(
-  networkUrls: Required<NetworkUrls>,
-  seed: string,
-  networkId: NetworkId.NetworkId,
-): Promise<WalletResult> {
-  const seedBuffer = Buffer.from(seed, "hex");
-  const hdResult = HDWallet.fromSeed(seedBuffer);
-  if (hdResult.type !== "seedOk") {
-    throw new Error(`Failed to create HD wallet: ${hdResult.type}`);
-  }
-  const derivation = hdResult.hdWallet
-    .selectAccount(0)
-    .selectRoles([Roles.Zswap, Roles.NightExternal, Roles.Dust])
-    .deriveKeysAt(0);
-  if (derivation.type !== "keysDerived") {
-    throw new Error(`Key derivation failed: ${derivation.type}`);
-  }
-  hdResult.hdWallet.clear();
-
-  const shieldedSeed = Buffer.from(derivation.keys[Roles.Zswap]);
-  const dustSeed = Buffer.from(derivation.keys[Roles.Dust]);
-  const unshieldedSeed = Buffer.from(derivation.keys[Roles.NightExternal]);
-
-  const zswapSecretKeys = ZswapSecretKeys.fromSeed(shieldedSeed);
-  const dustSecretKey = DustSecretKey.fromSeed(dustSeed);
-  const unshieldedKeystore = createKeystore(unshieldedSeed, networkId);
-  const unshieldedAddress = unshieldedKeystore.getBech32Address().asString();
-
-  const config = createWalletConfiguration(networkUrls, networkId);
-  const dustParameters = LedgerParameters.initialParameters().dust;
-
-  const wallet = await WalletFacade.init({
-    configuration: config,
-    shielded: (cfg) => ShieldedWallet(cfg).startWithSecretKeys(zswapSecretKeys),
-    unshielded: (cfg) =>
-      UnshieldedWallet(cfg).startWithPublicKey(PublicKey.fromKeyStore(unshieldedKeystore)),
-    dust: (cfg) =>
-      DustWallet(cfg).startWithSecretKey(dustSecretKey, dustParameters),
-  });
-
-  await wallet.start(zswapSecretKeys, dustSecretKey);
-
-  return {
-    wallet,
-    zswapSecretKeys,
-    walletZswapSecretKeys: zswapSecretKeys,
-    dustSecretKey,
-    walletDustSecretKey: dustSecretKey,
-    dustAddress: "",
-    unshieldedAddress,
-    unshieldedKeystore,
-  };
 }
 
 export async function waitForDustFunds(
@@ -686,7 +539,6 @@ const getContractAddress = async (): Promise<string> => {
 
 // Separate functions for Web App use
 // Global variables updated to hold new types
-let globalWallet: WalletFacade | null = null;
 let globalProviders: CounterProviders | null = null;
 let globalCounterContract: DeployedCounterContract | null = null;
 
@@ -694,62 +546,12 @@ const connectMidnightWallet = async (): Promise<{
   wallet: WalletFacade;
   providers: CounterProviders;
 }> => {
-  // Reuse cached wallet — first build is slow (WASM init + chain scan).
-  if (globalWallet && globalProviders) {
-    console.log("♻️  Reusing already-built Midnight wallet");
-    return { wallet: globalWallet, providers: globalProviders };
-  }
-
-  console.log("🔗 Building Midnight wallet with genesis seed...");
-
-  const midnightNodeUrl = await getMidnightNodeUrl();
-  const config = new StandaloneConfig(midnightNodeUrl);
-  
-  // New Modular Wallet Construction
-  const networkUrls = {
-      indexer: config.indexer,
-      indexerWS: config.indexerWS,
-      node: config.node,
-      proofServer: config.proofServer
-  };
-  
-  // Use MIDNIGHT_NETWORK_ID from config/env
-  const networkId = MIDNIGHT_NETWORK_ID as NetworkId.NetworkId;
-  
-  console.log(`Using network ID: ${networkId}`);
-  
-  const walletResult = await buildWalletFacade(networkUrls, GENESIS_MINT_WALLET_SEED, networkId);
-  console.log("✅ Wallet built successfully");
-
-  // Sync and wait for funds
-  const { shieldedBalance, unshieldedBalance, dustBalance } = await syncAndWaitForFunds(walletResult);
-  console.log(`✅ Wallet synced. Shielded: ${shieldedBalance}, Dust: ${dustBalance}, Unshielded: ${unshieldedBalance}`);
-
-  const providers = await configureProviders(walletResult, config);
-  console.log("✅ Providers configured successfully");
-
-  // We attach the `state` observable mapping for UI compatibility
-  const walletFacade = walletResult.wallet;
-  
-  // Helper to map state for UI
-  const originalState = walletFacade.state;
-  // @ts-ignore - Monkey patching for compatibility
-  walletFacade.state = () => originalState.call(walletFacade).pipe(
-    Rx.map((s: any) => {
-      // Map shielded address to top level address property for UI
-      const address = s.shielded?.address?.coinPublicKeyString?.() || "";
-      return {
-        ...s,
-        address
-      };
-    })
-  );
-
-  // Store globally for later use
-  globalWallet = walletFacade as any;
-  globalProviders = providers;
-
-  return { wallet: walletFacade as any, providers };
+  const connected = await connectMidnightLocalWallet({
+    sync: syncAndWaitForFunds,
+    configure: configureProviders,
+  });
+  globalProviders = connected.providers;
+  return connected;
 };
 
 const connectToContract = async (

--- a/templates/evm-midnight-v2/packages/frontend/client/src/midnight-wallet-guard.test.ts
+++ b/templates/evm-midnight-v2/packages/frontend/client/src/midnight-wallet-guard.test.ts
@@ -1,6 +1,8 @@
-import { describe, expect, mock, test } from "bun:test";
-import { WalletMode } from "@effectstream/wallets";
-import type { MidnightLocalApi } from "@effectstream/wallets/midnight-local";
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
+import {
+  MidnightLocalConnector,
+  type MidnightLocalApi,
+} from "@effectstream/wallets/midnight-local";
 import type { WalletResult } from "@effectstream/midnight-contracts/types";
 import type { WalletFacade } from "@midnightntwrk/wallet-sdk-facade";
 import { connectMidnightLocalWallet } from "./midnight-wallet.ts";
@@ -21,7 +23,11 @@ const injectedNetworkUrls = {
 };
 
 describe("MidnightLocal template selection", () => {
-  test("undeployed uses the real lazy default resolver and logs in once through the high-level full facade", async () => {
+  afterEach(() => {
+    mock.restore();
+  });
+
+  test("undeployed uses the real lazy default resolver and connects once through the published low-level full facade", async () => {
     const walletFacade = {
       state: mock(() => ({ pipe: mock(() => ({})) })),
     } as unknown as WalletFacade;
@@ -46,14 +52,7 @@ describe("MidnightLocal template selection", () => {
       }),
     };
     const resolveSeed = mock(() => SEED);
-    const login = mock(async () => ({
-      success: true as const,
-      result: {
-        provider,
-        walletAddress: "mn_addr_undeployed1test",
-        metadata: { name: "midnight-local", displayName: "Midnight local" },
-      },
-    }));
+    const connect = mock(async () => provider);
     const sync = mock(async () => ({
       shieldedBalance: 1n,
       unshieldedBalance: 2n,
@@ -65,15 +64,14 @@ describe("MidnightLocal template selection", () => {
     const connected = await connectMidnightLocalWallet({
       networkId: "undeployed",
       resolveSeed,
-      login: login as never,
+      connect: connect as never,
       sync: sync as never,
       configure: configure as never,
     });
 
     expect(resolveSeed).toHaveBeenCalledTimes(1);
-    expect(login).toHaveBeenCalledTimes(1);
-    expect(login).toHaveBeenCalledWith({
-      mode: WalletMode.MidnightLocal,
+    expect(connect).toHaveBeenCalledTimes(1);
+    expect(connect).toHaveBeenCalledWith({
       seed: SEED,
       networkId: "undeployed",
       networkUrls: defaultNetworkUrls,
@@ -86,12 +84,18 @@ describe("MidnightLocal template selection", () => {
   });
 
   test.each(["preview", "preprod", "mainnet"])(
-    "%s fails on injected and production-default paths before cached-wallet, seed, endpoint, login, provider, or network seams",
+    "%s fails on injected and production-default paths before cached-wallet, seed, endpoint, connector, provider, or network seams",
     async (networkId) => {
+      const connectorInstance = spyOn(
+        MidnightLocalConnector,
+        "instance",
+      ).mockImplementation(() => {
+        throw new Error("must not resolve the connector singleton");
+      });
       const resolveSeed = mock(() => SEED);
       const resolveNetworkUrls = mock(() => injectedNetworkUrls);
-      const login = mock(async () => {
-        throw new Error("must not log in");
+      const connect = mock(async () => {
+        throw new Error("must not connect");
       });
       const sync = mock(async () => {
         throw new Error("must not sync");
@@ -105,7 +109,7 @@ describe("MidnightLocal template selection", () => {
           networkId,
           resolveSeed,
           resolveNetworkUrls,
-          login: login as never,
+          connect: connect as never,
           sync: sync as never,
           configure: configure as never,
         }),
@@ -119,7 +123,6 @@ describe("MidnightLocal template selection", () => {
         connectMidnightLocalWallet({
           networkId,
           resolveSeed,
-          login: login as never,
           sync: sync as never,
           configure: configure as never,
         }),
@@ -129,7 +132,8 @@ describe("MidnightLocal template selection", () => {
 
       expect(resolveSeed).toHaveBeenCalledTimes(0);
       expect(resolveNetworkUrls).toHaveBeenCalledTimes(0);
-      expect(login).toHaveBeenCalledTimes(0);
+      expect(connect).toHaveBeenCalledTimes(0);
+      expect(connectorInstance).toHaveBeenCalledTimes(0);
       expect(sync).toHaveBeenCalledTimes(0);
       expect(configure).toHaveBeenCalledTimes(0);
     },

--- a/templates/evm-midnight-v2/packages/frontend/client/src/midnight-wallet-guard.test.ts
+++ b/templates/evm-midnight-v2/packages/frontend/client/src/midnight-wallet-guard.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, mock, test } from "bun:test";
+import { WalletMode } from "@effectstream/wallets";
+import type { MidnightLocalApi } from "@effectstream/wallets/midnight-local";
+import type { WalletResult } from "@effectstream/midnight-contracts/types";
+import type { WalletFacade } from "@midnightntwrk/wallet-sdk-facade";
+import { connectMidnightLocalWallet } from "./midnight-wallet.ts";
+
+const SEED =
+  "0000000000000000000000000000000000000000000000000000000000000001";
+const defaultNetworkUrls = {
+  indexer: "http://127.0.0.1:8088/api/v3/graphql",
+  indexerWS: "ws://127.0.0.1:8088/api/v3/graphql/ws",
+  node: "http://127.0.0.1:9944",
+  proofServer: "http://127.0.0.1:6300",
+};
+const injectedNetworkUrls = {
+  indexer: "http://127.0.0.1:18088/api/v3/graphql",
+  indexerWS: "ws://127.0.0.1:18088/api/v3/graphql/ws",
+  node: "http://127.0.0.1:19944",
+  proofServer: "http://127.0.0.1:16300",
+};
+
+describe("MidnightLocal template selection", () => {
+  test("undeployed uses the real lazy default resolver and logs in once through the high-level full facade", async () => {
+    const walletFacade = {
+      state: mock(() => ({ pipe: mock(() => ({})) })),
+    } as unknown as WalletFacade;
+    const walletResult = {
+      wallet: walletFacade,
+      zswapSecretKeys: {},
+      walletZswapSecretKeys: {},
+      dustSecretKey: {},
+      walletDustSecretKey: {},
+      dustAddress: "dust_undeployed1test",
+      unshieldedAddress: "mn_addr_undeployed1test",
+      unshieldedKeystore: {},
+    } as unknown as WalletResult;
+    const api: Pick<MidnightLocalApi, "walletFacade" | "walletResult"> = {
+      walletFacade,
+      walletResult,
+    };
+    const provider = {
+      getConnection: () => ({
+        api,
+        metadata: { name: "midnight-local", displayName: "Midnight local" },
+      }),
+    };
+    const resolveSeed = mock(() => SEED);
+    const login = mock(async () => ({
+      success: true as const,
+      result: {
+        provider,
+        walletAddress: "mn_addr_undeployed1test",
+        metadata: { name: "midnight-local", displayName: "Midnight local" },
+      },
+    }));
+    const sync = mock(async () => ({
+      shieldedBalance: 1n,
+      unshieldedBalance: 2n,
+      dustBalance: 3n,
+    }));
+    const providers = { kind: "counter-providers" };
+    const configure = mock(async () => providers);
+
+    const connected = await connectMidnightLocalWallet({
+      networkId: "undeployed",
+      resolveSeed,
+      login: login as never,
+      sync: sync as never,
+      configure: configure as never,
+    });
+
+    expect(resolveSeed).toHaveBeenCalledTimes(1);
+    expect(login).toHaveBeenCalledTimes(1);
+    expect(login).toHaveBeenCalledWith({
+      mode: WalletMode.MidnightLocal,
+      seed: SEED,
+      networkId: "undeployed",
+      networkUrls: defaultNetworkUrls,
+      syncMode: "all",
+    });
+    expect(sync).toHaveBeenCalledWith(walletResult);
+    expect(configure).toHaveBeenCalledWith(walletResult, defaultNetworkUrls);
+    expect(connected.wallet).toBe(walletFacade);
+    expect(connected.providers).toBe(providers);
+  });
+
+  test.each(["preview", "preprod", "mainnet"])(
+    "%s fails on injected and production-default paths before cached-wallet, seed, endpoint, login, provider, or network seams",
+    async (networkId) => {
+      const resolveSeed = mock(() => SEED);
+      const resolveNetworkUrls = mock(() => injectedNetworkUrls);
+      const login = mock(async () => {
+        throw new Error("must not log in");
+      });
+      const sync = mock(async () => {
+        throw new Error("must not sync");
+      });
+      const configure = mock(async () => {
+        throw new Error("must not construct providers");
+      });
+
+      await expect(
+        connectMidnightLocalWallet({
+          networkId,
+          resolveSeed,
+          resolveNetworkUrls,
+          login: login as never,
+          sync: sync as never,
+          configure: configure as never,
+        }),
+      ).rejects.toThrow(
+        `Selected "${networkId}" requires a supported external signer/profile`,
+      );
+
+      // Exercise the production dependency path too. Omitting the injected URL
+      // resolver must still reject before the real lazy default can be used.
+      await expect(
+        connectMidnightLocalWallet({
+          networkId,
+          resolveSeed,
+          login: login as never,
+          sync: sync as never,
+          configure: configure as never,
+        }),
+      ).rejects.toThrow(
+        `Selected "${networkId}" requires a supported external signer/profile`,
+      );
+
+      expect(resolveSeed).toHaveBeenCalledTimes(0);
+      expect(resolveNetworkUrls).toHaveBeenCalledTimes(0);
+      expect(login).toHaveBeenCalledTimes(0);
+      expect(sync).toHaveBeenCalledTimes(0);
+      expect(configure).toHaveBeenCalledTimes(0);
+    },
+  );
+});

--- a/templates/evm-midnight-v2/packages/frontend/client/src/midnight-wallet.ts
+++ b/templates/evm-midnight-v2/packages/frontend/client/src/midnight-wallet.ts
@@ -1,0 +1,106 @@
+import { WalletMode, walletLogin } from "@effectstream/wallets";
+import type {
+  MidnightLocalApi,
+  MidnightLocalNetworkUrls,
+} from "@effectstream/wallets/midnight-local";
+import type { WalletResult } from "@effectstream/midnight-contracts/types";
+import type { WalletFacade } from "@midnightntwrk/wallet-sdk-facade";
+import { map } from "rxjs";
+import {
+  assertMidnightLocalUndeployed,
+  MIDNIGHT_NETWORK_ID,
+  resolveUndeployedGenesisSeed,
+  resolveMidnightLocalNetworkUrls,
+} from "./config.ts";
+
+export type WalletBalances = {
+  shieldedBalance: bigint;
+  unshieldedBalance: bigint;
+  dustBalance: bigint;
+};
+
+export type ConnectMidnightWalletDependencies<Providers> = {
+  networkId?: string;
+  resolveSeed?: (networkId: string) => string;
+  resolveNetworkUrls?: () => MidnightLocalNetworkUrls;
+  login?: typeof walletLogin;
+  sync: (walletResult: WalletResult) => Promise<WalletBalances>;
+  configure: (
+    walletResult: WalletResult,
+    networkUrls: MidnightLocalNetworkUrls,
+  ) => Promise<Providers>;
+};
+
+let cachedConnection:
+  | { wallet: WalletFacade; providers: unknown }
+  | undefined;
+
+export async function connectMidnightLocalWallet<Providers>(
+  dependencies: ConnectMidnightWalletDependencies<Providers>,
+): Promise<{ wallet: WalletFacade; providers: Providers }> {
+  const networkId = dependencies.networkId ?? MIDNIGHT_NETWORK_ID;
+
+  // This is deliberately the first connect operation. Public network IDs must
+  // fail even if an undeployed wallet is already cached, and before endpoint
+  // resolution, genesis-seed access, wallet/provider startup, or network I/O.
+  assertMidnightLocalUndeployed(networkId);
+
+  if (cachedConnection != null) {
+    console.log("♻️  Reusing already-built Midnight wallet");
+    return cachedConnection as { wallet: WalletFacade; providers: Providers };
+  }
+
+  console.log("🔗 Building the undeployed MidnightLocal full facade...");
+  const seed = (dependencies.resolveSeed ?? resolveUndeployedGenesisSeed)(
+    networkId,
+  );
+  const networkUrls = (dependencies.resolveNetworkUrls ??
+    resolveMidnightLocalNetworkUrls)();
+  const login = dependencies.login ?? walletLogin;
+  const connected = await login({
+    mode: WalletMode.MidnightLocal,
+    seed,
+    networkId,
+    networkUrls,
+    syncMode: "all",
+  });
+  if (!connected.success) {
+    throw new Error(`MidnightLocal login failed: ${connected.errorMessage}`);
+  }
+
+  const localApi = connected.result.provider.getConnection()
+    .api as unknown as MidnightLocalApi;
+  if (localApi.walletFacade == null || localApi.walletResult == null) {
+    throw new Error(
+      "MidnightLocal login did not return the required full wallet facade/result.",
+    );
+  }
+
+  const walletResult = localApi.walletResult as WalletResult;
+  const walletFacade = localApi.walletFacade as WalletFacade;
+  if (walletResult.wallet !== walletFacade) {
+    throw new Error("MidnightLocal facade/result identity mismatch.");
+  }
+  console.log("✅ Wallet built successfully");
+
+  const { shieldedBalance, unshieldedBalance, dustBalance } =
+    await dependencies.sync(walletResult);
+  console.log(
+    `✅ Wallet synced. Shielded: ${shieldedBalance}, Dust: ${dustBalance}, Unshielded: ${unshieldedBalance}`,
+  );
+
+  const providers = await dependencies.configure(walletResult, networkUrls);
+  console.log("✅ Providers configured successfully");
+
+  const originalState = walletFacade.state;
+  // @ts-ignore - Preserve the template UI's top-level address compatibility.
+  walletFacade.state = () => originalState.call(walletFacade).pipe(
+    map((state: any) => ({
+      ...state,
+      address: state.shielded?.address?.coinPublicKeyString?.() || "",
+    })),
+  );
+
+  cachedConnection = { wallet: walletFacade, providers };
+  return { wallet: walletFacade, providers };
+}

--- a/templates/evm-midnight-v2/packages/frontend/client/src/midnight-wallet.ts
+++ b/templates/evm-midnight-v2/packages/frontend/client/src/midnight-wallet.ts
@@ -1,7 +1,9 @@
-import { WalletMode, walletLogin } from "@effectstream/wallets";
-import type {
-  MidnightLocalApi,
-  MidnightLocalNetworkUrls,
+import {
+  MidnightLocalConnector,
+  type MidnightLocalConnectArgs,
+  type MidnightLocalApi,
+  type MidnightLocalNetworkUrls,
+  type MidnightLocalProvider,
 } from "@effectstream/wallets/midnight-local";
 import type { WalletResult } from "@effectstream/midnight-contracts/types";
 import type { WalletFacade } from "@midnightntwrk/wallet-sdk-facade";
@@ -23,7 +25,9 @@ export type ConnectMidnightWalletDependencies<Providers> = {
   networkId?: string;
   resolveSeed?: (networkId: string) => string;
   resolveNetworkUrls?: () => MidnightLocalNetworkUrls;
-  login?: typeof walletLogin;
+  connect?: (
+    args: MidnightLocalConnectArgs,
+  ) => Promise<MidnightLocalProvider>;
   sync: (walletResult: WalletResult) => Promise<WalletBalances>;
   configure: (
     walletResult: WalletResult,
@@ -56,23 +60,19 @@ export async function connectMidnightLocalWallet<Providers>(
   );
   const networkUrls = (dependencies.resolveNetworkUrls ??
     resolveMidnightLocalNetworkUrls)();
-  const login = dependencies.login ?? walletLogin;
-  const connected = await login({
-    mode: WalletMode.MidnightLocal,
+  const connect = dependencies.connect ?? ((args: MidnightLocalConnectArgs) =>
+    MidnightLocalConnector.instance().connectFromSeed(args));
+  const provider = await connect({
     seed,
     networkId,
     networkUrls,
     syncMode: "all",
   });
-  if (!connected.success) {
-    throw new Error(`MidnightLocal login failed: ${connected.errorMessage}`);
-  }
 
-  const localApi = connected.result.provider.getConnection()
-    .api as unknown as MidnightLocalApi;
+  const localApi = provider.getConnection().api as unknown as MidnightLocalApi;
   if (localApi.walletFacade == null || localApi.walletResult == null) {
     throw new Error(
-      "MidnightLocal login did not return the required full wallet facade/result.",
+      "MidnightLocal connector did not return the required full wallet facade/result.",
     );
   }
 

--- a/templates/evm-midnight-v2/packages/tests/stm/midnight-property.test.ts
+++ b/templates/evm-midnight-v2/packages/tests/stm/midnight-property.test.ts
@@ -47,8 +47,8 @@ export async function midnightPropertyTest(db: Client) {
       // `api.walletFacade`; the raw `WalletResult` (secret keys, keystore,
       // addresses) ends up at `api.walletResult` for advanced flows like the
       // manual balance/sign/finalize loop below.
-      const { MidnightLocalConnector } = await import(
-        "@effectstream/wallets/midnight-local"
+      const { WalletMode, walletLogin } = await import(
+        "@effectstream/wallets"
       );
       const { syncAndWaitForFunds } = await import(
         "@effectstream/midnight-contracts"
@@ -75,13 +75,20 @@ export async function midnightPropertyTest(db: Client) {
 
       setNetworkId(MIDNIGHT_NETWORK_ID as any);
 
-      console.log("  Building wallet via MidnightLocalConnector...");
-      const provider = await MidnightLocalConnector.instance().connectFromSeed({
+      console.log("  Building wallet via high-level MidnightLocal login...");
+      const connected = await walletLogin({
+        mode: WalletMode.MidnightLocal,
         seed: GENESIS_SEED,
         networkId: MIDNIGHT_NETWORK_ID,
         networkUrls,
+        syncMode: "all",
       });
-      const api = provider.getConnection().api as any;
+      if (!connected.success) {
+        throw new Error(
+          `High-level MidnightLocal login failed: ${connected.errorMessage}`,
+        );
+      }
+      const api = connected.result.provider.getConnection().api as any;
       const walletResult = api.walletResult as Awaited<
         ReturnType<
           typeof import("@effectstream/midnight-contracts")["buildWalletFacade"]
@@ -89,7 +96,12 @@ export async function midnightPropertyTest(db: Client) {
       >;
       if (walletResult == null) {
         throw new Error(
-          "MidnightLocalConnector did not return walletResult — facade mode wiring is broken.",
+          "High-level MidnightLocal login did not return walletResult — facade mode wiring is broken.",
+        );
+      }
+      if (api.walletFacade !== walletResult.wallet) {
+        throw new Error(
+          "High-level MidnightLocal provider returned mismatched facade/result identities.",
         );
       }
       console.log("  Wallet built. Syncing funds...");

--- a/templates/evm-midnight-v2/packages/tests/stm/midnight-property.test.ts
+++ b/templates/evm-midnight-v2/packages/tests/stm/midnight-property.test.ts
@@ -38,17 +38,18 @@ export async function midnightPropertyTest(db: Client) {
   );
 
   await assert(
-    "Midnight property: build wallet via @effectstream/wallets MidnightLocal (facade mode) and sync funds",
+    "Midnight property: build wallet via published MidnightLocal connector (facade mode) and sync funds",
     async () => {
-      // Build the wallet through the unified @effectstream/wallets entry point.
+      // Build through the public low-level export already shipped by the
+      // template's pinned @effectstream/wallets version.
       // Supplying `networkUrls` switches MidnightLocal from signing-only to the
       // full WalletFacade (shielded + dust + unshielded sub-wallets connected
       // to the live indexer + node + proof server). The facade ends up at
       // `api.walletFacade`; the raw `WalletResult` (secret keys, keystore,
       // addresses) ends up at `api.walletResult` for advanced flows like the
       // manual balance/sign/finalize loop below.
-      const { WalletMode, walletLogin } = await import(
-        "@effectstream/wallets"
+      const { MidnightLocalConnector } = await import(
+        "@effectstream/wallets/midnight-local"
       );
       const { syncAndWaitForFunds } = await import(
         "@effectstream/midnight-contracts"
@@ -75,20 +76,14 @@ export async function midnightPropertyTest(db: Client) {
 
       setNetworkId(MIDNIGHT_NETWORK_ID as any);
 
-      console.log("  Building wallet via high-level MidnightLocal login...");
-      const connected = await walletLogin({
-        mode: WalletMode.MidnightLocal,
+      console.log("  Building wallet via published MidnightLocal connector...");
+      const provider = await MidnightLocalConnector.instance().connectFromSeed({
         seed: GENESIS_SEED,
         networkId: MIDNIGHT_NETWORK_ID,
         networkUrls,
         syncMode: "all",
       });
-      if (!connected.success) {
-        throw new Error(
-          `High-level MidnightLocal login failed: ${connected.errorMessage}`,
-        );
-      }
-      const api = connected.result.provider.getConnection().api as any;
+      const api = provider.getConnection().api as any;
       const walletResult = api.walletResult as Awaited<
         ReturnType<
           typeof import("@effectstream/midnight-contracts")["buildWalletFacade"]
@@ -96,12 +91,12 @@ export async function midnightPropertyTest(db: Client) {
       >;
       if (walletResult == null) {
         throw new Error(
-          "High-level MidnightLocal login did not return walletResult — facade mode wiring is broken.",
+          "Published MidnightLocal connector did not return walletResult — facade mode wiring is broken.",
         );
       }
       if (api.walletFacade !== walletResult.wallet) {
         throw new Error(
-          "High-level MidnightLocal provider returned mismatched facade/result identities.",
+          "Published MidnightLocal provider returned mismatched facade/result identities.",
         );
       }
       console.log("  Wallet built. Syncing funds...");


### PR DESCRIPTION
## Summary

- extend high-level `walletLogin({ mode: WalletMode.MidnightLocal, ... })` with the existing typed optional `networkUrls` and `syncMode` inputs, forwarding supplied values unchanged while preserving signing-only calls that omit them
- consolidate the EVM/Midnight template on one undeployed full-facade connector and preserve the existing facade/result/provider identities consumed by sync and contract submission
- fail every public Midnight network ID before cache reuse, endpoint construction, deterministic undeployed seed resolution, connector/provider startup, sync, configuration, fetch, or network selection

The high-level SDK change is additive and intended for future/published consumers. The standalone template intentionally calls the already-released public `@effectstream/wallets/midnight-local` low-level connector because its frozen lock pins npm `@effectstream/wallets@0.200.1`, whose high-level wrapper predates this additive forwarding. This keeps the template functional before the new SDK API is published and avoids manifest/lock churn.

## Draft dependency and follow-up gate

This PR is intentionally **DRAFT** and depends on #891. It is not stacked on that branch.

After #891 merges, this branch must be refreshed against current `v-next`, its shared template/docs changes reconciled, the docs checks and complete Docker gate rerun, and the resulting new clean SHA independently audited before this PR can be marked ready. Do not merge or enable auto-merge before that gate.

Public Preview/Preprod/Mainnet contract submission still needs the supported injected/external signer and coherent application profiles planned for PR G/future work. This PR deliberately supports contract transactions only on `undeployed` and fails public IDs safely instead of deriving the local genesis identity.

## Behavior and compatibility

- undeployed passes the exact existing indexer HTTP/WebSocket, node, and proof-server URLs with `syncMode: "all"` and receives the full shielded/dust/unshielded facade
- Preview, Preprod, Mainnet, and every other non-`undeployed` ID stop before the local seed or any wallet/network seam
- generic `Wallet` output remains unchanged; signing-only `MidnightLocal` callers remain supported
- no Lace or 1AM compatibility claim is introduced

**Breaking-change assessment:** non-breaking. The SDK fields are optional and signing-only omission is preserved. Rejecting public IDs in this local deterministic-wallet path is an intentional fail-safe for a previously unsupported/unsafe configuration, not removal of a supported public signer flow.

## Verification

Independently audited **PASS** at exact clean SHA `879979325ebf5fda2397af87e11ca2678bf94de5`.

- clean template-only amd64 `bun install --frozen-lockfile`: PASS, 3,349 packages; no `link.sh`, monorepo workspace package, or overlay
- frontend and tests resolved byte-identical npm `@effectstream/wallets@0.200.1` peer-context artifacts with the exact template-lock integrity
- public guard through the published low-level connector: 4 passed, 0 failed, 31 assertions; all public-ID seed/URL/connector/sync/configure seams stayed at zero
- existing local Phase-D proof through the published connector: 4/4 passed for facade/result identity and fixture funds, the existing increment transaction, property DB sync, and API property
- retained high-level SDK wallet suite: 9 passed, 0 failed, 40 assertions; strict no-emit actual-import type gate passed
- current template connector/config source-exact strict no-emit gate passed
- native arm64 direct full Vite build: PASS, 8,978 modules and all five static-copy items; this is supplemental to the lifecycle-enabled amd64 frozen install/runtime proof
- root and template lock hashes unchanged; no package manifest change; exact owned Docker/container/temp teardown passed

The broad amd64 template runner completed the generated prerequisites and all Phase-D assertions, then its unchanged Phase-E spawn wrapper hit an esbuild write/close failure; direct amd64 esbuild also crashed under arm64 Docker Desktop platform emulation. Those attempts receive no browser pass credit. The fresh native arm64 direct full Vite build above supplies the browser closure without emulation.

All runtime integration used the existing deterministic undeployed fixture, loopback application endpoints, Docker's default bridge with zero host-published ports, and exact owned teardown. No public-chain call, new/funded wallet, NIGHT registration, or retained deployment/wallet state was created.

## Out of scope

- PR G's public-network profile and supported external-signer work
- NIGHT-to-DUST documentation/registration work
- the independently discovered Q5 credential-logging sinks; testing used only the previously audited one-statement disposable-container suppression and commits no logging change or secret
- manifest/lock cleanup and dependencies made unused by template consolidation
