### PR TITLE
ci: route releases by Midnight compatibility line

### DIFF
--- a/.github/ci-changes.test.ts
+++ b/.github/ci-changes.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "bun:test";
-import { classify, diffArgs } from "./ci-changes.ts";
+import {
+  classify,
+  baseIsUnusable,
+  diffArgs,
+  parseLongLivedBranches,
+} from "./ci-changes.ts";
 
 // A fixed enabled set so these assertions don't shift as templates are
 // enabled/disabled in run-template-tests.ts.
@@ -77,7 +82,13 @@ describe("classify — templates", () => {
 });
 
 describe("diffArgs — diff range selection", () => {
-  const opts = { base: "B", head: "H", headRef: "feat/x", defaultBranch: "v-next" };
+  const opts = {
+    base: "B",
+    head: "H",
+    headRef: "feat/x",
+    defaultBranch: "v-next",
+    longLivedBranches: ["v-next", "midnight-1"],
+  };
 
   test("pull_request uses three-dot base...head (only what the PR adds)", () => {
     expect(diffArgs({ ...opts, eventName: "pull_request" })).toEqual([
@@ -87,9 +98,25 @@ describe("diffArgs — diff range selection", () => {
     ]);
   });
 
+  test("pull_request merge ref still uses explicit base...head SHAs", () => {
+    expect(
+      diffArgs({
+        ...opts,
+        eventName: "pull_request",
+        headRef: "123/merge",
+      }),
+    ).toEqual(["diff", "--name-only", "B...H"]);
+  });
+
   test("push to the default branch uses two-arg before..after", () => {
     expect(
       diffArgs({ ...opts, eventName: "push", headRef: "v-next" }),
+    ).toEqual(["diff", "--name-only", "B", "H"]);
+  });
+
+  test("push to the maintenance branch uses only before..after", () => {
+    expect(
+      diffArgs({ ...opts, eventName: "push", headRef: "midnight-1" }),
     ).toEqual(["diff", "--name-only", "B", "H"]);
   });
 
@@ -101,6 +128,39 @@ describe("diffArgs — diff range selection", () => {
       "--name-only",
       "FETCH_HEAD...H",
     ]);
+  });
+});
+
+describe("initial and rewritten push bases", () => {
+  test.each([
+    [undefined, true],
+    ["", true],
+    ["0000000000000000000000000000000000000000", true],
+    ["000000", true],
+    ["0123456789012345678901234567890123456789", false],
+  ])("base %p unusable=%p", (base, expected) => {
+    expect(baseIsUnusable(base)).toBe(expected);
+  });
+});
+
+describe("mainline allowlist", () => {
+  test("accepts the exact approved long-lived branches", () => {
+    expect(parseLongLivedBranches("v-next,midnight-1")).toEqual([
+      "v-next",
+      "midnight-1",
+    ]);
+  });
+
+  test.each([
+    undefined,
+    "",
+    "v-next",
+    "v-next,midnight-1,feature/x",
+    "v-next,v-next",
+    "v-next,midnight-1,",
+    "v-next,midnight 1",
+  ])("rejects missing or malformed allowlist %p", (value) => {
+    expect(parseLongLivedBranches(value)).toBeNull();
   });
 });
 

--- a/.github/ci-changes.ts
+++ b/.github/ci-changes.ts
@@ -21,7 +21,10 @@
  *       here: on a "merge default into branch" push `before` is an ancestor of
  *       the merge commit, so before..after still contains everything the merge
  *       pulled in.
- *   - push to the default branch → two-arg before..after (BASE_SHA/HEAD_SHA).
+ *   - push to an allowlisted long-lived branch → two-arg before..after
+ *       (BASE_SHA/HEAD_SHA). Both v-next and midnight-1 are mainlines; comparing
+ *       the divergent maintenance line against v-next would select its entire
+ *       history on every push.
  * If the base is unusable (new branch, force-push) on a path that needs it, or
  * any git call fails, we fall back to running everything — over-run rather than
  * miss a real change.
@@ -85,9 +88,28 @@ export function classify(
 }
 
 const ZERO_SHA = "0000000000000000000000000000000000000000";
+export const REQUIRED_LONG_LIVED_BRANCHES = ["v-next", "midnight-1"] as const;
+
+/**
+ * Parse the workflow-owned mainline allowlist. Fail closed unless it names the
+ * exact two approved branches once each; event data cannot add another branch.
+ */
+export function parseLongLivedBranches(raw: string | undefined): string[] | null {
+  if (!raw) return null;
+  const branches = raw.split(",").map((branch) => branch.trim());
+  if (
+    branches.some((branch) => !branch || !/^[A-Za-z0-9._/-]+$/.test(branch)) ||
+    new Set(branches).size !== branches.length ||
+    branches.length !== REQUIRED_LONG_LIVED_BRANCHES.length ||
+    REQUIRED_LONG_LIVED_BRANCHES.some((branch) => !branches.includes(branch))
+  ) {
+    return null;
+  }
+  return branches;
+}
 
 /** True when we can't trust the base SHA and should just run everything. */
-function baseIsUnusable(base: string | undefined): boolean {
+export function baseIsUnusable(base: string | undefined): boolean {
   return !base || base === ZERO_SHA || /^0+$/.test(base);
 }
 
@@ -110,12 +132,13 @@ export function diffArgs(opts: {
   head: string;
   headRef: string;
   defaultBranch: string;
+  longLivedBranches: readonly string[];
 }): string[] {
-  const { eventName, base, head, headRef, defaultBranch } = opts;
+  const { eventName, base, head, headRef, longLivedBranches } = opts;
   if (eventName === "pull_request") {
     return ["diff", "--name-only", `${base}...${head}`];
   }
-  if (headRef === defaultBranch) {
+  if (longLivedBranches.includes(headRef)) {
     return ["diff", "--name-only", base, head];
   }
   return ["diff", "--name-only", `FETCH_HEAD...${head}`];
@@ -128,10 +151,11 @@ function changedFiles(
   head: string,
   headRef: string,
   defaultBranch: string,
+  longLivedBranches: readonly string[],
 ): string[] | null {
   // Feature-branch push: fetch the default branch so the three-dot diff has a
   // FETCH_HEAD to resolve its merge-base against.
-  if (eventName !== "pull_request" && headRef !== defaultBranch) {
+  if (eventName !== "pull_request" && !longLivedBranches.includes(headRef)) {
     const fetched = Bun.spawnSync(
       ["git", "fetch", "--no-tags", "origin", defaultBranch],
       { stdout: "pipe", stderr: "pipe" },
@@ -144,7 +168,14 @@ function changedFiles(
     }
   }
 
-  const args = diffArgs({ eventName, base, head, headRef, defaultBranch });
+  const args = diffArgs({
+    eventName,
+    base,
+    head,
+    headRef,
+    defaultBranch,
+    longLivedBranches,
+  });
   const proc = Bun.spawnSync(["git", ...args], { stdout: "pipe", stderr: "pipe" });
   if (proc.exitCode !== 0) {
     console.error(
@@ -161,22 +192,38 @@ if (import.meta.main) {
   const head = process.env.HEAD_SHA ?? "HEAD";
   const headRef = process.env.HEAD_REF ?? "";
   const defaultBranch = process.env.DEFAULT_BRANCH ?? "";
+  const longLivedBranches = parseLongLivedBranches(
+    process.env.LONG_LIVED_BRANCHES,
+  );
 
   // A feature-branch push diffs against the default branch's merge-base, so it
   // never reads `before` and the unusable-base fallback doesn't apply to it.
   const featureBranchPush =
-    eventName !== "pull_request" && !!defaultBranch && headRef !== defaultBranch;
+    eventName !== "pull_request" &&
+    !!defaultBranch &&
+    longLivedBranches !== null &&
+    !longLivedBranches.includes(headRef);
 
   let result: ChangeClassification;
   let files: string[] | null = null;
 
-  if (!featureBranchPush && baseIsUnusable(base)) {
+  if (longLivedBranches === null) {
+    console.log("Missing or malformed LONG_LIVED_BRANCHES — running everything.");
+    result = { core: true, templates: [...ENABLED].sort() };
+  } else if (!featureBranchPush && baseIsUnusable(base)) {
     console.log(
       `No usable base SHA (BASE_SHA=${JSON.stringify(base)}) — running everything.`,
     );
     result = { core: true, templates: [...ENABLED].sort() };
   } else {
-    files = changedFiles(eventName, base ?? "", head, headRef, defaultBranch);
+    files = changedFiles(
+      eventName,
+      base ?? "",
+      head,
+      headRef,
+      defaultBranch,
+      longLivedBranches,
+    );
     if (files === null) {
       console.log("git diff failed — running everything to be safe.");
       result = { core: true, templates: [...ENABLED].sort() };

--- a/.github/publish-bun.effectstream.registry.test.ts
+++ b/.github/publish-bun.effectstream.registry.test.ts
@@ -1,0 +1,271 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { createHash } from "crypto";
+import { cpSync, mkdtempSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import {
+  canonicalJson,
+  publishFromBundle,
+  readAndVerifyBundle,
+  readRegistryState,
+  type ReleaseManifest,
+} from "./publish-bun.effectstream";
+
+const port = Number(process.env.EFFECTSTREAM_TEST_REGISTRY_PORT ?? "15432");
+const registry = `http://127.0.0.1:${port}`;
+const root = mkdtempSync(join(tmpdir(), "effectstream-registry-test-"));
+const bundle = join(root, "bundle");
+const crossRunDir = process.env.EFFECTSTREAM_CROSS_RUN_DIR;
+const crossRunPhase = process.env.EFFECTSTREAM_CROSS_RUN_PHASE;
+const occupied = new Map<string, string>();
+const distTags = new Map<string, Record<string, string>>();
+const unqueryable = new Set<string>();
+let publishAttempts = 0;
+let failPublishAttempt = 0;
+let server: ReturnType<typeof Bun.serve>;
+let manifest: ReleaseManifest;
+
+function digest(bytes: Uint8Array) {
+  const value = createHash("sha512").update(bytes).digest();
+  return { hex: value.toString("hex"), integrity: `sha512-${value.toString("base64")}` };
+}
+
+beforeAll(() => {
+  mkdirSync(join(bundle, "tarballs"), { recursive: true });
+  const packages = Array.from({ length: 39 }, (_, index) => {
+    const name = `@effectstream/fake-${String(index).padStart(2, "0")}`;
+    const filename = `fake-${index}.tgz`;
+    const packageDir = join(root, `package-${index}`);
+    mkdirSync(packageDir, { recursive: true });
+    writeFileSync(
+      join(packageDir, "package.json"),
+      `${JSON.stringify({ name, version: "0.104.2", files: ["index.js", "README.md"] }, null, 2)}\n`,
+    );
+    writeFileSync(join(packageDir, "index.js"), `export const exact = ${index};\n`);
+    writeFileSync(join(packageDir, "README.md"), `# ${name}\n\nExact persisted tarball fixture.\n`);
+    const packed = Bun.spawnSync([
+      "bun",
+      "pm",
+      "pack",
+      "--filename",
+      join(bundle, "tarballs", filename),
+      "--quiet",
+    ], { cwd: packageDir });
+    if (packed.exitCode !== 0) throw new Error(packed.stderr.toString());
+    const bytes = readFileSync(join(bundle, "tarballs", filename));
+    const sum = digest(bytes);
+    distTags.set(name, { latest: "0.200.2" });
+    return {
+      name,
+      relativeDir: `packages/fake-${index}`,
+      filename,
+      size: statSync(join(bundle, "tarballs", filename)).size,
+      sha512: sum.hex,
+      integrity: sum.integrity,
+      versionBefore: "0.104.1",
+    };
+  });
+  manifest = {
+    schemaVersion: 1,
+    releaseTag: "v0.104.2",
+    version: "0.104.2",
+    sourceSha: "a".repeat(40),
+    branch: "midnight-1",
+    distTag: "midnight-1",
+    prerelease: false,
+    kind: "maintenance-stable",
+    workflow: { runId: "producer-1", runAttempt: "1" },
+    toolchain: { bun: "1.4.0", platform: "linux-x64" },
+    latestBefore: Object.fromEntries(packages.map((pkg) => [pkg.name, "0.200.2"])),
+    packages,
+  };
+  writeFileSync(join(bundle, "manifest.json"), canonicalJson(manifest));
+  server = Bun.serve({
+    port,
+    async fetch(request) {
+      const url = new URL(request.url);
+      const distTagMatch = /^\/-\/package\/(.+)\/dist-tags\/([^/]+)$/.exec(url.pathname);
+      if (request.method === "PUT" && distTagMatch) {
+        const name = decodeURIComponent(distTagMatch[1]);
+        const tag = decodeURIComponent(distTagMatch[2]);
+        const version = await request.json() as string;
+        distTags.set(name, { ...(distTags.get(name) ?? {}), [tag]: version });
+        return Response.json({ ok: true });
+      }
+      if (request.method === "PUT") {
+        publishAttempts++;
+        if (failPublishAttempt && publishAttempts === failPublishAttempt) {
+          return Response.json({ error: "injected first-publish failure" }, { status: 500 });
+        }
+        const document = await request.json() as any;
+        const name = document.name ?? document._id;
+        const version = Object.keys(document.versions ?? {})[0];
+        const integrity = document.versions?.[version]?.dist?.integrity;
+        if (!name || !version || !integrity) return Response.json({ error: "invalid publish" }, { status: 400 });
+        if (occupied.has(name)) return Response.json({ error: "conflict" }, { status: 409 });
+        occupied.set(name, integrity);
+        distTags.set(name, { ...(distTags.get(name) ?? {}), ...(document["dist-tags"] ?? {}) });
+        return Response.json({ ok: true }, { status: 201 });
+      }
+      const name = decodeURIComponent(url.pathname.slice(1));
+      if (unqueryable.has(name)) return Response.json({ error: "unavailable" }, { status: 503 });
+      const integrity = occupied.get(name);
+      return Response.json({
+        "dist-tags": distTags.get(name) ?? { latest: "0.200.2" },
+        versions: integrity ? { "0.104.2": { dist: { integrity } } } : {},
+      });
+    },
+  });
+});
+
+afterAll(() => {
+  server?.stop(true);
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe("persisted bundle verification and lost-runner recovery", () => {
+  test("verifies every exact byte and plans all-absent ordinary publication", async () => {
+    expect(readAndVerifyBundle(bundle).packages).toHaveLength(39);
+    const result = await publishFromBundle({
+      artifactDir: bundle,
+      registry,
+      recovery: false,
+      publish: false,
+    });
+    expect(result.published).toHaveLength(39);
+    expect(result.skipped).toEqual([]);
+  });
+
+  test("an independent recovery process skips exact non-prefix occupancy", async () => {
+    occupied.clear();
+    for (const index of [1, 8, 25]) {
+      const pkg = manifest.packages[index];
+      occupied.set(pkg.name, pkg.integrity);
+    }
+    const result = await publishFromBundle({
+      artifactDir: bundle,
+      registry,
+      recovery: true,
+      publish: false,
+    });
+    expect(result.skipped).toEqual([1, 8, 25].map((index) => manifest.packages[index].name));
+    expect(result.published).toHaveLength(36);
+  });
+
+  test("publishes exact tarballs, stops on first failure, then completes from a downloaded copy", async () => {
+    if (crossRunPhase === "consumer") {
+      if (!crossRunDir) throw new Error("consumer requires EFFECTSTREAM_CROSS_RUN_DIR");
+      const persisted = JSON.parse(readFileSync(join(crossRunDir, "registry-state.json"), "utf8")) as {
+        occupied: [string, string][];
+        distTags: [string, Record<string, string>][];
+      };
+      occupied.clear();
+      distTags.clear();
+      for (const entry of persisted.occupied) occupied.set(...entry);
+      for (const entry of persisted.distTags) distTags.set(...entry);
+      const downloaded = join(root, "runner-b-downloaded-artifact");
+      cpSync(join(crossRunDir, "artifact"), downloaded, { recursive: true });
+      manifest = readAndVerifyBundle(downloaded);
+      process.env.NPM_TOKEN = "fake-test-token";
+      process.env.BUN_AUTH_TOKEN = "fake-test-token";
+      process.env.NPM_CONFIG_TOKEN = "fake-test-token";
+      const npmrc = join(import.meta.dir, "..", ".npmrc");
+      writeFileSync(npmrc, `//127.0.0.1:${port}/:_authToken=fake-test-token\n`);
+      const result = await publishFromBundle({ artifactDir: downloaded, registry, recovery: true, publish: true });
+      expect(result.skipped).toHaveLength(5);
+      expect(result.published).toHaveLength(34);
+      expect(occupied.size).toBe(39);
+      delete process.env.NPM_TOKEN;
+      delete process.env.BUN_AUTH_TOKEN;
+      delete process.env.NPM_CONFIG_TOKEN;
+      rmSync(npmrc, { force: true });
+      return;
+    }
+
+    occupied.clear();
+    for (const name of manifest.packages.map((pkg) => pkg.name)) distTags.set(name, { latest: "0.200.2" });
+    publishAttempts = 0;
+    failPublishAttempt = 6;
+    process.env.NPM_TOKEN = "fake-test-token";
+    process.env.BUN_AUTH_TOKEN = "fake-test-token";
+    process.env.NPM_CONFIG_TOKEN = "fake-test-token";
+    const npmrc = join(import.meta.dir, "..", ".npmrc");
+    writeFileSync(npmrc, `//127.0.0.1:${port}/:_authToken=fake-test-token\n`);
+    await expect(
+      publishFromBundle({ artifactDir: bundle, registry, recovery: false, publish: true }),
+    ).rejects.toThrow(/stopping/);
+    expect(occupied.size).toBe(5);
+
+    if (crossRunPhase === "producer") {
+      if (!crossRunDir) throw new Error("producer requires EFFECTSTREAM_CROSS_RUN_DIR");
+      rmSync(join(crossRunDir, "artifact"), { recursive: true, force: true });
+      rmSync(join(crossRunDir, "registry-state.json"), { force: true });
+      cpSync(bundle, join(crossRunDir, "artifact"), { recursive: true });
+      writeFileSync(
+        join(crossRunDir, "registry-state.json"),
+        canonicalJson({ occupied: [...occupied], distTags: [...distTags] }),
+      );
+      delete process.env.NPM_TOKEN;
+      delete process.env.BUN_AUTH_TOKEN;
+      delete process.env.NPM_CONFIG_TOKEN;
+      rmSync(npmrc, { force: true });
+      return;
+    }
+
+    const downloaded = join(root, "independent-downloaded-bundle");
+    cpSync(bundle, downloaded, { recursive: true });
+    failPublishAttempt = 0;
+    const result = await publishFromBundle({
+      artifactDir: downloaded,
+      registry,
+      recovery: true,
+      publish: true,
+    });
+    expect(result.skipped).toHaveLength(5);
+    expect(result.published).toHaveLength(34);
+    expect(occupied.size).toBe(39);
+    for (const pkg of manifest.packages) {
+      expect(occupied.get(pkg.name)).toBe(pkg.integrity);
+      expect(distTags.get(pkg.name)).toEqual({ latest: "0.200.2", "midnight-1": "0.104.2" });
+    }
+    const completeRetry = await publishFromBundle({
+      artifactDir: downloaded,
+      registry,
+      recovery: true,
+      publish: false,
+    });
+    expect(completeRetry.published).toEqual([]);
+    expect(completeRetry.skipped).toHaveLength(39);
+    delete process.env.NPM_TOKEN;
+    delete process.env.BUN_AUTH_TOKEN;
+    delete process.env.NPM_CONFIG_TOKEN;
+    rmSync(npmrc, { force: true });
+  });
+
+  test("registry integrity mismatch fails closed", async () => {
+    occupied.clear();
+    occupied.set(manifest.packages[4].name, "sha512-different");
+    await expect(
+      publishFromBundle({ artifactDir: bundle, registry, recovery: true, publish: false }),
+    ).rejects.toThrow(/integrity differs/);
+  });
+
+  test("an unqueryable package fails closed", async () => {
+    const name = manifest.packages[7].name;
+    unqueryable.add(name);
+    await expect(readRegistryState(registry, name, manifest.version)).rejects.toThrow(/HTTP 503/);
+    unqueryable.delete(name);
+  });
+
+  test("tampered, missing, and unrelated artifact files fail closed", () => {
+    occupied.clear();
+    const target = join(bundle, "tarballs", manifest.packages[0].filename);
+    const original = readFileSync(target);
+    writeFileSync(target, "tampered");
+    expect(() => readAndVerifyBundle(bundle)).toThrow(/size mismatch|digest mismatch/);
+    writeFileSync(target, original);
+    writeFileSync(join(bundle, "tarballs", "unrelated.txt"), "not allowed");
+    expect(() => readAndVerifyBundle(bundle)).toThrow(/unrelated/);
+    rmSync(join(bundle, "tarballs", "unrelated.txt"));
+  });
+});

--- a/.github/publish-bun.effectstream.registry.test.ts
+++ b/.github/publish-bun.effectstream.registry.test.ts
@@ -22,6 +22,7 @@ const distTags = new Map<string, Record<string, string>>();
 const unqueryable = new Set<string>();
 let publishAttempts = 0;
 let failPublishAttempt = 0;
+let registryRequests = 0;
 let server: ReturnType<typeof Bun.serve>;
 let manifest: ReleaseManifest;
 
@@ -83,6 +84,7 @@ beforeAll(() => {
   server = Bun.serve({
     port,
     async fetch(request) {
+      registryRequests++;
       const url = new URL(request.url);
       const distTagMatch = /^\/-\/package\/(.+)\/dist-tags\/([^/]+)$/.exec(url.pathname);
       if (request.method === "PUT" && distTagMatch) {
@@ -152,9 +154,57 @@ describe("persisted bundle verification and lost-runner recovery", () => {
     expect(result.published).toHaveLength(36);
   });
 
+  test("version drift fails before the first registry or dist-tag request", async () => {
+    const originalManifest = canonicalJson(manifest);
+    const repositoryRoot = join(import.meta.dir, "..");
+    const actualPackages = [...new Bun.Glob("packages/**/package.json").scanSync({ cwd: repositoryRoot })]
+      .map((path) => ({ path, value: JSON.parse(readFileSync(join(repositoryRoot, path), "utf8")) as { name?: string; private?: boolean } }))
+      .filter(({ value }) => value.name && !value.private && value.name !== "@effectstream/explorer")
+      .sort((left, right) => left.value.name!.localeCompare(right.value.name!));
+    expect(actualPackages).toHaveLength(39);
+    const head = Bun.spawnSync(["git", "rev-parse", "HEAD"], { cwd: repositoryRoot }).stdout.toString().trim();
+    const packages = manifest.packages.map((pkg, index) => ({
+      ...pkg,
+      name: actualPackages[index].value.name!,
+      relativeDir: actualPackages[index].path.replace(/\/package\.json$/, ""),
+    }));
+    const driftManifest: ReleaseManifest = {
+      ...manifest,
+      sourceSha: head,
+      packages,
+      latestBefore: Object.fromEntries(packages.map((pkg) => [pkg.name, "0.200.2"])),
+    };
+    writeFileSync(join(bundle, "manifest.json"), canonicalJson(driftManifest));
+    const manifestSha512 = digest(readFileSync(join(bundle, "manifest.json"))).hex;
+    const requestsBefore = registryRequests;
+    try {
+      const proc = Bun.spawn([
+        "bun", "run", ".github/publish-bun.effectstream.ts",
+        "--recover-bundle", "--publish",
+        "--artifact-dir", bundle,
+        "--manifest-sha512", manifestSha512,
+        "--expected-current-branch-sha", head,
+        "--recovery-mode", "partial-tag",
+        "--audit-ref", "audit:test",
+        "--authorization-ref", "G4:test",
+        "--registry", registry,
+      ], { cwd: repositoryRoot, stdout: "pipe", stderr: "pipe" });
+      expect(await proc.exited).not.toBe(0);
+      expect(await new Response(proc.stderr).text()).toContain("Version drift in recovery branch");
+      expect(registryRequests).toBe(requestsBefore);
+    } finally {
+      writeFileSync(join(bundle, "manifest.json"), originalManifest);
+    }
+  });
+
   test("publishes exact tarballs, stops on first failure, then completes from a downloaded copy", async () => {
     if (crossRunPhase === "consumer") {
       if (!crossRunDir) throw new Error("consumer requires EFFECTSTREAM_CROSS_RUN_DIR");
+      const failedResult = JSON.parse(readFileSync(join(crossRunDir, "ordinary-publish-result.json"), "utf8")) as {
+        packages: { status: string }[];
+      };
+      expect(failedResult.packages.filter((pkg) => pkg.status === "published")).toHaveLength(5);
+      expect(failedResult.packages.filter((pkg) => pkg.status === "failed")).toHaveLength(1);
       const persisted = JSON.parse(readFileSync(join(crossRunDir, "registry-state.json"), "utf8")) as {
         occupied: [string, string][];
         distTags: [string, Record<string, string>][];
@@ -195,12 +245,18 @@ describe("persisted bundle verification and lost-runner recovery", () => {
       publishFromBundle({ artifactDir: bundle, registry, recovery: false, publish: true }),
     ).rejects.toThrow(/stopping/);
     expect(occupied.size).toBe(5);
+    const failedResult = JSON.parse(readFileSync(`${bundle}.publish-result.json`, "utf8")) as {
+      packages: { status: string }[];
+    };
+    expect(failedResult.packages.filter((pkg) => pkg.status === "published")).toHaveLength(5);
+    expect(failedResult.packages.filter((pkg) => pkg.status === "failed")).toHaveLength(1);
 
     if (crossRunPhase === "producer") {
       if (!crossRunDir) throw new Error("producer requires EFFECTSTREAM_CROSS_RUN_DIR");
       rmSync(join(crossRunDir, "artifact"), { recursive: true, force: true });
       rmSync(join(crossRunDir, "registry-state.json"), { force: true });
       cpSync(bundle, join(crossRunDir, "artifact"), { recursive: true });
+      cpSync(`${bundle}.publish-result.json`, join(crossRunDir, "ordinary-publish-result.json"));
       writeFileSync(
         join(crossRunDir, "registry-state.json"),
         canonicalJson({ occupied: [...occupied], distTags: [...distTags] }),

--- a/.github/publish-bun.effectstream.test.ts
+++ b/.github/publish-bun.effectstream.test.ts
@@ -320,6 +320,31 @@ describe("workflow invariants", () => {
     expect(release).not.toContain("HEAD:refs/heads/v-next");
   });
 
+  test("recovery compatibility is proven before auth or registry mutation", () => {
+    const order = [
+      "Verify original service and embedded identities",
+      "Validate recovery branch compatibility before authentication or mutation",
+      "Configure npm auth after all artifact and source checks",
+      "Complete exact artifact publication and apply version delta",
+    ].map((needle) => recovery.indexOf(needle));
+    expect(order.every((position) => position >= 0)).toBe(true);
+    expect(order).toEqual([...order].sort((a, b) => a - b));
+    expect(recovery).toContain("--validate-recovery-branch");
+  });
+
+  test("ordinary and recovery attempts persist separate result evidence under always", () => {
+    expect(release).toContain("steps.publish.outcome != 'skipped'");
+    expect(release).toContain("effectstream-release-bundle.publish-result.json");
+    expect(release).toContain("release-result-${{ github.event.release.tag_name }}");
+    expect(recovery).toContain("steps.recover-publication.outcome != 'skipped'");
+    expect(recovery).toContain("effectstream-release-bundle.publish-result.json");
+    expect(recovery).toContain("recovery-result-${{ inputs.release_tag }}");
+    for (const workflow of [release, recovery]) {
+      expect(workflow).toContain("if-no-files-found: error");
+      expect(workflow).toContain("retention-days: 90");
+    }
+  });
+
   test("all privileged actions are immutable pins", () => {
     for (const workflow of [release, recovery, rehearsal]) {
       for (const match of workflow.matchAll(/uses:\s+([^\s#]+)/g)) {

--- a/.github/publish-bun.effectstream.test.ts
+++ b/.github/publish-bun.effectstream.test.ts
@@ -2,338 +2,379 @@ import { describe, expect, test } from "bun:test";
 import { readFileSync } from "fs";
 import { join } from "path";
 import {
-  STABLE_DIST_TAG,
+  EXPECTED_PACKAGE_COUNT,
+  assertRecoveryLatestPrecondition,
+  canonicalJson,
+  isSecretLikeTarEntry,
+  classifyRecoveryMode,
   compareSemver,
   parseSemver,
+  planRegistryCompletion,
+  preflightOrdinary,
   resolveDistTag,
+  resolveReleasePolicy,
   resolveReleaseVersion,
   setVersionInText,
+  verifyLatestPostcondition,
+  type RegistryPackageState,
+  type ReleaseManifest,
+  type ReleasePolicy,
 } from "./publish-bun.effectstream";
 
-describe("parseSemver", () => {
-  test("parses and normalizes stable, prerelease, and build forms", () => {
-    const parsed = parseSemver("0.105.0-beta.1+build.007");
-    expect(parsed.major).toBe(0n);
-    expect(parsed.minor).toBe(105n);
-    expect(parsed.patch).toBe(0n);
-    expect(parsed.prerelease.map((part) => part.raw)).toEqual(["beta", "1"]);
-    expect(parsed.build).toEqual(["build", "007"]);
-    expect(parsed.normalized).toBe("0.105.0-beta.1+build.007");
+const packageNames = Array.from(
+  { length: EXPECTED_PACKAGE_COUNT },
+  (_, index) => `@effectstream/package-${String(index).padStart(2, "0")}`,
+);
+
+function states(
+  latest: string | ((index: number) => string | undefined) = "0.200.2",
+  targetIntegrity: string | null | ((index: number) => string | null) = null,
+  selectedTag?: { name: string; version: string },
+): RegistryPackageState[] {
+  return packageNames.map((name, index) => {
+    const latestValue = typeof latest === "function" ? latest(index) : latest;
+    const integrity =
+      typeof targetIntegrity === "function" ? targetIntegrity(index) : targetIntegrity;
+    return {
+      name,
+      targetIntegrity: integrity,
+      distTags: {
+        ...(latestValue ? { latest: latestValue } : {}),
+        ...(selectedTag ? { [selectedTag.name]: selectedTag.version } : {}),
+      },
+    };
+  });
+}
+
+function manifest(policy: ReleasePolicy): ReleaseManifest {
+  return {
+    schemaVersion: 1,
+    releaseTag: policy.releaseTag,
+    version: policy.version,
+    sourceSha: "a".repeat(40),
+    branch: policy.branch,
+    distTag: policy.distTag,
+    prerelease: policy.prerelease,
+    kind: policy.kind,
+    workflow: { runId: "123", runAttempt: "1" },
+    toolchain: { bun: "1.4.0", platform: "linux-x64" },
+    latestBefore: Object.fromEntries(packageNames.map((name) => [name, "0.200.2"])),
+    packages: packageNames.map((name, index) => ({
+      name,
+      relativeDir: `packages/${index}`,
+      filename: `package-${index}.tgz`,
+      size: 1,
+      sha512: String(index),
+      integrity: `sha512-${index}`,
+      versionBefore: policy.kind === "maintenance-stable" ? "0.104.1" : "0.200.2",
+    })),
+  };
+}
+
+describe("strict SemVer", () => {
+  test("orders core and prerelease values without precision loss", () => {
+    expect(compareSemver(parseSemver("0.200.3-rc.1"), parseSemver("0.200.2"))).toBeGreaterThan(0);
+    expect(compareSemver(parseSemver("9007199254740993.0.0"), parseSemver("9007199254740992.9.9"))).toBeGreaterThan(0);
+    expect(compareSemver(parseSemver("1.0.0-alpha"), parseSemver("1.0.0"))).toBeLessThan(0);
   });
 
-  test("strips an optional leading v", () => {
-    expect(parseSemver("v1.2.3-rc.1").normalized).toBe("1.2.3-rc.1");
+  test.each([
+    "v1.2",
+    "01.2.3",
+    "1.02.3",
+    "1.2.03",
+    "1.2.3-01",
+    "1.2.3+",
+    " 0.200.3",
+    "0.200.3 ",
+  ])("rejects malformed form %s", (value) => {
+    expect(() => parseSemver(value)).toThrow(/valid SemVer/);
   });
 
-  test("trims surrounding whitespace", () => {
-    expect(parseSemver("  0.100.20  ").normalized).toBe("0.100.20");
-  });
-
-  test("rejects malformed SemVer without silently normalizing it", () => {
-    for (const malformed of [
-      "v1.2",
-      "1.2.3.4",
-      "latest",
-      "vv1.2.3",
-      "01.2.3",
-      "1.02.3",
-      "1.2.03",
-      "1.2.3-01",
-      "1.2.3-alpha..1",
-      "1.2.3-alpha_1",
-      "1.2.3+build..1",
-      "1.2.3-",
-      "1.2.3+",
-    ]) {
-      expect(() => parseSemver(malformed)).toThrow(/valid SemVer/);
-    }
-  });
-});
-
-describe("compareSemver", () => {
-  const compare = (a: string, b: string) => compareSemver(parseSemver(a), parseSemver(b));
-
-  test("orders core versions without Number precision loss", () => {
-    expect(compare("1.0.0", "0.999.999")).toBeGreaterThan(0);
-    expect(compare("0.101.0", "0.100.99")).toBeGreaterThan(0);
-    expect(compare("0.100.21", "0.100.20")).toBeGreaterThan(0);
-    expect(compare("9007199254740993.0.0", "9007199254740992.999.999")).toBeGreaterThan(0);
-    expect(compare("0.100.20", "0.100.20")).toBe(0);
-    expect(compare("0.100.19", "0.100.20")).toBeLessThan(0);
-  });
-
-  test("implements the canonical prerelease precedence chain", () => {
-    const ordered = [
-      "1.0.0-alpha",
-      "1.0.0-alpha.1",
-      "1.0.0-alpha.beta",
-      "1.0.0-beta",
-      "1.0.0-beta.2",
-      "1.0.0-beta.11",
-      "1.0.0-rc.1",
-      "1.0.0",
-    ];
-    for (let i = 0; i < ordered.length - 1; i++) {
-      expect(compare(ordered[i], ordered[i + 1])).toBeLessThan(0);
-    }
-  });
-
-  test("orders the approved release correctly and ignores build metadata", () => {
-    expect(compare("0.105.0-beta.1", "0.104.1")).toBeGreaterThan(0);
-    expect(compare("0.105.0-beta.1", "0.105.0")).toBeLessThan(0);
-    expect(compare("1.0.0+one", "1.0.0+two")).toBe(0);
-  });
-});
-
-describe("resolveReleaseVersion", () => {
-  test("accepts a greater version and strips the v prefix", () => {
-    expect(resolveReleaseVersion("v0.100.20", "0.100.18")).toBe("0.100.20");
-  });
-
-  test("accepts a greater version without a prefix", () => {
-    expect(resolveReleaseVersion("0.105.0-beta.1", "0.104.1")).toBe("0.105.0-beta.1");
-  });
-
-  test("accepts minor and major boundary increments", () => {
-    expect(resolveReleaseVersion("0.101.0", "0.100.99")).toBe("0.101.0");
-    expect(resolveReleaseVersion("1.0.0", "0.999.999")).toBe("1.0.0");
-  });
-
-  test("rejects an equal version", () => {
-    expect(() => resolveReleaseVersion("0.100.18", "0.100.18")).toThrow(
-      /strictly greater/,
-    );
-  });
-
-  test("rejects a lower version", () => {
-    expect(() => resolveReleaseVersion("v0.100.17", "0.100.18")).toThrow(
-      /strictly greater/,
-    );
-  });
-
-  test("rejects a non-semver tag", () => {
-    expect(() => resolveReleaseVersion("v1.2", "0.100.18")).toThrow();
-  });
-
-  test("rejects a prerelease that is lower than its stable current version", () => {
-    expect(() => resolveReleaseVersion("0.105.0-beta.1", "0.105.0")).toThrow(
-      /strictly greater/,
-    );
+  test("requires a strictly greater branch-local version", () => {
+    expect(resolveReleaseVersion("v0.104.2", "0.104.1")).toBe("0.104.2");
+    expect(() => resolveReleaseVersion("v0.104.1", "0.104.1")).toThrow(/strictly greater/);
+    expect(() => resolveReleaseVersion("v0.104.0", "0.104.1")).toThrow(/strictly greater/);
   });
 });
 
-describe("resolveDistTag", () => {
-  test("maps stable releases only to latest", () => {
-    expect(resolveDistTag("0.105.0", STABLE_DIST_TAG)).toBe("latest");
-    expect(() => resolveDistTag("0.105.0", "next")).toThrow(/Stable release/);
-  });
-
-  test("accepts generic prerelease channels", () => {
-    for (const tag of ["next", "beta", "canary", "preview.2", "rc-1", "xray", "x-canary"]) {
-      expect(resolveDistTag("0.105.0-beta.1", tag)).toBe(tag);
-    }
-  });
-
-  test("rejects lower-, upper-, mixed-, and qualified npm wildcard ranges", () => {
-    for (const tag of [
-      "x",
-      "X",
-      "x.x",
-      "X.X.X",
-      "x.1",
-      "X.1.2",
-      "x.x.1",
-      "X.1.x",
-      "x.1.x",
-      "x.x.x-beta",
-      "X.1.2-rc.1",
-    ]) {
-      expect(() => resolveDistTag("0.105.0-beta.1", tag)).toThrow(
-        /npm wildcard SemVer ranges are not allowed/,
-      );
-    }
-  });
-
-  test("rejects prerelease latest and a missing tag", () => {
-    expect(() => resolveDistTag("0.105.0-beta.1", STABLE_DIST_TAG)).toThrow(
-      /must not use dist-tag latest/,
-    );
-    expect(() => resolveDistTag("0.105.0-beta.1")).toThrow(/--dist-tag is required/);
-    expect(() => resolveDistTag("0.105.0-beta.1", "")).toThrow(/--dist-tag is required/);
-  });
-
-  test("rejects whitespace and invalid npm tag characters", () => {
-    for (const tag of [" next", "next ", "next tag", "next/tag", "next+tag", "@next"]) {
-      expect(() => resolveDistTag("0.105.0-beta.1", tag)).toThrow(/Invalid dist-tag/);
-    }
-  });
-
-  test("rejects digit- and v-prefixed SemVer-like tags", () => {
-    for (const tag of ["1.2.3", "9beta", "v1", "version", "Vnext"]) {
-      expect(() => resolveDistTag("0.105.0-beta.1", tag)).toThrow(
-        /must not begin with a digit or v/,
-      );
-    }
-  });
-});
-
-describe("CLI release guard", () => {
-  const root = join(import.meta.dir, "..");
-  const script = join(import.meta.dir, "publish-bun.effectstream.ts");
-
-  async function runGuard(args: string[]) {
-    const packageBefore = readFileSync(join(root, "package.json"), "utf8");
-    const statusBefore = Bun.spawnSync(["git", "status", "--porcelain=v1", "--untracked-files=all"], {
-      cwd: root,
-    }).stdout.toString();
-    const child = Bun.spawn([process.execPath, script, ...args], {
-      cwd: root,
-      stdout: "pipe",
-      stderr: "pipe",
+describe("closed release policy", () => {
+  test.each([
+    ["v0.104.2", false, "midnight-1", "midnight-1", "maintenance-stable"],
+    ["v0.200.3", false, "v-next", "latest", "node2-stable"],
+    ["v0.200.3-rc.1", true, "v-next", "next", "node2-prerelease"],
+  ])("maps %s", (tag, prerelease, branch, distTag, kind) => {
+    expect(resolveReleasePolicy(tag, branch, distTag, prerelease)).toMatchObject({
+      branch,
+      distTag,
+      prerelease,
+      kind,
     });
-    const [exitCode, stdout, stderr] = await Promise.all([
-      child.exited,
-      new Response(child.stdout).text(),
-      new Response(child.stderr).text(),
-    ]);
-    expect(readFileSync(join(root, "package.json"), "utf8")).toBe(packageBefore);
-    expect(
-      Bun.spawnSync(["git", "status", "--porcelain=v1", "--untracked-files=all"], {
-        cwd: root,
-      }).stdout.toString(),
-    ).toBe(statusBefore);
-    return { exitCode, output: stdout + stderr };
-  }
-
-  test("missing dist-tag rejects before any package mutation", async () => {
-    const result = await runGuard(["--release-version", "0.105.0-beta.1"]);
-    expect(result.exitCode).not.toBe(0);
-    expect(result.output).toContain("--dist-tag is required");
   });
 
-  test("prerelease paired with latest rejects before any package mutation", async () => {
-    const result = await runGuard([
-      "--release-version",
-      "0.105.0-beta.1",
-      "--dist-tag",
-      "latest",
-    ]);
-    expect(result.exitCode).not.toBe(0);
-    expect(result.output).toContain("must not use dist-tag latest");
+  test.each([
+    ["v0.104.2", "v-next", "midnight-1", false],
+    ["v0.104.2", "midnight-1", "latest", false],
+    ["v0.200.3", "midnight-1", "latest", false],
+    ["v0.200.3", "v-next", "next", false],
+    ["v0.200.3-rc.1", "v-next", "latest", true],
+    ["v0.200.3-rc.1", "midnight-1", "next", true],
+  ])("rejects mismatched tuple %s/%s/%s", (tag, branch, distTag, prerelease) => {
+    expect(() => resolveReleasePolicy(tag, branch, distTag, prerelease)).toThrow();
   });
 
-  test("stable release paired with a non-latest tag rejects before mutation", async () => {
-    const result = await runGuard([
-      "--release-version",
-      "0.105.0",
-      "--dist-tag",
-      "next",
-    ]);
-    expect(result.exitCode).not.toBe(0);
-    expect(result.output).toContain("must use dist-tag latest");
+  test.each([
+    "v0.103.999",
+    "v0.104.2-rc.1",
+    "v0.104.2+build.1",
+    "v0.105.0",
+    "v0.199.999",
+    "v0.200.3+build.1",
+    "v0.201.0",
+    "v1.0.0",
+    "0.104.2",
+  ])("rejects unsupported form %s", (tag) => {
+    expect(() => resolveReleasePolicy(tag)).toThrow();
   });
 
-  test("invalid npm tags reject before any package mutation", async () => {
-    for (const tag of [" next", "next/tag", "1.2.3", "v1"]) {
-      const result = await runGuard([
-        "--release-version",
-        "0.105.0-beta.1",
-        "--dist-tag",
-        tag,
-      ]);
-      expect(result.exitCode).not.toBe(0);
-      expect(result.output).toContain("Invalid dist-tag");
+  test("requires the only allowed explicit dist-tag", () => {
+    expect(resolveDistTag("0.104.2", "midnight-1")).toBe("midnight-1");
+    expect(resolveDistTag("0.200.3", "latest")).toBe("latest");
+    expect(resolveDistTag("0.200.3-rc.1", "next")).toBe("next");
+    expect(() => resolveDistTag("0.104.2")).toThrow(/required/);
+    expect(() => resolveDistTag("0.104.2", "latest")).toThrow();
+  });
+});
+
+describe("all-package ordinary preflight", () => {
+  test.each(["v0.104.2", "v0.200.3", "v0.200.3-rc.1"])(
+    "accepts absent targets and one stable Node-2 latest snapshot for %s",
+    (tag) => {
+      const policy = resolveReleasePolicy(tag);
+      const snapshot = preflightOrdinary(policy, states());
+      expect(Object.keys(snapshot)).toHaveLength(EXPECTED_PACKAGE_COUNT);
+      expect(new Set(Object.values(snapshot))).toEqual(new Set(["0.200.2"]));
+    },
+  );
+
+  test.each([
+    ["occupied target", states("0.200.2", (index) => (index === 8 ? "sha512-existing" : null))],
+    ["missing latest", states((index) => (index === 8 ? undefined : "0.200.2"))],
+    ["mixed patches", states((index) => (index === 8 ? "0.200.1" : "0.200.2"))],
+    ["wrong family", states("0.104.1")],
+    ["prerelease latest", states("0.200.3-rc.1")],
+  ])("rejects %s with no mutation plan", (_name, registryStates) => {
+    expect(() => preflightOrdinary(resolveReleasePolicy("v0.104.2"), registryStates)).toThrow();
+  });
+
+  test("stable Node-2 target must be above the uniform current latest", () => {
+    expect(() => preflightOrdinary(resolveReleasePolicy("v0.200.2"), states())).toThrow(/greater/);
+  });
+});
+
+describe("persisted exact-tarball completion", () => {
+  const maintenance = manifest(resolveReleasePolicy("v0.104.2"));
+
+  test("ordinary run requires every target absent", () => {
+    expect(planRegistryCompletion(maintenance, states(), false).missing).toEqual(packageNames);
+    expect(() =>
+      planRegistryCompletion(
+        maintenance,
+        states("0.200.2", (index) => (index === 0 ? "sha512-0" : null)),
+        false,
+      ),
+    ).toThrow(/occupied/);
+  });
+
+  test("recovery skips exact prefix and non-prefix subsets only", () => {
+    for (const occupied of [new Set([0, 1, 2]), new Set([1, 9, 25])]) {
+      const result = planRegistryCompletion(
+        maintenance,
+        states("0.200.2", (index) => (occupied.has(index) ? `sha512-${index}` : null)),
+        true,
+      );
+      expect(result.existing).toEqual([...occupied].sort((a, b) => a - b).map((i) => packageNames[i]));
+      expect(result.missing).toHaveLength(EXPECTED_PACKAGE_COUNT - occupied.size);
     }
   });
 
-  test("npm wildcard ranges reject before any package mutation", async () => {
-    for (const tag of ["x", "X", "x.1", "X.1.2", "x.x.x-beta"]) {
-      const result = await runGuard([
-        "--release-version",
-        "0.105.0-beta.1",
-        "--dist-tag",
-        tag,
-      ]);
-      expect(result.exitCode).not.toBe(0);
-      expect(result.output).toContain("npm wildcard SemVer ranges are not allowed");
+  test("recovery rejects any occupied version with different integrity", () => {
+    expect(() =>
+      planRegistryCompletion(
+        maintenance,
+        states("0.200.2", (index) => (index === 4 ? "sha512-tampered" : null)),
+        true,
+      ),
+    ).toThrow(/differs/);
+  });
+});
+
+describe("release-kind postconditions", () => {
+  test("maintenance and Node-2 prerelease preserve latest exactly", () => {
+    for (const tag of ["v0.104.2", "v0.200.3-rc.1"]) {
+      const item = manifest(resolveReleasePolicy(tag));
+      expect(() =>
+        verifyLatestPostcondition(
+          item,
+          states("0.200.2", `sha512-unused`, { name: item.distTag, version: item.version }),
+        ),
+      ).not.toThrow();
+      expect(() =>
+        verifyLatestPostcondition(
+          item,
+          states((index) => (index === 2 ? "0.200.1" : "0.200.2"), `sha512-unused`, {
+            name: item.distTag,
+            version: item.version,
+          }),
+        ),
+      ).toThrow(/latest changed/);
+    }
+  });
+
+  test("stable Node-2 requires every latest at the target", () => {
+    const item = manifest(resolveReleasePolicy("v0.200.3"));
+    expect(() =>
+      verifyLatestPostcondition(
+        item,
+        states("0.200.3", `sha512-unused`, { name: "latest", version: "0.200.3" }),
+      ),
+    ).not.toThrow();
+    expect(() =>
+      verifyLatestPostcondition(
+        item,
+        states((index) => (index === 1 ? "0.200.2" : "0.200.3"), `sha512-unused`),
+      ),
+    ).toThrow(/expected/);
+  });
+
+  test("stable Node-2 recovery accepts only persisted-prestate or target during a tag loop", () => {
+    const item = manifest(resolveReleasePolicy("v0.200.3"));
+    expect(() =>
+      assertRecoveryLatestPrecondition(
+        item,
+        states((index) => (index % 2 ? "0.200.2" : "0.200.3")),
+      ),
+    ).not.toThrow();
+    expect(() =>
+      assertRecoveryLatestPrecondition(
+        item,
+        states((index) => (index === 3 ? "0.200.1" : "0.200.2")),
+      ),
+    ).toThrow(/neither/);
+  });
+
+  test("maintenance and prerelease recovery reject any latest snapshot drift", () => {
+    for (const tag of ["v0.104.2", "v0.200.3-rc.1"]) {
+      const item = manifest(resolveReleasePolicy(tag));
+      expect(() => assertRecoveryLatestPrecondition(item, states())).not.toThrow();
+      expect(() =>
+        assertRecoveryLatestPrecondition(
+          item,
+          states((index) => (index === 3 ? "0.200.1" : "0.200.2")),
+        ),
+      ).toThrow(/differs/);
     }
   });
 });
 
-describe("release workflow", () => {
-  test("pins privileged actions/tools and verifies source identity before mutation", () => {
-    const workflow = readFileSync(join(import.meta.dir, "workflows", "release.yaml"), "utf8");
-    expect(workflow).toContain(
-      "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7",
-    );
-    expect(workflow).toContain(
-      "oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2",
-    );
-    expect(workflow).toContain("bun-version: 1.4.0");
-    expect(workflow).not.toContain("bun-version: latest");
-    expect(workflow).toContain("runs-on: ubuntu-22.04");
-    expect(workflow).toContain("ref: ${{ github.event.release.tag_name }}");
-    expect(workflow).toContain("RELEASE_TARGET_COMMITISH: ${{ github.event.release.target_commitish }}");
-    expect(workflow).toContain(
-      "affd55aab609d4db7d6c6f38925859586d1ce67fd50f790d97c5dc027214af11",
-    );
-    expect(workflow).toContain("bash .github/verify-release-source.sh");
-    expect(workflow).toContain("git push origin HEAD:refs/heads/v-next");
-    expect(workflow).not.toContain("git push origin v-next");
+describe("recovery matrix", () => {
+  test.each([
+    [true, false, "partial-tag"],
+    [false, false, "complete-tag"],
+    [true, true, "partial-advanced"],
+    [false, true, "complete-advanced"],
+  ])("partial=%p advanced=%p => %s", (partial, advanced, expected) => {
+    expect(classifyRecoveryMode(partial, advanced)).toBe(expected);
+  });
+});
 
-    const ordered = [
+describe("workflow invariants", () => {
+  const workflows = join(import.meta.dir, "workflows");
+  const release = readFileSync(join(workflows, "release.yaml"), "utf8");
+  const recovery = readFileSync(join(workflows, "release-recovery.yaml"), "utf8");
+  const rehearsal = readFileSync(join(workflows, "release-artifact-rehearsal.yaml"), "utf8");
+
+  test("ordinary and recovery mutations share the exact non-cancelling lock", () => {
+    for (const workflow of [release, recovery]) {
+      expect(workflow).toContain("group: release-publish");
+      expect(workflow).toContain("cancel-in-progress: false");
+    }
+  });
+
+  test("guard and immutable upload precede auth and persisted-byte publish", () => {
+    const order = [
       "Verify immutable release source identity",
       "Setup Bun",
       "Install dependencies",
+      "Preflight registry and prepare exact release bundle",
+      "Upload immutable release bundle before authentication or mutation",
       "Configure npm auth",
-      "Select release channel",
-      "name: Publish",
-      "git add package.json",
-    ].map((needle) => workflow.indexOf(needle));
-    expect(ordered.every((position) => position >= 0)).toBe(true);
-    expect(ordered).toEqual([...ordered].sort((a, b) => a - b));
+      "Publish exact persisted tarballs",
+      "Commit and push version-only delta",
+    ].map((needle) => release.indexOf(needle));
+    expect(order.every((position) => position >= 0)).toBe(true);
+    expect(order).toEqual([...order].sort((a, b) => a - b));
+    expect(release).toContain("retention-days: 90");
+    expect(release).toContain("steps.release-source.outputs.dist-tag");
+    expect(release).toContain('git push origin "HEAD:refs/heads/$SOURCE_BRANCH"');
+    expect(release).not.toContain("HEAD:refs/heads/v-next");
   });
 
-  test("maps GitHub prerelease metadata to a generic explicit publisher channel", () => {
-    const workflow = readFileSync(join(import.meta.dir, "workflows", "release.yaml"), "utf8");
-    const channelStart = workflow.indexOf("- name: Select release channel");
-    const channelEnd = workflow.indexOf("- name: Publish", channelStart);
-    const channelBlock = workflow.slice(channelStart, channelEnd);
+  test("all privileged actions are immutable pins", () => {
+    for (const workflow of [release, recovery, rehearsal]) {
+      for (const match of workflow.matchAll(/uses:\s+([^\s#]+)/g)) {
+        expect(match[1]).toMatch(/@[0-9a-f]{40}$/);
+      }
+    }
+  });
 
-    expect(channelStart).toBeGreaterThanOrEqual(0);
-    expect(channelEnd).toBeGreaterThan(channelStart);
-    expect(channelBlock).toContain("PRERELEASE: ${{ github.event.release.prerelease }}");
-    expect(channelBlock).toContain('[[ "$PRERELEASE" == "true" ]]');
-    expect(channelBlock).toContain('DIST_TAG="next"');
-    expect(channelBlock).toContain('DIST_TAG="latest"');
-    expect(channelBlock).not.toContain("github.event.release.tag_name");
-    expect(channelBlock).not.toContain("RELEASE_TAG");
-    expect(workflow).toContain('--dist-tag "${{ steps.release-channel.outputs.dist-tag }}"');
+  test("recovery is separate, cross-run, reviewer-gated, and never reruns release", () => {
+    expect(recovery).toContain("workflow_dispatch:");
+    expect(recovery).toContain("actions: read");
+    expect(recovery).toContain("environment: npm-release-recovery");
+    expect(recovery).toContain("run-id: ${{ inputs.original_run_id }}");
+    expect(recovery).toContain("artifact-ids: ${{ inputs.artifact_id }}");
+    expect(recovery).not.toContain("run-attempt");
+  });
+
+  test("artifact proof producer and consumer are incapable of npm/source mutation", () => {
+    expect(rehearsal).toContain("contents: read");
+    expect(rehearsal).not.toContain("NPM_TOKEN");
+    expect(rehearsal).not.toContain("environment:");
+    expect(rehearsal).not.toContain("actions/checkout");
+    const proof = recovery.slice(recovery.indexOf("artifact-proof:"), recovery.indexOf("  recover:"));
+    expect(proof).toContain("actions: read");
+    expect(proof).toContain("contents: read");
+    expect(proof).not.toContain("NPM_TOKEN");
+    expect(proof).not.toContain("environment:");
   });
 });
 
-describe("setVersionInText", () => {
-  test("changes only the version line, preserving exact formatting", () => {
-    const src = [
-      "{",
-      '  "name": "@effectstream/node-sdk",',
-      '  "version": "0.100.17",',
-      '  "peerDependenciesMeta": {',
-      '    "@effectstream/example": { "optional": true }',
-      "  }",
-      "}",
-      "",
-    ].join("\n");
-    const out = setVersionInText(src, "0.100.20");
-    expect(out).toBe(src.replace("0.100.17", "0.100.20"));
-    // Compact object formatting is untouched.
-    expect(out).toContain('{ "optional": true }');
+describe("canonical and version-only bytes", () => {
+  test("secret-like bundle paths reject credentials without rejecting token source code", () => {
+    for (const path of [
+      "package/.npmrc",
+      "package/.env.production",
+      "package/npm-token.txt",
+      "package/secrets.json",
+      "package/id_ed25519",
+      "package/signing.pem",
+    ]) expect(isSecretLikeTarEntry(path)).toBe(true);
+    for (const path of [
+      "package/src/contracts/token/Token.sol",
+      "package/src/midnight-token-mint.ts",
+      "package/src/secret-sharing.ts",
+    ]) expect(isSecretLikeTarEntry(path)).toBe(false);
   });
 
-  test("only the first (package) version is replaced", () => {
-    const src = '{ "version": "0.100.17", "engines": { "version": "x" } }';
-    expect(setVersionInText(src, "0.100.20")).toBe(
-      '{ "version": "0.100.20", "engines": { "version": "x" } }',
+  test("canonical JSON recursively sorts keys", () => {
+    expect(canonicalJson({ z: 1, a: { y: 2, b: 3 } })).toBe('{"a":{"b":3,"y":2},"z":1}\n');
+  });
+
+  test("changes only the first package version field", () => {
+    const source = '{ "version": "0.104.1", "engines": { "version": "x" } }';
+    expect(setVersionInText(source, "0.104.2")).toBe(
+      '{ "version": "0.104.2", "engines": { "version": "x" } }',
     );
   });
 });

--- a/.github/publish-bun.effectstream.ts
+++ b/.github/publish-bun.effectstream.ts
@@ -449,12 +449,15 @@ async function setDistTag(name: string, version: string, distTag: string, regist
 }
 export async function publishFromBundle(options: { artifactDir: string; registry: string; recovery: boolean; publish: boolean; manifestSha512?: string }): Promise<{ published: string[]; skipped: string[] }> {
   const manifest = readAndVerifyBundle(options.artifactDir, options.manifestSha512);
+  const results: { name: string; status: string }[] = [];
+  const writeResults = () => writeFileSync(`${options.artifactDir}.publish-result.json`, canonicalJson({ releaseTag: manifest.releaseTag, sourceSha: manifest.sourceSha, recovery: options.recovery, packages: results }));
+  writeResults();
   const states = await Promise.all(manifest.packages.map((pkg) => readRegistryState(options.registry, pkg.name, manifest.version)));
   if (options.recovery) assertRecoveryLatestPrecondition(manifest, states);
   const completion = planRegistryCompletion(manifest, states, options.recovery);
   const published: string[] = [];
-  const results: { name: string; status: string }[] = completion.existing.map((name) => ({ name, status: "skipped-exact" }));
-  const writeResults = () => writeFileSync(`${options.artifactDir}.publish-result.json`, canonicalJson({ releaseTag: manifest.releaseTag, sourceSha: manifest.sourceSha, recovery: options.recovery, packages: results }));
+  results.push(...completion.existing.map((name) => ({ name, status: "skipped-exact" })));
+  writeResults();
   for (const name of completion.missing) {
     const pkg = manifest.packages.find((candidate) => candidate.name === name)!;
     if (options.publish) {
@@ -482,6 +485,11 @@ export async function publishFromBundle(options: { artifactDir: string; registry
 }
 
 export type RecoveryMode = "partial-tag" | "complete-tag" | "partial-advanced" | "complete-advanced";
+const RECOVERY_MODES = new Set<RecoveryMode>(["partial-tag", "complete-tag", "partial-advanced", "complete-advanced"]);
+function requireRecoveryMode(value: string): RecoveryMode {
+  if (!RECOVERY_MODES.has(value as RecoveryMode)) throw new Error(`Unsupported recovery mode ${value}`);
+  return value as RecoveryMode;
+}
 export function classifyRecoveryMode(partial: boolean, advanced: boolean): RecoveryMode {
   return `${partial ? "partial" : "complete"}-${advanced ? "advanced" : "tag"}` as RecoveryMode;
 }
@@ -500,7 +508,7 @@ export function validateRecoveryBranchState(
   const expectedBefore = manifest.packages[0].versionBefore;
   if (currentVersions.some((version) => version !== expectedBefore)) throw new Error("Version drift in recovery branch");
 }
-async function applyRecoveryVersionDelta(manifest: ReleaseManifest, mode: RecoveryMode, expectedCurrentBranchSha: string): Promise<void> {
+export async function validateRecoveryCheckout(manifest: ReleaseManifest, mode: RecoveryMode, expectedCurrentBranchSha: string): Promise<string[]> {
   if (!FULL_SHA_RE.test(expectedCurrentBranchSha)) throw new Error("Expected current branch SHA is invalid");
   const head = (await $`git -C ${ROOT} rev-parse HEAD^{commit}`.text()).trim();
   if (head !== expectedCurrentBranchSha) throw new Error(`Current HEAD ${head} differs from approved ${expectedCurrentBranchSha}`);
@@ -511,6 +519,10 @@ async function applyRecoveryVersionDelta(manifest: ReleaseManifest, mode: Recove
   const currentVersions = versionFiles.map((path) => JSON.parse(readFileSync(path, "utf8")).version as string);
   const sourceIsAncestor = Bun.spawnSync(["git", "merge-base", "--is-ancestor", manifest.sourceSha, head], { cwd: ROOT }).exitCode === 0;
   validateRecoveryBranchState(manifest, mode, head, sourceIsAncestor, currentVersions);
+  return versionFiles;
+}
+async function applyRecoveryVersionDelta(manifest: ReleaseManifest, mode: RecoveryMode, expectedCurrentBranchSha: string): Promise<void> {
+  const versionFiles = await validateRecoveryCheckout(manifest, mode, expectedCurrentBranchSha);
   for (const path of versionFiles) writeFileSync(path, setVersionInText(readFileSync(path, "utf8"), manifest.version));
 }
 
@@ -535,18 +547,28 @@ async function cli(): Promise<void> {
     console.log(canonicalJson(await publishFromBundle({ artifactDir: requireFlag("--artifact-dir"), registry, recovery: false, publish: process.argv.includes("--publish"), manifestSha512: getFlagValue("--manifest-sha512") })).trim());
     return;
   }
+  if (process.argv.includes("--validate-recovery-branch")) {
+    const artifactDir = requireFlag("--artifact-dir");
+    const manifest = readAndVerifyBundle(artifactDir, requireFlag("--manifest-sha512"));
+    const mode = requireRecoveryMode(requireFlag("--recovery-mode"));
+    const expectedCurrentBranchSha = requireFlag("--expected-current-branch-sha");
+    await validateRecoveryCheckout(manifest, mode, expectedCurrentBranchSha);
+    console.log(canonicalJson({ releaseTag: manifest.releaseTag, sourceSha: manifest.sourceSha, branch: manifest.branch, recoveryMode: mode, currentBranchSha: expectedCurrentBranchSha, compatible: true }).trim());
+    return;
+  }
   if (process.argv.includes("--recover-bundle")) {
     const auditRef = requireFlag("--audit-ref");
     const authorizationRef = requireFlag("--authorization-ref");
     const artifactDir = requireFlag("--artifact-dir");
     const manifestSha512 = requireFlag("--manifest-sha512");
     const manifest = readAndVerifyBundle(artifactDir, manifestSha512);
+    const expectedCurrentBranchSha = requireFlag("--expected-current-branch-sha");
+    const requested = requireRecoveryMode(requireFlag("--recovery-mode"));
+    await validateRecoveryCheckout(manifest, requested, expectedCurrentBranchSha);
     const states = await Promise.all(manifest.packages.map((pkg) => readRegistryState(registry, pkg.name, manifest.version)));
     assertRecoveryLatestPrecondition(manifest, states);
     const completion = planRegistryCompletion(manifest, states, true);
-    const expectedCurrentBranchSha = requireFlag("--expected-current-branch-sha");
     const observed = classifyRecoveryMode(completion.missing.length > 0, expectedCurrentBranchSha !== manifest.sourceSha);
-    const requested = requireFlag("--recovery-mode") as RecoveryMode;
     if (requested !== observed) throw new Error(`Recovery mode ${requested} differs from observed ${observed}`);
     const result = await publishFromBundle({ artifactDir, registry, recovery: true, publish: process.argv.includes("--publish"), manifestSha512 });
     if (process.argv.includes("--publish")) await applyRecoveryVersionDelta(manifest, requested, expectedCurrentBranchSha);
@@ -555,7 +577,7 @@ async function cli(): Promise<void> {
     console.log(canonicalJson(final).trim());
     return;
   }
-  throw new Error("Choose exactly one of --policy, --prepare, --publish-bundle, or --recover-bundle");
+  throw new Error("Choose exactly one of --policy, --prepare, --publish-bundle, --validate-recovery-branch, or --recover-bundle");
 }
 
 if (import.meta.main) cli().catch((error) => {

--- a/.github/publish-bun.effectstream.ts
+++ b/.github/publish-bun.effectstream.ts
@@ -1,92 +1,37 @@
 #!/usr/bin/env bun
 
+// The legacy root unpublish-bun.effectstream.ts script has an incomplete static
+// package list and is not a recovery mechanism. npm unpublish is non-atomic;
+// release recovery must complete the exact persisted bundle through this file.
+
 import { $ } from "bun";
-import { resolve, join, relative } from "path";
-import { readFileSync, writeFileSync, existsSync, copyFileSync, unlinkSync } from "fs";
-import { Glob } from "bun";
+import { createHash } from "crypto";
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from "fs";
+import { basename, join, relative, resolve } from "path";
 
-// This script lives in `.github/`; the monorepo root is one level up. Everything
-// below (package discovery, root package.json, relative dirs) is resolved against ROOT.
 const ROOT = resolve(import.meta.dir, "..");
-
-const FLAGS_HELP = `
-Flags:
-  --publish                real publish (default is dry-run via \`bun publish --dry-run\`)
-  --release-version <ver>  validate <ver> (SemVer, must be > current root version) and
-                           use it as the version to publish; also writes it into root package.json
-  --dist-tag <tag>         required release channel: stable uses latest; prereleases use
-                           a non-latest npm tag (for example next, beta, or canary)
-  --allow-uncommitted      skip the git-clean check
-  --allow-missing-readme   skip the per-package README presence / 400-char check
-`;
-function printFlags() {
-  console.error(FLAGS_HELP);
-}
-
-const DEPRECATED = new Set([
-  "@effectstream/explorer",
-]);
-
-const PACKAGE_META = {
-  homepage: "https://effectstream.github.io/docs/",
-  repository: {
-    type: "git",
-    url: "https://github.com/effectstream/effectstream",
-  },
-  bugs: {
-    url: "https://github.com/effectstream/effectstream/issues",
-  },
-} as const;
-
-const PACKAGE_DESCRIPTIONS: Record<string, string> = {
-  "@effectstream/utils": "Shared utilities for the EffectStream framework",
-  "@effectstream/log": "OpenTelemetry observability for EffectStream",
-  "@effectstream/config": "Chain and runtime configuration for EffectStream",
-  "@effectstream/precompile": "Precompile utilities for EffectStream",
-  "@effectstream/chain-types": "Chain-specific type definitions for EffectStream",
-  "@effectstream/crypto": "Multi-chain signature verification for EffectStream",
-  "@effectstream/concise": "Type-safe schemas for EffectStream",
-  "@effectstream/event-client": "MQTT-based event client for EffectStream",
-  "@effectstream/wallets": "Wallet connector integrations for EffectStream",
-  "@effectstream/coroutine": "Async control flow for EffectStream",
-  "@effectstream/db": "PostgreSQL and PgLite database layer for EffectStream",
-  "@effectstream/sync": "Blockchain sync service for EffectStream",
-  "@effectstream/sm": "State machine DSL for EffectStream",
-  "@effectstream/db-emulator": "In-memory test database for EffectStream",
-  "@effectstream/event-server": "Event server for EffectStream",
-  "@effectstream/runtime": "State machine runtime for EffectStream",
-  "@effectstream/node-sdk": "Main application node SDK for EffectStream",
-  "@effectstream/midnight-contracts": "Midnight network contract interfaces for EffectStream",
-  "@effectstream/evm-hardhat": "Hardhat deployment and JSON-RPC utilities for EffectStream",
-  "@effectstream/evm-contracts": "EVM smart contract interfaces for EffectStream",
-  "@effectstream/bitcoin-contracts": "Bitcoin script utilities for EffectStream",
-  "@effectstream/cardano-contracts": "Cardano contract interfaces for EffectStream",
-  "@effectstream/avail-contracts": "Avail DA contract interfaces for EffectStream",
-  "@effectstream/batcher-sdk": "Cross-chain transaction batching SDK for EffectStream",
-  "@effectstream/batcher": "Cross-chain transaction batching for EffectStream",
-  "@effectstream/explorer": "Block explorer for EffectStream",
-  "@effectstream/tui": "Terminal UI for EffectStream",
-  "@effectstream/orchestrator": "Multi-chain local development environment for EffectStream",
-  "@effectstream/frontend-sdk": "React frontend SDK for EffectStream",
-  "@effectstream/bitcoin-core": "Bitcoin Core binary wrapper for EffectStream",
-  "@effectstream/ord": "Ord binary wrapper for EffectStream",
-  "@effectstream/avail-light-client": "Avail light client binary wrapper for EffectStream",
-  "@effectstream/avail-node": "Avail node binary wrapper for EffectStream",
-  "@effectstream/midnight-indexer": "Midnight indexer binary wrapper for EffectStream",
-  "@effectstream/midnight-node": "Midnight node binary wrapper for EffectStream",
-  "@effectstream/midnight-proof-server": "Midnight proof server binary wrapper for EffectStream",
-  "@effectstream/grafana-alloy": "Grafana Alloy binary wrapper for EffectStream",
-  "@effectstream/grafana-loki": "Grafana Loki binary wrapper for EffectStream",
-  "@effectstream/near-sandbox": "NEAR sandbox binary wrapper for EffectStream",
-  "@effectstream/celestia": "Celestia binary wrapper for EffectStream",
-};
-
-// --- Version/channel helpers (pure, exported for unit testing) ---
+export const EXPECTED_PACKAGE_COUNT = 39;
+export const STABLE_DIST_TAG = "latest";
+export const RELEASE_BUNDLE_SCHEMA = 1;
+const DEPRECATED = new Set(["@effectstream/explorer"]);
+const LICENSE_FILES = ["LICENSE-MIT", "LICENSE-APACHE"] as const;
+const MIN_README_CHARS = 400;
+const SEMVER_RE = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*))*))?(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$/;
+const FULL_SHA_RE = /^[0-9a-f]{40}$/;
 
 type PrereleaseIdentifier =
   | { numeric: true; value: bigint; raw: string }
   | { numeric: false; value: string; raw: string };
-
 export type ParsedSemver = {
   major: bigint;
   minor: bigint;
@@ -95,477 +40,525 @@ export type ParsedSemver = {
   build: string[];
   normalized: string;
 };
+export type ReleaseKind = "maintenance-stable" | "node2-stable" | "node2-prerelease";
+export type ReleasePolicy = {
+  version: string;
+  releaseTag: string;
+  branch: "midnight-1" | "v-next";
+  distTag: "midnight-1" | "latest" | "next";
+  prerelease: boolean;
+  kind: ReleaseKind;
+};
+export type RegistryPackageState = {
+  name: string;
+  targetIntegrity: string | null;
+  distTags: Record<string, string>;
+};
+export type ManifestPackage = {
+  name: string;
+  relativeDir: string;
+  filename: string;
+  size: number;
+  sha512: string;
+  integrity: string;
+  versionBefore: string;
+};
+export type ReleaseManifest = {
+  schemaVersion: 1;
+  releaseTag: string;
+  version: string;
+  sourceSha: string;
+  branch: "midnight-1" | "v-next";
+  distTag: "midnight-1" | "latest" | "next";
+  prerelease: boolean;
+  kind: ReleaseKind;
+  workflow: { runId: string; runAttempt: string };
+  toolchain: { bun: string; platform: string };
+  latestBefore: Record<string, string>;
+  packages: ManifestPackage[];
+};
+type PackageInfo = {
+  name: string;
+  dir: string;
+  relativeDir: string;
+  manifestPath: string;
+  pkg: Record<string, any>;
+};
 
-// Strict SemVer 2.0.0 grammar. Numeric core/prerelease identifiers cannot have
-// leading zeroes; build identifiers may. We intentionally allow one leading
-// `v` for Git tags and normalize it away.
-const SEMVER_RE = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*))*))?(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$/;
-
-/** Parse a complete SemVer string, accepting and removing one leading `v`. */
 export function parseSemver(input: string): ParsedSemver {
-  const trimmed = input.trim();
-  const candidate = trimmed.startsWith("v") ? trimmed.slice(1) : trimmed;
+  if (input !== input.trim()) throw new Error(`"${input}" is not a valid SemVer version`);
+  const candidate = input.startsWith("v") ? input.slice(1) : input;
   const match = SEMVER_RE.exec(candidate);
-  if (!match) {
-    throw new Error(`"${input}" is not a valid SemVer version`);
-  }
-
-  const prereleaseRaw = match[4] ? match[4].split(".") : [];
-  const prerelease: PrereleaseIdentifier[] = prereleaseRaw.map((raw) =>
+  if (!match) throw new Error(`"${input}" is not a valid SemVer version`);
+  const prerelease = (match[4] ? match[4].split(".") : []).map((raw) =>
     /^\d+$/.test(raw)
-      ? { numeric: true, value: BigInt(raw), raw }
-      : { numeric: false, value: raw, raw },
+      ? ({ numeric: true, value: BigInt(raw), raw } as const)
+      : ({ numeric: false, value: raw, raw } as const),
   );
-  const build = match[5] ? match[5].split(".") : [];
-
   return {
     major: BigInt(match[1]),
     minor: BigInt(match[2]),
     patch: BigInt(match[3]),
     prerelease,
-    build,
+    build: match[5] ? match[5].split(".") : [],
     normalized: candidate,
   };
 }
 
-/** Compare parsed SemVer values using SemVer 2.0.0 precedence rules. */
 export function compareSemver(a: ParsedSemver, b: ParsedSemver): number {
   for (const key of ["major", "minor", "patch"] as const) {
     if (a[key] < b[key]) return -1;
     if (a[key] > b[key]) return 1;
   }
-
-  if (a.prerelease.length === 0 && b.prerelease.length === 0) return 0;
-  if (a.prerelease.length === 0) return 1;
-  if (b.prerelease.length === 0) return -1;
-
-  const count = Math.max(a.prerelease.length, b.prerelease.length);
-  for (let i = 0; i < count; i++) {
+  if (!a.prerelease.length && !b.prerelease.length) return 0;
+  if (!a.prerelease.length) return 1;
+  if (!b.prerelease.length) return -1;
+  for (let i = 0; i < Math.max(a.prerelease.length, b.prerelease.length); i++) {
     const left = a.prerelease[i];
     const right = b.prerelease[i];
-    if (left === undefined) return -1;
-    if (right === undefined) return 1;
+    if (!left) return -1;
+    if (!right) return 1;
     if (left.numeric && right.numeric) {
       if (left.value < right.value) return -1;
       if (left.value > right.value) return 1;
-      continue;
+    } else if (left.numeric !== right.numeric) {
+      return left.numeric ? -1 : 1;
+    } else {
+      const comparison = String(left.value).localeCompare(String(right.value));
+      if (comparison) return comparison;
     }
-    if (left.numeric !== right.numeric) return left.numeric ? -1 : 1;
-    const leftText = String(left.value);
-    const rightText = String(right.value);
-    if (leftText < rightText) return -1;
-    if (leftText > rightText) return 1;
   }
-
-  // Build metadata does not participate in precedence.
   return 0;
 }
 
-/**
- * Resolve and validate a release version against the current one.
- * Strips an optional leading `v`, requires both to be MAJOR.MINOR.PATCH, and
- * requires the release version to be strictly greater than `current`.
- * Returns the normalized (no-`v`) version string, or throws on any violation.
- */
 export function resolveReleaseVersion(tag: string, current: string): string {
   const next = parseSemver(tag);
-  const cur = parseSemver(current);
-  if (compareSemver(next, cur) <= 0) {
+  const previous = parseSemver(current);
+  if (compareSemver(next, previous) <= 0) {
     throw new Error(
-      `Release version ${next.normalized} must be strictly greater than current ${cur.normalized}`,
+      `Release version ${next.normalized} must be strictly greater than current ${previous.normalized}`,
     );
   }
   return next.normalized;
 }
 
-export const STABLE_DIST_TAG = "latest";
-const NPM_DIST_TAG_RE = /^[A-Za-z][A-Za-z0-9._-]*$/;
-const NPM_WILDCARD_RANGE_RE = /^x(?:$|\.)/i;
-
-/**
- * Enforce the complete release-channel contract before any package mutation:
- * stable releases use `latest`; prereleases use an explicit non-`latest` npm tag.
- */
-export function resolveDistTag(version: string, requestedTag?: string): string {
-  if (requestedTag === undefined || requestedTag.length === 0) {
-    throw new Error("--dist-tag is required for every release");
+export function resolveReleasePolicy(
+  releaseTag: string,
+  requestedBranch?: string,
+  requestedDistTag?: string,
+  githubPrerelease?: boolean,
+): ReleasePolicy {
+  if (!releaseTag.startsWith("v")) throw new Error("Release tag must begin with one lowercase v");
+  const parsed = parseSemver(releaseTag);
+  if (parsed.build.length) throw new Error("Build metadata is not supported for releases");
+  if (parsed.major !== 0n) throw new Error(`Unsupported release family ${parsed.normalized}`);
+  let policy: ReleasePolicy;
+  if (parsed.minor === 104n && parsed.prerelease.length === 0) {
+    policy = { version: parsed.normalized, releaseTag, branch: "midnight-1", distTag: "midnight-1", prerelease: false, kind: "maintenance-stable" };
+  } else if (parsed.minor === 200n && parsed.prerelease.length === 0) {
+    policy = { version: parsed.normalized, releaseTag, branch: "v-next", distTag: "latest", prerelease: false, kind: "node2-stable" };
+  } else if (parsed.minor === 200n && parsed.prerelease.length > 0) {
+    policy = { version: parsed.normalized, releaseTag, branch: "v-next", distTag: "next", prerelease: true, kind: "node2-prerelease" };
+  } else if (parsed.minor === 104n) {
+    throw new Error("Maintenance prereleases are not supported");
+  } else {
+    throw new Error(`Unsupported release family ${parsed.normalized}`);
   }
-  if (requestedTag !== requestedTag.trim()) {
-    throw new Error(`Invalid dist-tag "${requestedTag}": surrounding whitespace is not allowed`);
+  if (githubPrerelease !== undefined && githubPrerelease !== policy.prerelease) {
+    throw new Error(`GitHub prerelease=${githubPrerelease} disagrees with release tag ${releaseTag}`);
   }
-  if (/^[0-9v]/i.test(requestedTag)) {
-    throw new Error(
-      `Invalid dist-tag "${requestedTag}": npm tags must not begin with a digit or v`,
-    );
+  if (requestedBranch !== undefined && requestedBranch !== policy.branch) {
+    throw new Error(`Release ${policy.version} requires branch ${policy.branch}, not ${requestedBranch}`);
   }
-  if (!NPM_DIST_TAG_RE.test(requestedTag)) {
-    throw new Error(
-      `Invalid dist-tag "${requestedTag}": use letters, digits, dots, underscores, or hyphens`,
-    );
+  if (requestedDistTag !== undefined && requestedDistTag !== policy.distTag) {
+    throw new Error(`Release ${policy.version} requires dist-tag ${policy.distTag}, not ${requestedDistTag}`);
   }
-  if (NPM_WILDCARD_RANGE_RE.test(requestedTag)) {
-    throw new Error(
-      `Invalid dist-tag "${requestedTag}": npm wildcard SemVer ranges are not allowed`,
-    );
-  }
-
-  const parsed = parseSemver(version);
-  if (parsed.prerelease.length === 0) {
-    if (requestedTag !== STABLE_DIST_TAG) {
-      throw new Error(`Stable release ${parsed.normalized} must use dist-tag ${STABLE_DIST_TAG}`);
-    }
-    return requestedTag;
-  }
-
-  if (requestedTag === STABLE_DIST_TAG) {
-    throw new Error(`Prerelease ${parsed.normalized} must not use dist-tag ${STABLE_DIST_TAG}`);
-  }
-  return requestedTag;
+  return policy;
 }
 
-/**
- * Replace the top-level `"version": "..."` value in a package.json text while
- * preserving the rest of the file's formatting byte-for-byte. Only the first
- * `"version"` occurrence (the package's own version) is changed.
- */
+export function resolveDistTag(version: string, requestedTag?: string): string {
+  if (!requestedTag) throw new Error("--dist-tag is required for every release");
+  return resolveReleasePolicy(version.startsWith("v") ? version : `v${version}`, undefined, requestedTag).distTag;
+}
+
 export function setVersionInText(text: string, version: string): string {
   return text.replace(/"version":(\s*)"[^"]*"/, `"version":$1"${version}"`);
 }
 
-/** Read a `--flag value` or `--flag=value` argument from argv. */
+function sortObject(value: any): any {
+  if (Array.isArray(value)) return value.map(sortObject);
+  if (value && typeof value === "object") {
+    return Object.fromEntries(Object.keys(value).sort().map((key) => [key, sortObject(value[key])]))
+  }
+  return value;
+}
+export function canonicalJson(value: unknown): string {
+  return `${JSON.stringify(sortObject(value))}\n`;
+}
+function sha512File(path: string): { hex: string; integrity: string } {
+  const digest = createHash("sha512").update(readFileSync(path)).digest();
+  return { hex: digest.toString("hex"), integrity: `sha512-${digest.toString("base64")}` };
+}
+export function isSecretLikeTarEntry(entry: string): boolean {
+  const name = basename(entry).toLowerCase();
+  return name === ".npmrc"
+    || name === ".env"
+    || name.startsWith(".env.")
+    || /^(?:npm|bun|registry|github|gh)[_-]?(?:auth[_-]?)?token(?:\.[^/]*)?$/.test(name)
+    || /^(?:auth[_-]?token|credentials|secrets?)(?:\.[^/]*)?$/.test(name)
+    || /^id_(?:rsa|dsa|ecdsa|ed25519)(?:\.[^/]*)?$/.test(name)
+    || /\.(?:pem|p12|pfx)$/.test(name);
+}
 function getFlagValue(flag: string): string | undefined {
-  const argv = process.argv;
-  const eq = argv.find((a) => a.startsWith(`${flag}=`));
-  if (eq) return eq.slice(flag.length + 1);
-  const i = argv.indexOf(flag);
-  if (i !== -1 && i + 1 < argv.length) return argv[i + 1];
-  return undefined;
+  const direct = process.argv.find((arg) => arg.startsWith(`${flag}=`));
+  if (direct) return direct.slice(flag.length + 1);
+  const index = process.argv.indexOf(flag);
+  return index >= 0 ? process.argv[index + 1] : undefined;
+}
+function requireFlag(flag: string): string {
+  const value = getFlagValue(flag);
+  if (!value) throw new Error(`${flag} is required`);
+  return value;
 }
 
-if (import.meta.main) {
-  const rootPkgPath = join(ROOT, "package.json");
-  const rootPkg = JSON.parse(readFileSync(rootPkgPath, "utf-8"));
-
-  // --- Resolve target version ---
-  // With --release-version the tag drives (and validates) the version; otherwise
-  // we publish whatever is already in root package.json (the original behavior).
-  const releaseArg = getFlagValue("--release-version");
-  let version: string;
-  let distTag: string;
-  try {
-    if (releaseArg !== undefined) {
-      version = resolveReleaseVersion(releaseArg, rootPkg.version);
-    } else {
-      version = parseSemver(rootPkg.version).normalized;
-    }
-    distTag = resolveDistTag(version, getFlagValue("--dist-tag"));
-  } catch (e: any) {
-    console.error(`\n❌ ${e.message}`);
-    printFlags();
-    process.exit(1);
-  }
-
-  if (releaseArg !== undefined) {
-    console.log(
-      `\n🔖 Release version ${version} (from "${releaseArg}"), current root ${rootPkg.version}, dist-tag ${distTag}`,
-    );
-  }
-
-  // --- Step 1: Find all publishable packages ---
-
-  console.log(`\n📦 Publishing version: ${version} on dist-tag ${distTag}\n`);
-
-  const glob = new Glob("packages/**/package.json");
-  const packageDirs: { name: string; dir: string; pkg: any }[] = [];
-
-  for await (const path of glob.scan({ cwd: ROOT })) {
+function discoverPackages(root = ROOT): PackageInfo[] {
+  const manifests = new Bun.Glob("packages/**/package.json");
+  const packages: PackageInfo[] = [];
+  for (const path of manifests.scanSync({ cwd: root })) {
     if (path.includes("node_modules")) continue;
-
-    const fullPath = resolve(ROOT, path);
-    const pkg = JSON.parse(readFileSync(fullPath, "utf-8"));
-
-    if (!pkg.name) continue;
-    if (pkg.private) continue;
-    if (DEPRECATED.has(pkg.name)) continue;
-
-    packageDirs.push({
-      name: pkg.name,
-      dir: resolve(ROOT, path, ".."),
-      pkg,
-    });
+    const manifestPath = resolve(root, path);
+    const pkg = JSON.parse(readFileSync(manifestPath, "utf8"));
+    if (!pkg.name || pkg.private || DEPRECATED.has(pkg.name)) continue;
+    packages.push({ name: pkg.name, dir: resolve(manifestPath, ".."), relativeDir: relative(root, resolve(manifestPath, "..")), manifestPath, pkg });
   }
-
-  packageDirs.sort((a, b) => a.name.localeCompare(b.name));
-
-  // --- Step 1b: Verify each package ships a real README ---
-  // npm renders the README on the package page. Without one, the package looks
-  // abandoned. We fail the publish unless --allow-missing-readme is set.
-
-  const MIN_README_CHARS = 400;
-  const missingReadme: string[] = [];
-  const stubReadme: string[] = [];
-
-  for (const { name, dir } of packageDirs) {
-    const readmePath = join(dir, "README.md");
-    if (!existsSync(readmePath)) {
-      missingReadme.push(name);
-      continue;
-    }
-    const content = readFileSync(readmePath, "utf-8").trim();
-    if (content.length < MIN_README_CHARS) stubReadme.push(name);
+  packages.sort((left, right) => left.name.localeCompare(right.name));
+  if (packages.length !== EXPECTED_PACKAGE_COUNT) {
+    throw new Error(`Expected exactly ${EXPECTED_PACKAGE_COUNT} publishable packages, found ${packages.length}`);
   }
-
-  if (missingReadme.length || stubReadme.length) {
-    console.error("\nREADME check failed:");
-    for (const n of missingReadme) console.error(`  missing:  ${n}`);
-    for (const n of stubReadme) console.error(`  stub:     ${n}`);
-    if (!process.argv.includes("--allow-missing-readme")) {
-      console.error(
-        "\nAdd a real README.md to each package, or pass --allow-missing-readme to bypass.",
-      );
-      printFlags();
-      process.exit(1);
-    }
-    console.error("  (continuing because --allow-missing-readme was set)\n");
-  }
-
-  // --- Step 1c: Check for uncommitted changes early (before we modify files) ---
-
-  console.log("Checking git status...");
-
-  const allowUncommitted = process.argv.includes("--allow-uncommitted");
-  const status = await $`git status --porcelain`.text();
-  if (status.trim().length > 0) {
-    if (allowUncommitted) {
-      console.log("  ⚠ Uncommitted changes (--allow-uncommitted)\n");
-    } else {
-      console.error("\n❌ Uncommitted changes detected:\n");
-      console.error(status);
-      console.error("Commit or stash changes before publishing.");
-      printFlags();
-      process.exit(1);
-    }
-  } else {
-    console.log("  Working tree clean ✓\n");
-  }
-
-  // --- Step 1d: Apply the release version to root package.json ---
-  // Done AFTER the git-clean check so the check still guards a pristine tree.
-  // Edit the version string in place to preserve the file's exact formatting.
-  if (releaseArg !== undefined && rootPkg.version !== version) {
-    const rootText = readFileSync(rootPkgPath, "utf-8");
-    writeFileSync(rootPkgPath, setVersionInText(rootText, version));
-    console.log(`Set root package.json version → ${version}\n`);
-  }
-
-  // --- Cleanup: always restore each package.json to "pristine + new version" ---
-  // We snapshot the committed on-disk text BEFORE any mutation. On exit we rewrite
-  // each file from that snapshot with only `version` updated — which reverts both
-  // the dependency pinning (Step 2c) and the metadata injection (Step 2b) while
-  // keeping the intended version bump. npm still receives pinned deps + metadata
-  // because those live on disk *during* `bun publish`; only the post-run tree is
-  // version-only. Registered on exit/SIGINT/SIGTERM so deps are ALWAYS reverted.
-
-  const pristine = new Map<string, string>();
-  for (const { dir } of packageDirs) {
-    const fp = join(dir, "package.json");
-    pristine.set(fp, readFileSync(fp, "utf-8"));
-  }
-
-  // License files staged into each package dir for the tarball (Step 2d);
-  // removed again by restore(). Declared here so restore() can see them even
-  // if we bail out before the staging step runs.
-  const LICENSE_FILES = ["LICENSE-MIT", "LICENSE-APACHE"];
-  const stagedLicenses: string[] = [];
-
-  let restored = false;
-  function restore() {
-    if (restored) return;
-    restored = true;
-    for (const { dir } of packageDirs) {
-      const fp = join(dir, "package.json");
-      // Rewrite the pristine TEXT with only the version string changed, so the
-      // file's exact original formatting (and metadata/deps) is preserved.
-      writeFileSync(fp, setVersionInText(pristine.get(fp)!, version));
-    }
-    for (const fp of stagedLicenses) {
-      try {
-        unlinkSync(fp);
-      } catch {}
-    }
-    console.log(
-      `\nRestored ${packageDirs.length} package.json files (version-only; deps & metadata reverted)` +
-        (stagedLicenses.length ? ` and removed ${stagedLicenses.length} staged license files` : ""),
-    );
-  }
-  process.on("exit", restore);
-  process.on("SIGINT", () => {
-    restore();
-    process.exit(130);
-  });
-  process.on("SIGTERM", () => {
-    restore();
-    process.exit(143);
-  });
-
-  // --- Step 2: Bump versions ---
-
-  console.log(`Bumping ${packageDirs.length} packages to v${version}:\n`);
-
-  for (const { name, dir, pkg } of packageDirs) {
-    const fullPath = join(dir, "package.json");
-    const oldVersion = pkg.version;
-
-    if (oldVersion === version) {
-      console.log(`  ${name} — already at ${version}`);
-      continue;
-    }
-
-    pkg.version = version;
-    writeFileSync(fullPath, JSON.stringify(pkg, null, 2) + "\n");
-    console.log(`  ${name} — ${oldVersion} → ${version}`);
-  }
-
-  // --- Step 2b: Inject package metadata ---
-
-  console.log(`Injecting package metadata...\n`);
-
-  for (const { name, dir, pkg } of packageDirs) {
-    const fullPath = join(dir, "package.json");
-    const relDir = relative(ROOT, dir);
-
-    pkg.homepage = PACKAGE_META.homepage;
-    pkg.repository = { ...PACKAGE_META.repository, directory: relDir };
-    pkg.bugs = { ...PACKAGE_META.bugs };
-    if (PACKAGE_DESCRIPTIONS[name]) {
-      pkg.description = PACKAGE_DESCRIPTIONS[name];
-    }
-
-    // Packages with a `files` allowlist would otherwise exclude the license
-    // files staged in Step 2d (npm/bun only auto-include a file literally
-    // named LICENSE/LICENCE, not LICENSE-MIT/LICENSE-APACHE).
-    if (Array.isArray(pkg.files)) {
-      for (const lf of LICENSE_FILES) {
-        if (!pkg.files.includes(lf)) pkg.files.push(lf);
-      }
-    }
-
-    writeFileSync(fullPath, JSON.stringify(pkg, null, 2) + "\n");
-  }
-
-  console.log(`  Updated ${packageDirs.length} packages\n`);
-
-  // --- Step 2c: Replace workspace:* with concrete version ---
-  // `bun publish` resolves `workspace:*` from the lockfile, which may still
-  // point at the previous version. We replace `workspace:*` with the target
-  // version in every package.json before publishing; restore() reverts it.
-
-  console.log(`\nReplacing workspace:* with v${version}...`);
-
-  const workspacePackageNames = new Set(packageDirs.map((p) => p.name));
-  let patched = 0;
-
-  for (const { dir, pkg } of packageDirs) {
-    const fullPath = join(dir, "package.json");
-    let changed = false;
-
-    for (const depField of ["dependencies", "devDependencies", "peerDependencies"]) {
-      const deps = pkg[depField];
-      if (!deps) continue;
-      for (const [name, ver] of Object.entries(deps)) {
-        if (typeof ver === "string" && ver.startsWith("workspace:") && workspacePackageNames.has(name)) {
-          deps[name] = version;
-          changed = true;
-        }
-      }
-    }
-
-    if (changed) {
-      writeFileSync(fullPath, JSON.stringify(pkg, null, 2) + "\n");
-      patched++;
-    }
-  }
-
-  console.log(`  Patched ${patched} package.json files\n`);
-
-  // --- Step 2d: Stage license files into each package ---
-  // The published tarball should carry the actual license text, not just the
-  // SPDX expression in package.json. Copy the root LICENSE-MIT/LICENSE-APACHE
-  // into every package dir; restore() deletes the copies after publishing.
-  // A package that already ships its own license file keeps it untouched.
-
-  console.log(`Staging ${LICENSE_FILES.join(", ")} into each package...`);
-
-  for (const lf of LICENSE_FILES) {
-    if (!existsSync(join(ROOT, lf))) {
-      console.error(`\n❌ Missing ${lf} at repo root`);
-      printFlags();
-      process.exit(1);
-    }
-  }
-
-  for (const { dir } of packageDirs) {
-    for (const lf of LICENSE_FILES) {
-      const dest = join(dir, lf);
-      if (existsSync(dest)) continue;
-      copyFileSync(join(ROOT, lf), dest);
-      stagedLicenses.push(dest);
-    }
-  }
-
-  console.log(`  Staged ${stagedLicenses.length} license files\n`);
-
-  // --- Step 3: Build packages that need it ---
-
-  const BUILD_PACKAGES = new Set(["@effectstream/frontend-sdk"]);
-
-  for (const { name, dir } of packageDirs) {
-    if (!BUILD_PACKAGES.has(name)) continue;
-
-    console.log(`\nBuilding ${name}...`);
-    try {
-      await $`cd ${dir} && bun run build`.quiet();
-      console.log(`  ${name} built ✓`);
-    } catch (e: any) {
-      console.error(`  ${name} build failed ✗`);
-      console.error(`    ${e.stderr?.toString().trim() || e.message}`);
-      restore();
-      printFlags();
-      process.exit(1);
-    }
-  }
-
-  // --- Step 4: Publish ---
-
-  const isPublish = process.argv.includes("--publish");
-  const dryRunArgs = isPublish ? [] : ["--dry-run"];
-
-  console.log(`Running ${isPublish ? "LIVE" : "dry-run"} publish:\n`);
-
-  let failed = 0;
-
-  for (const { name, dir } of packageDirs) {
-    const rel = relative(ROOT, dir);
-    process.stdout.write(`  ${name} (${rel}) ... `);
-
-    try {
-      await $`cd ${dir} && bun publish ${dryRunArgs} --access public --tag ${distTag}`.quiet();
-      console.log("✓");
-    } catch (e: any) {
-      console.log("✗");
-      console.error(`    ${e.stderr?.toString().trim() || e.message}`);
-      failed++;
-    }
-  }
-
-  restore();
-
-  console.log(
-    `\nDone: ${packageDirs.length - failed} ok, ${failed} failed out of ${packageDirs.length} packages.`,
-  );
-
-  if (failed > 0) {
-    printFlags();
-    process.exit(1);
+  return packages;
+}
+function assertCleanTree(root = ROOT): void {
+  const status = Bun.spawnSync(["git", "status", "--porcelain=v1", "--untracked-files=all"], { cwd: root });
+  if (status.exitCode !== 0) throw new Error("git status failed");
+  if (status.stdout.toString().trim()) throw new Error("Uncommitted changes detected");
+}
+function assertPackageInputs(packages: PackageInfo[], currentVersion: string): void {
+  for (const license of LICENSE_FILES) if (!existsSync(join(ROOT, license))) throw new Error(`Missing root ${license}`);
+  for (const pkg of packages) {
+    if (pkg.pkg.version !== currentVersion) throw new Error(`${pkg.name} version ${pkg.pkg.version} differs from root ${currentVersion}`);
+    const readme = join(pkg.dir, "README.md");
+    if (!existsSync(readme)) throw new Error(`Missing README for ${pkg.name}`);
+    if (readFileSync(readme, "utf8").trim().length < MIN_README_CHARS) throw new Error(`README for ${pkg.name} is shorter than ${MIN_README_CHARS} characters`);
   }
 }
+function packageRegistryUrl(registry: string, name: string): string {
+  return `${registry.replace(/\/$/, "")}/${encodeURIComponent(name)}`;
+}
+export async function readRegistryState(registry: string, name: string, targetVersion: string, request: typeof fetch = fetch): Promise<RegistryPackageState> {
+  const response = await request(packageRegistryUrl(registry, name), { headers: { accept: "application/vnd.npm.install-v1+json, application/json" } });
+  if (response.status === 404) return { name, targetIntegrity: null, distTags: {} };
+  if (!response.ok) throw new Error(`Registry query failed for ${name}: HTTP ${response.status}`);
+  const document = (await response.json()) as any;
+  return { name, targetIntegrity: document.versions?.[targetVersion]?.dist?.integrity ?? null, distTags: document["dist-tags"] ?? {} };
+}
+function assertUniformNode2Latest(states: RegistryPackageState[]): Record<string, string> {
+  const snapshot: Record<string, string> = {};
+  const values = new Set<string>();
+  for (const state of states) {
+    const latest = state.distTags.latest;
+    if (!latest) throw new Error(`Registry package ${state.name} has no latest tag`);
+    const parsed = parseSemver(latest);
+    if (parsed.major !== 0n || parsed.minor !== 200n || parsed.prerelease.length || parsed.build.length) throw new Error(`Registry package ${state.name} has invalid latest=${latest}`);
+    values.add(latest);
+    snapshot[state.name] = latest;
+  }
+  if (values.size !== 1) throw new Error("Registry latest tags are not one uniform 0.200.x value");
+  return snapshot;
+}
+export function preflightOrdinary(policy: ReleasePolicy, states: RegistryPackageState[]): Record<string, string> {
+  if (states.length !== EXPECTED_PACKAGE_COUNT) throw new Error(`Preflight expected ${EXPECTED_PACKAGE_COUNT} packages, got ${states.length}`);
+  for (const state of states) if (state.targetIntegrity !== null) throw new Error(`${state.name}@${policy.version} already exists`);
+  const latest = assertUniformNode2Latest(states);
+  if (policy.kind === "node2-stable" && compareSemver(parseSemver(policy.version), parseSemver(Object.values(latest)[0])) <= 0) {
+    throw new Error(`Stable Node-2 target ${policy.version} must be greater than current latest`);
+  }
+  return latest;
+}
+export function verifyLatestPostcondition(manifest: ReleaseManifest, states: RegistryPackageState[]): void {
+  for (const state of states) {
+    const latest = state.distTags.latest;
+    if (manifest.kind === "node2-stable") {
+      if (latest !== manifest.version) throw new Error(`${state.name} latest=${latest ?? "missing"}, expected ${manifest.version}`);
+    } else if (latest !== manifest.latestBefore[state.name]) {
+      throw new Error(`${state.name} latest changed from ${manifest.latestBefore[state.name]} to ${latest ?? "missing"}`);
+    }
+    if (state.distTags[manifest.distTag] !== manifest.version) throw new Error(`${state.name} ${manifest.distTag}=${state.distTags[manifest.distTag] ?? "missing"}, expected ${manifest.version}`);
+  }
+}
+export function planRegistryCompletion(manifest: ReleaseManifest, states: RegistryPackageState[], recovery: boolean): { missing: string[]; existing: string[] } {
+  const byName = new Map(states.map((state) => [state.name, state]));
+  const missing: string[] = [];
+  const existing: string[] = [];
+  for (const pkg of manifest.packages) {
+    const state = byName.get(pkg.name);
+    if (!state || state.targetIntegrity === null) missing.push(pkg.name);
+    else if (state.targetIntegrity === pkg.integrity && recovery) existing.push(pkg.name);
+    else if (state.targetIntegrity === pkg.integrity) throw new Error(`${pkg.name}@${manifest.version} became occupied during ordinary publish`);
+    else throw new Error(`${pkg.name}@${manifest.version} registry integrity differs from artifact`);
+  }
+  return { missing, existing };
+}
+function applyPackManifest(pkg: PackageInfo, version: string): void {
+  const data = JSON.parse(readFileSync(pkg.manifestPath, "utf8"));
+  data.version = version;
+  for (const field of ["dependencies", "devDependencies", "peerDependencies"]) {
+    if (!data[field]) continue;
+    for (const [name, value] of Object.entries(data[field])) {
+      if (typeof value === "string" && value.startsWith("workspace:") && name.startsWith("@effectstream/")) data[field][name] = version;
+    }
+  }
+  if (Array.isArray(data.files)) for (const license of LICENSE_FILES) if (!data.files.includes(license)) data.files.push(license);
+  data.homepage = "https://effectstream.github.io/docs/";
+  data.repository = { type: "git", url: "https://github.com/effectstream/effectstream", directory: pkg.relativeDir };
+  data.bugs = { url: "https://github.com/effectstream/effectstream/issues" };
+  writeFileSync(pkg.manifestPath, `${JSON.stringify(data, null, 2)}\n`);
+}
+function restoreVersionOnly(packages: PackageInfo[], originals: Map<string, string>, version: string, stagedLicenses: string[]): void {
+  for (const pkg of packages) writeFileSync(pkg.manifestPath, setVersionInText(originals.get(pkg.manifestPath)!, version));
+  for (const path of stagedLicenses) if (existsSync(path)) unlinkSync(path);
+}
+
+export async function prepareReleaseBundle(options: {
+  releaseTag: string; sourceSha: string; sourceBranch: string; distTag: string; githubPrerelease: boolean;
+  registry: string; artifactDir: string; runId: string; runAttempt: string;
+}): Promise<ReleaseManifest> {
+  const policy = resolveReleasePolicy(options.releaseTag, options.sourceBranch, options.distTag, options.githubPrerelease);
+  if (!FULL_SHA_RE.test(options.sourceSha)) throw new Error("--source-sha must be a full lowercase SHA");
+  assertCleanTree();
+  const head = (await $`git -C ${ROOT} rev-parse HEAD^{commit}`.text()).trim();
+  if (head !== options.sourceSha) throw new Error(`HEAD ${head} differs from source ${options.sourceSha}`);
+  const rootManifest = join(ROOT, "package.json");
+  const rootOriginal = readFileSync(rootManifest, "utf8");
+  const currentVersion = JSON.parse(rootOriginal).version;
+  resolveReleaseVersion(options.releaseTag, currentVersion);
+  const packages = discoverPackages();
+  assertPackageInputs(packages, currentVersion);
+  const preflightStates = await Promise.all(packages.map((pkg) => readRegistryState(options.registry, pkg.name, policy.version)));
+  const latestBefore = preflightOrdinary(policy, preflightStates);
+  rmSync(options.artifactDir, { recursive: true, force: true });
+  const tarballDir = join(options.artifactDir, "tarballs");
+  mkdirSync(tarballDir, { recursive: true });
+  const originals = new Map<string, string>();
+  const stagedLicenses: string[] = [];
+  for (const pkg of packages) originals.set(pkg.manifestPath, readFileSync(pkg.manifestPath, "utf8"));
+  let prepared = false;
+  try {
+    writeFileSync(rootManifest, setVersionInText(rootOriginal, policy.version));
+    for (const pkg of packages) {
+      applyPackManifest(pkg, policy.version);
+      for (const license of LICENSE_FILES) {
+        const destination = join(pkg.dir, license);
+        if (!existsSync(destination)) { copyFileSync(join(ROOT, license), destination); stagedLicenses.push(destination); }
+      }
+    }
+    const frontend = packages.find((pkg) => pkg.name === "@effectstream/frontend-sdk");
+    if (!frontend) throw new Error("Missing @effectstream/frontend-sdk");
+    await $`bun run build`.cwd(frontend.dir).quiet();
+    const manifestPackages: ManifestPackage[] = [];
+    for (const pkg of packages) {
+      const filename = `${pkg.name.replace(/^@/, "").replaceAll("/", "-")}-${policy.version}.tgz`;
+      await $`bun pm pack --filename ${join(tarballDir, filename)} --gzip-level 9 --quiet`.cwd(pkg.dir).quiet();
+      const tarball = join(tarballDir, filename);
+      const listing = (await $`tar -tzf ${tarball}`.text()).split("\n").filter(Boolean);
+      if (listing.some(isSecretLikeTarEntry)) throw new Error(`Secret-like or auth file found in ${filename}`);
+      const digest = sha512File(tarball);
+      manifestPackages.push({ name: pkg.name, relativeDir: pkg.relativeDir, filename, size: statSync(tarball).size, sha512: digest.hex, integrity: digest.integrity, versionBefore: currentVersion });
+    }
+    const manifest: ReleaseManifest = {
+      schemaVersion: RELEASE_BUNDLE_SCHEMA,
+      releaseTag: policy.releaseTag, version: policy.version, sourceSha: options.sourceSha,
+      branch: policy.branch, distTag: policy.distTag, prerelease: policy.prerelease, kind: policy.kind,
+      workflow: { runId: options.runId, runAttempt: options.runAttempt },
+      toolchain: { bun: Bun.version, platform: `${process.platform}-${process.arch}` },
+      latestBefore, packages: manifestPackages,
+    };
+    writeFileSync(join(options.artifactDir, "manifest.json"), canonicalJson(manifest), { mode: 0o444 });
+    prepared = true;
+    restoreVersionOnly(packages, originals, policy.version, stagedLicenses);
+    return manifest;
+  } finally {
+    if (!prepared) {
+      writeFileSync(rootManifest, rootOriginal);
+      for (const [path, text] of originals) writeFileSync(path, text);
+      for (const path of stagedLicenses) if (existsSync(path)) unlinkSync(path);
+      rmSync(options.artifactDir, { recursive: true, force: true });
+    }
+  }
+}
+
+export function readAndVerifyBundle(artifactDir: string, expectedManifestSha512?: string): ReleaseManifest {
+  const manifestPath = join(artifactDir, "manifest.json");
+  if (!existsSync(manifestPath)) throw new Error("Artifact manifest is missing");
+  const manifestBytes = readFileSync(manifestPath);
+  const manifestDigest = createHash("sha512").update(manifestBytes).digest("hex");
+  if (expectedManifestSha512 && manifestDigest !== expectedManifestSha512) throw new Error("Artifact manifest digest mismatch");
+  const manifest = JSON.parse(manifestBytes.toString("utf8")) as ReleaseManifest;
+  if (manifest.schemaVersion !== RELEASE_BUNDLE_SCHEMA) throw new Error("Unsupported manifest schema");
+  resolveReleasePolicy(manifest.releaseTag, manifest.branch, manifest.distTag, manifest.prerelease);
+  if (!FULL_SHA_RE.test(manifest.sourceSha)) throw new Error("Manifest source SHA is invalid");
+  if (manifest.packages.length !== EXPECTED_PACKAGE_COUNT) throw new Error("Manifest package count is invalid");
+  if (new Set(manifest.packages.map((pkg) => pkg.name)).size !== EXPECTED_PACKAGE_COUNT) throw new Error("Duplicate package in manifest");
+  for (const pkg of manifest.packages) {
+    const path = join(artifactDir, "tarballs", pkg.filename);
+    if (basename(path) !== pkg.filename || !existsSync(path)) throw new Error(`Missing tarball ${pkg.filename}`);
+    if (statSync(path).size !== pkg.size) throw new Error(`Tarball size mismatch for ${pkg.name}`);
+    const digest = sha512File(path);
+    if (digest.hex !== pkg.sha512 || digest.integrity !== pkg.integrity) throw new Error(`Tarball digest mismatch for ${pkg.name}`);
+  }
+  const allowedFiles = ["manifest.json", ...manifest.packages.map((pkg) => `tarballs/${pkg.filename}`)].sort();
+  const actualFiles = ["manifest.json", ...readdirSync(join(artifactDir, "tarballs")).map((name) => `tarballs/${name}`)].sort();
+  if (canonicalJson(readdirSync(artifactDir).sort()) !== canonicalJson(["manifest.json", "tarballs"])) throw new Error("Artifact contains unrelated top-level files");
+  if (canonicalJson(actualFiles) !== canonicalJson(allowedFiles)) throw new Error("Artifact contains missing or unrelated files");
+  return manifest;
+}
+export function assertRecoveryLatestPrecondition(manifest: ReleaseManifest, states: RegistryPackageState[]): void {
+  for (const state of states) {
+    const latest = state.distTags.latest;
+    const before = manifest.latestBefore[state.name];
+    if (!before) throw new Error(`Persisted latest snapshot lacks ${state.name}`);
+    if (manifest.kind === "node2-stable") {
+      if (latest !== before && latest !== manifest.version) throw new Error(`${state.name} latest is neither persisted pre-state nor target`);
+    } else if (latest !== before) throw new Error(`${state.name} latest differs from persisted snapshot`);
+  }
+}
+async function setDistTag(name: string, version: string, distTag: string, registry: string): Promise<void> {
+  const token = process.env.NPM_TOKEN ?? process.env.BUN_AUTH_TOKEN;
+  if (!token) throw new Error("NPM_TOKEN is required to set dist-tags");
+  const response = await fetch(
+    `${registry.replace(/\/$/, "")}/-/package/${encodeURIComponent(name)}/dist-tags/${encodeURIComponent(distTag)}`,
+    {
+      method: "PUT",
+      headers: {
+        authorization: `Bearer ${token}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify(version),
+    },
+  );
+  if (!response.ok) throw new Error(`Failed to set ${name} ${distTag}: HTTP ${response.status}`);
+}
+export async function publishFromBundle(options: { artifactDir: string; registry: string; recovery: boolean; publish: boolean; manifestSha512?: string }): Promise<{ published: string[]; skipped: string[] }> {
+  const manifest = readAndVerifyBundle(options.artifactDir, options.manifestSha512);
+  const states = await Promise.all(manifest.packages.map((pkg) => readRegistryState(options.registry, pkg.name, manifest.version)));
+  if (options.recovery) assertRecoveryLatestPrecondition(manifest, states);
+  const completion = planRegistryCompletion(manifest, states, options.recovery);
+  const published: string[] = [];
+  const results: { name: string; status: string }[] = completion.existing.map((name) => ({ name, status: "skipped-exact" }));
+  const writeResults = () => writeFileSync(`${options.artifactDir}.publish-result.json`, canonicalJson({ releaseTag: manifest.releaseTag, sourceSha: manifest.sourceSha, recovery: options.recovery, packages: results }));
+  for (const name of completion.missing) {
+    const pkg = manifest.packages.find((candidate) => candidate.name === name)!;
+    if (options.publish) {
+      const proc = Bun.spawn(["bun", "publish", "--access", "public", "--tag", manifest.distTag, "--registry", options.registry, join(options.artifactDir, "tarballs", pkg.filename)], { cwd: ROOT, stdout: "inherit", stderr: "inherit", env: process.env });
+      if ((await proc.exited) !== 0) {
+        results.push({ name, status: "failed" });
+        writeResults();
+        throw new Error(`Publish failed for ${name}; stopping`);
+      }
+    }
+    published.push(name);
+    results.push({ name, status: options.publish ? "published" : "would-publish" });
+    writeResults();
+  }
+  if (!options.publish) return { published, skipped: completion.existing };
+  const complete = await Promise.all(manifest.packages.map((pkg) => readRegistryState(options.registry, pkg.name, manifest.version)));
+  for (const pkg of manifest.packages) {
+    const state = complete.find((candidate) => candidate.name === pkg.name)!;
+    if (state.targetIntegrity !== pkg.integrity) throw new Error(`Post-publish integrity mismatch for ${pkg.name}`);
+  }
+  for (const pkg of manifest.packages) await setDistTag(pkg.name, manifest.version, manifest.distTag, options.registry);
+  const post = await Promise.all(manifest.packages.map((pkg) => readRegistryState(options.registry, pkg.name, manifest.version)));
+  verifyLatestPostcondition(manifest, post);
+  return { published, skipped: completion.existing };
+}
+
+export type RecoveryMode = "partial-tag" | "complete-tag" | "partial-advanced" | "complete-advanced";
+export function classifyRecoveryMode(partial: boolean, advanced: boolean): RecoveryMode {
+  return `${partial ? "partial" : "complete"}-${advanced ? "advanced" : "tag"}` as RecoveryMode;
+}
+export function validateRecoveryBranchState(
+  manifest: ReleaseManifest,
+  mode: RecoveryMode,
+  head: string,
+  sourceIsAncestor: boolean,
+  currentVersions: string[],
+): void {
+  if (!FULL_SHA_RE.test(head)) throw new Error("Expected current branch SHA is invalid");
+  const advanced = mode.endsWith("advanced");
+  if (!advanced && head !== manifest.sourceSha) throw new Error("Tag-state recovery requires branch at source SHA");
+  if (advanced && head === manifest.sourceSha) throw new Error("Advanced recovery requires an advanced branch");
+  if (advanced && !sourceIsAncestor) throw new Error("Advanced branch does not descend from release source");
+  const expectedBefore = manifest.packages[0].versionBefore;
+  if (currentVersions.some((version) => version !== expectedBefore)) throw new Error("Version drift in recovery branch");
+}
+async function applyRecoveryVersionDelta(manifest: ReleaseManifest, mode: RecoveryMode, expectedCurrentBranchSha: string): Promise<void> {
+  if (!FULL_SHA_RE.test(expectedCurrentBranchSha)) throw new Error("Expected current branch SHA is invalid");
+  const head = (await $`git -C ${ROOT} rev-parse HEAD^{commit}`.text()).trim();
+  if (head !== expectedCurrentBranchSha) throw new Error(`Current HEAD ${head} differs from approved ${expectedCurrentBranchSha}`);
+  const rootPath = join(ROOT, "package.json");
+  const packageByName = new Map(discoverPackages().map((pkg) => [pkg.name, pkg]));
+  const versionFiles = [rootPath, ...manifest.packages.map((pkg) => packageByName.get(pkg.name)?.manifestPath ?? "")];
+  if (versionFiles.some((path) => !path)) throw new Error("Current branch package set differs from artifact");
+  const currentVersions = versionFiles.map((path) => JSON.parse(readFileSync(path, "utf8")).version as string);
+  const sourceIsAncestor = Bun.spawnSync(["git", "merge-base", "--is-ancestor", manifest.sourceSha, head], { cwd: ROOT }).exitCode === 0;
+  validateRecoveryBranchState(manifest, mode, head, sourceIsAncestor, currentVersions);
+  for (const path of versionFiles) writeFileSync(path, setVersionInText(readFileSync(path, "utf8"), manifest.version));
+}
+
+async function cli(): Promise<void> {
+  const registry = getFlagValue("--registry") ?? "https://registry.npmjs.org";
+  if (process.argv.includes("--policy")) {
+    console.log(canonicalJson(resolveReleasePolicy(requireFlag("--release-tag"), getFlagValue("--source-branch"), getFlagValue("--dist-tag"), getFlagValue("--github-prerelease") === undefined ? undefined : getFlagValue("--github-prerelease") === "true")).trim());
+    return;
+  }
+  if (process.argv.includes("--prepare")) {
+    const artifactDir = requireFlag("--artifact-dir");
+    const manifest = await prepareReleaseBundle({
+      releaseTag: requireFlag("--release-tag"), sourceSha: requireFlag("--source-sha"), sourceBranch: requireFlag("--source-branch"), distTag: requireFlag("--dist-tag"), githubPrerelease: requireFlag("--github-prerelease") === "true",
+      registry, artifactDir, runId: requireFlag("--run-id"), runAttempt: requireFlag("--run-attempt"),
+    });
+    const manifestSha512 = sha512File(join(artifactDir, "manifest.json")).hex;
+    if (process.env.GITHUB_OUTPUT) writeFileSync(process.env.GITHUB_OUTPUT, `manifest-sha512=${manifestSha512}\npackage-count=${manifest.packages.length}\nartifact-name=release-${manifest.releaseTag}-${manifest.sourceSha}-${manifest.workflow.runId}\n`, { flag: "a" });
+    console.log(`Prepared ${manifest.packages.length} exact tarballs; manifest sha512=${manifestSha512}`);
+    return;
+  }
+  if (process.argv.includes("--publish-bundle")) {
+    console.log(canonicalJson(await publishFromBundle({ artifactDir: requireFlag("--artifact-dir"), registry, recovery: false, publish: process.argv.includes("--publish"), manifestSha512: getFlagValue("--manifest-sha512") })).trim());
+    return;
+  }
+  if (process.argv.includes("--recover-bundle")) {
+    const auditRef = requireFlag("--audit-ref");
+    const authorizationRef = requireFlag("--authorization-ref");
+    const artifactDir = requireFlag("--artifact-dir");
+    const manifestSha512 = requireFlag("--manifest-sha512");
+    const manifest = readAndVerifyBundle(artifactDir, manifestSha512);
+    const states = await Promise.all(manifest.packages.map((pkg) => readRegistryState(registry, pkg.name, manifest.version)));
+    assertRecoveryLatestPrecondition(manifest, states);
+    const completion = planRegistryCompletion(manifest, states, true);
+    const expectedCurrentBranchSha = requireFlag("--expected-current-branch-sha");
+    const observed = classifyRecoveryMode(completion.missing.length > 0, expectedCurrentBranchSha !== manifest.sourceSha);
+    const requested = requireFlag("--recovery-mode") as RecoveryMode;
+    if (requested !== observed) throw new Error(`Recovery mode ${requested} differs from observed ${observed}`);
+    const result = await publishFromBundle({ artifactDir, registry, recovery: true, publish: process.argv.includes("--publish"), manifestSha512 });
+    if (process.argv.includes("--publish")) await applyRecoveryVersionDelta(manifest, requested, expectedCurrentBranchSha);
+    const final = { originalRunId: manifest.workflow.runId, recoveryRunId: process.env.GITHUB_RUN_ID ?? "local", artifactId: getFlagValue("--artifact-id") ?? "local", serviceDigest: getFlagValue("--service-digest") ?? "local", manifestSha512, recoveryMode: requested, releaseTag: manifest.releaseTag, version: manifest.version, branch: manifest.branch, distTag: manifest.distTag, published: result.published, skipped: result.skipped, sourceSha: manifest.sourceSha, currentBranchSha: expectedCurrentBranchSha, latestPostcondition: process.argv.includes("--publish") ? "verified" : "dry-run", auditRef, authorizationRef };
+    writeFileSync(`${artifactDir}.recovery-result.json`, canonicalJson(final));
+    console.log(canonicalJson(final).trim());
+    return;
+  }
+  throw new Error("Choose exactly one of --policy, --prepare, --publish-bundle, or --recover-bundle");
+}
+
+if (import.meta.main) cli().catch((error) => {
+  console.error(`release publisher failed: ${error instanceof Error ? error.message : error}`);
+  process.exit(1);
+});

--- a/.github/release-recovery.test.ts
+++ b/.github/release-recovery.test.ts
@@ -107,6 +107,12 @@ describe("recovery authorization and branch protections", () => {
     expect(workflow).toContain('git push origin "HEAD:refs/heads/$SOURCE_BRANCH"');
     expect(workflow).not.toContain("git push --force");
     expect(workflow).not.toContain("--force-with-lease");
+    const compatibility = workflow.indexOf("Validate recovery branch compatibility before authentication or mutation");
+    const auth = workflow.indexOf("Configure npm auth after all artifact and source checks");
+    const mutation = workflow.indexOf("Complete exact artifact publication and apply version delta");
+    expect(compatibility).toBeGreaterThan(0);
+    expect(compatibility).toBeLessThan(auth);
+    expect(auth).toBeLessThan(mutation);
   });
 
   test("read-only proof cannot fall through to recovery mutation", () => {

--- a/.github/release-recovery.test.ts
+++ b/.github/release-recovery.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "fs";
+import { join } from "path";
+import {
+  classifyRecoveryMode,
+  planRegistryCompletion,
+  resolveReleasePolicy,
+  validateRecoveryBranchState,
+  type RegistryPackageState,
+  type ReleaseManifest,
+} from "./publish-bun.effectstream";
+
+function fixture(tag: string): ReleaseManifest {
+  const policy = resolveReleasePolicy(tag);
+  const packages = Array.from({ length: 39 }, (_, index) => ({
+    name: `@effectstream/recovery-${index}`,
+    relativeDir: `packages/${index}`,
+    filename: `${index}.tgz`,
+    size: index,
+    sha512: `hex-${index}`,
+    integrity: `sha512-${index}`,
+    versionBefore: policy.kind === "maintenance-stable" ? "0.104.1" : "0.200.2",
+  }));
+  return {
+    schemaVersion: 1,
+    releaseTag: policy.releaseTag,
+    version: policy.version,
+    sourceSha: "a".repeat(40),
+    branch: policy.branch,
+    distTag: policy.distTag,
+    prerelease: policy.prerelease,
+    kind: policy.kind,
+    workflow: { runId: "11", runAttempt: "1" },
+    toolchain: { bun: "1.4.0", platform: "linux-x64" },
+    latestBefore: Object.fromEntries(packages.map((pkg) => [pkg.name, "0.200.2"])),
+    packages,
+  };
+}
+
+function registry(manifest: ReleaseManifest, partial: boolean): RegistryPackageState[] {
+  return manifest.packages.map((pkg, index) => ({
+    name: pkg.name,
+    targetIntegrity: partial && index > 4 ? null : pkg.integrity,
+    distTags: {
+      latest: manifest.kind === "node2-stable" && !partial ? manifest.version : "0.200.2",
+      [manifest.distTag]: manifest.version,
+    },
+  }));
+}
+
+describe("all release kinds and recovery states", () => {
+  test.each(["v0.104.2", "v0.200.3", "v0.200.3-rc.1"])(
+    "%s uses exact persisted occupancy in all four states",
+    (tag) => {
+      const manifest = fixture(tag);
+      for (const partial of [true, false]) {
+        for (const advanced of [false, true]) {
+          const completion = planRegistryCompletion(manifest, registry(manifest, partial), true);
+          expect(classifyRecoveryMode(completion.missing.length > 0, advanced)).toBe(
+            `${partial ? "partial" : "complete"}-${advanced ? "advanced" : "tag"}`,
+          );
+          expect(completion.missing.length).toBe(partial ? 34 : 0);
+          expect(completion.existing.length).toBe(partial ? 5 : 39);
+        }
+      }
+    },
+  );
+
+  test.each(["v0.104.2", "v0.200.3", "v0.200.3-rc.1"])(
+    "%s validates tag/advanced ancestry and unchanged versions",
+    (tag) => {
+      const manifest = fixture(tag);
+      const versions = Array(40).fill(manifest.packages[0].versionBefore);
+      expect(() => validateRecoveryBranchState(manifest, "partial-tag", manifest.sourceSha, true, versions)).not.toThrow();
+      expect(() => validateRecoveryBranchState(manifest, "complete-tag", manifest.sourceSha, true, versions)).not.toThrow();
+      expect(() => validateRecoveryBranchState(manifest, "partial-advanced", "b".repeat(40), true, versions)).not.toThrow();
+      expect(() => validateRecoveryBranchState(manifest, "complete-advanced", "b".repeat(40), true, versions)).not.toThrow();
+      expect(() => validateRecoveryBranchState(manifest, "partial-tag", "b".repeat(40), true, versions)).toThrow(/Tag-state/);
+      expect(() => validateRecoveryBranchState(manifest, "partial-advanced", "b".repeat(40), false, versions)).toThrow(/does not descend/);
+      expect(() => validateRecoveryBranchState(manifest, "complete-advanced", "b".repeat(40), true, [...versions.slice(0, 2), "9.9.9", ...versions.slice(3)])).toThrow(/Version drift/);
+    },
+  );
+});
+
+describe("recovery authorization and branch protections", () => {
+  const workflow = readFileSync(
+    join(import.meta.dir, "workflows", "release-recovery.yaml"),
+    "utf8",
+  );
+
+  test("requires exact state, artifact, audit, authorization, and branch inputs", () => {
+    for (const input of [
+      "recovery_mode",
+      "original_run_id",
+      "artifact_id",
+      "expected_service_digest",
+      "manifest_sha512",
+      "release_tag",
+      "source_sha",
+      "expected_current_branch_sha",
+      "approval_refs",
+    ]) {
+      expect(workflow).toContain(`${input}:`);
+    }
+    expect(workflow).toContain("environment: npm-release-recovery");
+    expect(workflow).toContain("git merge-base --is-ancestor");
+    expect(workflow).toContain('git push origin "HEAD:refs/heads/$SOURCE_BRANCH"');
+    expect(workflow).not.toContain("git push --force");
+    expect(workflow).not.toContain("--force-with-lease");
+  });
+
+  test("read-only proof cannot fall through to recovery mutation", () => {
+    expect(workflow).toContain("if: ${{ inputs.recovery_mode == 'artifact-proof' }}");
+    expect(workflow).toContain("if: ${{ inputs.recovery_mode != 'artifact-proof' }}");
+    const proof = workflow.slice(workflow.indexOf("  artifact-proof:"), workflow.indexOf("  recover:"));
+    expect(proof).not.toContain("NPM_TOKEN");
+    expect(proof).not.toContain("contents: write");
+    expect(proof).not.toContain("environment:");
+  });
+});

--- a/.github/verify-release-source.sh
+++ b/.github/verify-release-source.sh
@@ -9,40 +9,93 @@ fail() {
 
 release_tag="${RELEASE_TAG:-}"
 release_target="${RELEASE_TARGET_COMMITISH:-}"
+github_prerelease="${RELEASE_PRERELEASE:-}"
 
 test -n "$release_tag" || fail "RELEASE_TAG is required"
-git check-ref-format "refs/tags/$release_tag" >/dev/null 2>&1 \
-  || fail "release tag is not a valid Git tag name: $release_tag"
 [[ "$release_target" =~ ^[0-9a-f]{40}$ ]] \
   || fail "release.target_commitish must be an exact lowercase 40-character commit SHA"
+[[ "$github_prerelease" == "true" || "$github_prerelease" == "false" ]] \
+  || fail "RELEASE_PRERELEASE must be exactly true or false"
+git check-ref-format "refs/tags/$release_tag" >/dev/null 2>&1 \
+  || fail "release tag is not a valid Git tag name: $release_tag"
+
+semver_re='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?(\+([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?$'
+[[ "$release_tag" =~ $semver_re ]] || fail "release tag must be strict vMAJOR.MINOR.PATCH SemVer"
+major="${BASH_REMATCH[1]}"
+minor="${BASH_REMATCH[2]}"
+patch="${BASH_REMATCH[3]}"
+prerelease="${BASH_REMATCH[5]:-}"
+build="${BASH_REMATCH[8]:-}"
+test -z "$build" || fail "build metadata is not supported"
+if [[ -n "$prerelease" ]]; then
+  IFS='.' read -r -a prerelease_parts <<< "$prerelease"
+  for part in "${prerelease_parts[@]}"; do
+    test -n "$part" || fail "empty prerelease identifier"
+    if [[ "$part" =~ ^[0-9]+$ && "$part" != "0" && "$part" == 0* ]]; then
+      fail "numeric prerelease identifiers may not have leading zeroes"
+    fi
+  done
+fi
+
+test "$major" = "0" || fail "unsupported release major $major"
+if [[ "$minor" == "104" && -z "$prerelease" ]]; then
+  mapped_branch="midnight-1"
+  mapped_dist_tag="midnight-1"
+  mapped_kind="maintenance-stable"
+  expected_prerelease="false"
+elif [[ "$minor" == "200" && -z "$prerelease" ]]; then
+  mapped_branch="v-next"
+  mapped_dist_tag="latest"
+  mapped_kind="node2-stable"
+  expected_prerelease="false"
+elif [[ "$minor" == "200" && -n "$prerelease" ]]; then
+  mapped_branch="v-next"
+  mapped_dist_tag="next"
+  mapped_kind="node2-prerelease"
+  expected_prerelease="true"
+elif [[ "$minor" == "104" ]]; then
+  fail "maintenance prereleases are not supported"
+else
+  fail "unsupported release family 0.$minor.x"
+fi
+test "$github_prerelease" = "$expected_prerelease" \
+  || fail "GitHub prerelease metadata disagrees with $release_tag"
 
 if git symbolic-ref -q HEAD >/dev/null 2>&1; then
   fail "HEAD must be detached at the immutable release commit"
 fi
 
-# Refresh both identities from the authoritative remote. The explicit refspecs
-# support lightweight and annotated tags while ensuring origin/v-next is fresh.
+# Fetch exactly the policy-selected tag and branch. Neither target_commitish nor
+# another event field can select a source branch or npm channel.
 git fetch --force --no-tags origin \
   "+refs/tags/$release_tag:refs/tags/$release_tag" \
-  "+refs/heads/v-next:refs/remotes/origin/v-next"
+  "+refs/heads/$mapped_branch:refs/remotes/origin/$mapped_branch"
 
 head_commit="$(git rev-parse --verify 'HEAD^{commit}')" \
   || fail "checked-out HEAD is not a commit"
 tag_commit="$(git rev-parse --verify "refs/tags/$release_tag^{commit}")" \
   || fail "release tag does not peel to a commit: $release_tag"
-branch_commit="$(git rev-parse --verify 'refs/remotes/origin/v-next^{commit}')" \
-  || fail "freshly fetched origin/v-next is not a commit"
-
+branch_commit="$(git rev-parse --verify "refs/remotes/origin/$mapped_branch^{commit}")" \
+  || fail "freshly fetched origin/$mapped_branch is not a commit"
 for resolved_commit in "$head_commit" "$tag_commit" "$branch_commit"; do
   [[ "$resolved_commit" =~ ^[0-9a-f]{40}$ ]] \
     || fail "Git resolved a non-full commit identity: $resolved_commit"
 done
-
 test "$head_commit" = "$release_target" \
   || fail "checked-out HEAD $head_commit does not equal release target $release_target"
 test "$tag_commit" = "$release_target" \
   || fail "peeled release tag $tag_commit does not equal release target $release_target"
 test "$branch_commit" = "$release_target" \
-  || fail "origin/v-next $branch_commit does not equal release target $release_target"
+  || fail "origin/$mapped_branch $branch_commit does not equal release target $release_target"
 
-printf 'release source guard passed: HEAD=tag=target=origin/v-next=%s\n' "$release_target"
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  {
+    printf 'branch=%s\n' "$mapped_branch"
+    printf 'dist-tag=%s\n' "$mapped_dist_tag"
+    printf 'version=%s.%s.%s%s\n' "$major" "$minor" "$patch" "${prerelease:+-$prerelease}"
+    printf 'release-kind=%s\n' "$mapped_kind"
+    printf 'source-sha=%s\n' "$release_target"
+  } >> "$GITHUB_OUTPUT"
+fi
+printf 'release source guard passed: HEAD=tag=target=origin/%s=%s; dist-tag=%s\n' \
+  "$mapped_branch" "$release_target" "$mapped_dist_tag"

--- a/.github/verify-release-source.test.sh
+++ b/.github/verify-release-source.test.sh
@@ -6,129 +6,128 @@ test_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 guard="$test_dir/verify-release-source.sh"
 temp_root="$(mktemp -d "${TMPDIR:-/tmp}/effectstream-release-source-test.XXXXXX")"
 trap 'rm -rf "$temp_root"' EXIT
-
 origin="$temp_root/origin.git"
 seed="$temp_root/seed"
-
 git init --bare --quiet "$origin"
 git init --quiet "$seed"
-git -C "$seed" config user.name "release source test"
-git -C "$seed" config user.email "release-source-test@example.invalid"
-git -C "$seed" checkout -b v-next >/dev/null 2>&1
-printf 'release candidate\n' > "$seed/package.txt"
+git -C "$seed" config user.name 'release source test'
+git -C "$seed" config user.email 'release-source-test@example.invalid'
+
+git -C "$seed" checkout -b midnight-1 >/dev/null 2>&1
+printf 'midnight node 1\n' > "$seed/package.txt"
 git -C "$seed" add package.txt
-git -C "$seed" commit --quiet -m "release candidate"
-candidate="$(git -C "$seed" rev-parse HEAD)"
+git -C "$seed" commit --quiet -m 'maintenance candidate'
+maintenance="$(git -C "$seed" rev-parse HEAD)"
+git -C "$seed" tag v0.104.2 "$maintenance"
+git -C "$seed" tag -a v0.104.3 -m maintenance-annotated "$maintenance"
+
+git -C "$seed" checkout --orphan v-next >/dev/null 2>&1
+git -C "$seed" rm -rf --quiet .
+printf 'midnight node 2\n' > "$seed/package.txt"
+git -C "$seed" add package.txt
+git -C "$seed" commit --quiet -m 'node2 candidate'
+node2="$(git -C "$seed" rev-parse HEAD)"
+git -C "$seed" tag v0.200.3 "$node2"
+git -C "$seed" tag -a v0.200.4 -m node2-annotated "$node2"
+git -C "$seed" tag v0.200.5-rc.1 "$node2"
 git -C "$seed" remote add origin "$origin"
-git -C "$seed" push --quiet origin v-next
+git -C "$seed" push --quiet origin midnight-1 v-next --tags
 git --git-dir="$origin" symbolic-ref HEAD refs/heads/v-next
 
-git -C "$seed" tag v-light-ok "$candidate"
-git -C "$seed" tag -a v-annotated-ok -m "annotated release" "$candidate"
-
-git -C "$seed" checkout -b mismatch >/dev/null 2>&1
-printf 'different commit\n' >> "$seed/package.txt"
-git -C "$seed" commit --quiet -am "different commit"
-mismatch="$(git -C "$seed" rev-parse HEAD)"
-git -C "$seed" tag v-light-mismatch "$mismatch"
-git -C "$seed" tag -a v-annotated-mismatch -m "annotated mismatch" "$mismatch"
-git -C "$seed" push --quiet origin \
-  refs/tags/v-light-ok \
-  refs/tags/v-annotated-ok \
-  refs/tags/v-light-mismatch \
-  refs/tags/v-annotated-mismatch
-
-reset_branch() {
-  git --git-dir="$origin" update-ref refs/heads/v-next "$candidate"
-}
-
 new_runner() {
-  runner_name="$1"
-  runner_head="$2"
-  runner="$temp_root/$runner_name"
+  local name="$1" head="$2"
+  local runner="$temp_root/$name"
   git clone --quiet --no-tags "$origin" "$runner"
-  git -C "$runner" checkout --quiet --detach "$runner_head"
+  git -C "$runner" checkout --quiet --detach "$head"
   printf '%s\n' "$runner"
 }
 
 expect_pass() {
-  case_name="$1"
-  release_tag="$2"
-  release_target="$3"
-  runner_head="$4"
-  reset_branch
-  runner="$(new_runner "$case_name" "$runner_head")"
+  local name="$1" tag="$2" target="$3" head="$4" prerelease="$5" branch="$6" dist_tag="$7"
+  local runner output
+  runner="$(new_runner "$name" "$head")"
+  output="$temp_root/$name.outputs"
   (
     cd "$runner"
-    RELEASE_TAG="$release_tag" \
-      RELEASE_TARGET_COMMITISH="$release_target" \
-      bash "$guard"
-  ) > "$temp_root/$case_name.log" 2>&1
+    RELEASE_TAG="$tag" RELEASE_TARGET_COMMITISH="$target" RELEASE_PRERELEASE="$prerelease" \
+      GITHUB_OUTPUT="$output" bash "$guard"
+  ) > "$temp_root/$name.log" 2>&1
+  grep -qx "branch=$branch" "$output"
+  grep -qx "dist-tag=$dist_tag" "$output"
+  grep -qx "source-sha=$target" "$output"
 }
 
 expect_fail() {
-  case_name="$1"
-  release_tag="$2"
-  release_target="$3"
-  runner_head="$4"
-  reset_branch
-  runner="$(new_runner "$case_name" "$runner_head")"
+  local name="$1" tag="$2" target="$3" head="$4" prerelease="$5"
+  local runner output
+  runner="$(new_runner "$name" "$head")"
+  output="$temp_root/$name.outputs"
   if (
     cd "$runner"
-    RELEASE_TAG="$release_tag" \
-      RELEASE_TARGET_COMMITISH="$release_target" \
-      bash "$guard"
-  ) > "$temp_root/$case_name.log" 2>&1; then
-    printf 'expected guard failure for %s\n' "$case_name" >&2
+    RELEASE_TAG="$tag" RELEASE_TARGET_COMMITISH="$target" RELEASE_PRERELEASE="$prerelease" \
+      GITHUB_OUTPUT="$output" bash "$guard"
+  ) > "$temp_root/$name.log" 2>&1; then
+    printf 'expected guard failure for %s\n' "$name" >&2
+    exit 1
+  fi
+  test ! -s "$output"
+}
+
+expect_pass maintenance-light v0.104.2 "$maintenance" "$maintenance" false midnight-1 midnight-1
+expect_pass maintenance-annotated v0.104.3 "$maintenance" "$maintenance" false midnight-1 midnight-1
+expect_pass node2-light v0.200.3 "$node2" "$node2" false v-next latest
+expect_pass node2-annotated v0.200.4 "$node2" "$node2" false v-next latest
+expect_pass node2-prerelease v0.200.5-rc.1 "$node2" "$node2" true v-next next
+
+expect_fail swapped-maintenance v0.104.2 "$node2" "$node2" false
+expect_fail swapped-node2 v0.200.3 "$maintenance" "$maintenance" false
+expect_fail metadata-stable v0.200.3 "$node2" "$node2" true
+expect_fail metadata-prerelease v0.200.5-rc.1 "$node2" "$node2" false
+expect_fail maintenance-prerelease v0.104.3-rc.1 "$maintenance" "$maintenance" true
+expect_fail build-metadata v0.200.3+build.1 "$node2" "$node2" false
+expect_fail unsupported-low v0.103.999 "$node2" "$node2" false
+expect_fail unsupported-high v0.201.0 "$node2" "$node2" false
+expect_fail leading-zero v0.0200.3 "$node2" "$node2" false
+expect_fail prerelease-leading-zero v0.200.3-rc.01 "$node2" "$node2" true
+expect_fail malformed-tag release-0.200.3 "$node2" "$node2" false
+expect_fail short-target v0.200.3 "${node2:0:12}" "$node2" false
+expect_fail uppercase-target v0.200.3 "$(tr '[:lower:]' '[:upper:]' <<< "$node2")" "$node2" false
+expect_fail head-mismatch v0.200.3 "$node2" "$maintenance" false
+
+# Missing mapped branch and fresh branch advance both fail with empty outputs.
+git --git-dir="$origin" update-ref -d refs/heads/midnight-1
+expect_fail missing-branch v0.104.2 "$maintenance" "$maintenance" false
+git --git-dir="$origin" update-ref refs/heads/midnight-1 "$maintenance"
+git --git-dir="$origin" update-ref refs/heads/v-next "$maintenance"
+expect_fail stale-branch-head v0.200.3 "$node2" "$node2" false
+git --git-dir="$origin" update-ref refs/heads/v-next "$node2"
+
+race_branch() {
+  local branch="$1" tag="$2" target="$3" prerelease="$4" name="$5"
+  local runner concurrent
+  runner="$(new_runner "$name-runner" "$target")"
+  (
+    cd "$runner"
+    RELEASE_TAG="$tag" RELEASE_TARGET_COMMITISH="$target" RELEASE_PRERELEASE="$prerelease" bash "$guard"
+    git config user.name runner
+    git config user.email runner@example.invalid
+    printf 'version\n' >> package.txt
+    git commit --quiet -am version
+  )
+  concurrent="$(new_runner "$name-concurrent" "$target")"
+  git -C "$concurrent" config user.name concurrent
+  git -C "$concurrent" config user.email concurrent@example.invalid
+  printf 'advance\n' >> "$concurrent/package.txt"
+  git -C "$concurrent" commit --quiet -am advance
+  git -C "$concurrent" push --quiet origin "HEAD:refs/heads/$branch"
+  if git -C "$runner" push origin "HEAD:refs/heads/$branch" > "$temp_root/$name-push.log" 2>&1; then
+    printf 'expected non-fast-forward race rejection for %s\n' "$branch" >&2
     exit 1
   fi
 }
 
-expect_pass lightweight-positive v-light-ok "$candidate" "$candidate"
-expect_pass annotated-positive v-annotated-ok "$candidate" "$candidate"
-expect_fail malformed-target v-light-ok v-next "$candidate"
-expect_fail tag-mismatch v-light-mismatch "$candidate" "$candidate"
-expect_fail detached-head-mismatch v-light-ok "$candidate" "$mismatch"
+race_branch v-next v0.200.3 "$node2" false node2-race
+git --git-dir="$origin" update-ref refs/heads/midnight-1 "$maintenance"
+race_branch midnight-1 v0.104.2 "$maintenance" false maintenance-race
 
-git --git-dir="$origin" update-ref refs/heads/v-next "$mismatch"
-runner="$(new_runner branch-mismatch "$candidate")"
-if (
-  cd "$runner"
-  RELEASE_TAG=v-light-ok RELEASE_TARGET_COMMITISH="$candidate" bash "$guard"
-) > "$temp_root/branch-mismatch.log" 2>&1; then
-  printf 'expected guard failure for branch-mismatch\n' >&2
-  exit 1
-fi
-
-expect_fail annotated-tag-mismatch v-annotated-mismatch "$candidate" "$candidate"
-
-# Prove that the exact post-publication push is non-force and rejects a branch
-# advance that occurs after a successful identity guard.
-reset_branch
-runner="$(new_runner branch-advance "$candidate")"
-(
-  cd "$runner"
-  RELEASE_TAG=v-light-ok RELEASE_TARGET_COMMITISH="$candidate" bash "$guard"
-  git config user.name "release runner"
-  git config user.email "release-runner@example.invalid"
-  printf 'version bump\n' >> package.txt
-  git commit --quiet -am "version bump"
-)
-
-concurrent="$temp_root/concurrent"
-git clone --quiet --no-tags "$origin" "$concurrent"
-git -C "$concurrent" config user.name "concurrent writer"
-git -C "$concurrent" config user.email "concurrent-writer@example.invalid"
-printf 'concurrent advance\n' >> "$concurrent/package.txt"
-git -C "$concurrent" commit --quiet -am "concurrent advance"
-concurrent_commit="$(git -C "$concurrent" rev-parse HEAD)"
-git -C "$concurrent" push --quiet origin HEAD:refs/heads/v-next
-
-if git -C "$runner" push origin HEAD:refs/heads/v-next \
-  > "$temp_root/branch-advance-push.log" 2>&1; then
-  printf 'expected non-fast-forward release push rejection\n' >&2
-  exit 1
-fi
-test "$(git --git-dir="$origin" rev-parse refs/heads/v-next)" = "$concurrent_commit"
-
-printf 'release source guard matrix passed: 2 positives, 5 mismatch negatives, 1 non-fast-forward race\n'
+printf 'release source guard matrix passed: 5 positives, 16 fail-closed negatives, 2 non-fast-forward races\n'

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -4,7 +4,7 @@
 # pre-merge run (rather than duplicating every same-repository branch push).
 on:
   push:
-    branches: [v-next]
+    branches: [v-next, midnight-1]
   pull_request:
     # Expensive jobs skip drafts. Re-run when a draft becomes reviewable, and
     # cancel an in-progress run through the PR-scoped concurrency group when a
@@ -50,6 +50,7 @@ jobs:
           HEAD_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           HEAD_REF: ${{ github.ref_name }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          LONG_LIVED_BRANCHES: v-next,midnight-1
         run: bun .github/ci-changes.ts
 
   # Existing Dockerized e2e suite — now gated on core changes.

--- a/.github/workflows/release-artifact-rehearsal.yaml
+++ b/.github/workflows/release-artifact-rehearsal.yaml
@@ -1,0 +1,56 @@
+on:
+  workflow_dispatch:
+
+name: Effectstream Release Artifact Rehearsal
+
+permissions:
+  contents: read
+
+jobs:
+  upload-proof:
+    permissions:
+      contents: read
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    steps:
+      - name: Build deterministic secret-free synthetic bundle
+        id: prepare
+        shell: bash
+        run: |
+          set -euo pipefail
+          proof_dir='${{ runner.temp }}/effectstream-artifact-proof'
+          mkdir -p "$proof_dir"
+          printf 'effectstream-artifact-cross-run-proof-v1\n' > "$proof_dir/payload.txt"
+          payload_sha="$(sha256sum "$proof_dir/payload.txt" | awk '{print $1}')"
+          printf '{"payload":"payload.txt","schemaVersion":1,"sha256":"%s"}\n' "$payload_sha" > "$proof_dir/manifest.json"
+          manifest_sha="$(sha256sum "$proof_dir/manifest.json" | awk '{print $1}')"
+          echo "payload-sha256=$payload_sha" >> "$GITHUB_OUTPUT"
+          echo "manifest-sha256=$manifest_sha" >> "$GITHUB_OUTPUT"
+
+      - name: Upload immutable rehearsal artifact
+        id: upload
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: release-artifact-proof-${{ github.run_id }}
+          path: ${{ runner.temp }}/effectstream-artifact-proof
+          if-no-files-found: error
+          retention-days: 90
+          compression-level: 0
+
+      - name: Record proof identity for independent consumer run
+        shell: bash
+        env:
+          PRODUCER_RUN_ID: ${{ github.run_id }}
+          ARTIFACT_ID: ${{ steps.upload.outputs.artifact-id }}
+          SERVICE_DIGEST: ${{ steps.upload.outputs.artifact-digest }}
+          MANIFEST_SHA256: ${{ steps.prepare.outputs.manifest-sha256 }}
+          PAYLOAD_SHA256: ${{ steps.prepare.outputs.payload-sha256 }}
+        run: |
+          {
+            echo '### Hosted artifact proof producer'
+            echo "- producer run ID: $PRODUCER_RUN_ID"
+            echo "- immutable artifact ID: $ARTIFACT_ID"
+            echo "- service digest: $SERVICE_DIGEST"
+            echo "- proof digests input: $MANIFEST_SHA256:$PAYLOAD_SHA256"
+            echo '- consumer: dispatch release recovery in artifact-proof mode from an independent run.'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-recovery.yaml
+++ b/.github/workflows/release-recovery.yaml
@@ -203,6 +203,14 @@ jobs:
           test "$(jq -r .branch "$manifest")" = '${{ steps.policy.outputs.branch }}'
           test "$(jq -r .distTag "$manifest")" = '${{ steps.policy.outputs.dist-tag }}'
 
+      - name: Validate recovery branch compatibility before authentication or mutation
+        run: |
+          bun run .github/publish-bun.effectstream.ts --validate-recovery-branch \
+            --artifact-dir '${{ runner.temp }}/effectstream-release-bundle' \
+            --manifest-sha512 '${{ inputs.manifest_sha512 }}' \
+            --expected-current-branch-sha '${{ inputs.expected_current_branch_sha }}' \
+            --recovery-mode '${{ inputs.recovery_mode }}'
+
       - name: Configure npm auth after all artifact and source checks
         shell: bash
         env:
@@ -210,6 +218,7 @@ jobs:
         run: printf '//registry.npmjs.org/:_authToken=%s\n' "$NPM_TOKEN" > .npmrc
 
       - name: Complete exact artifact publication and apply version delta
+        id: recover-publication
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           BUN_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -224,6 +233,30 @@ jobs:
             --recovery-mode '${{ inputs.recovery_mode }}' \
             --audit-ref '${{ steps.authorization.outputs.audit-ref }}' \
             --authorization-ref '${{ steps.authorization.outputs.authorization-ref }}'
+
+      - name: Persist secret-free recovery publication result even after failure
+        id: recovery-result-upload
+        if: ${{ always() && steps.recover-publication.outcome != 'skipped' }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: recovery-result-${{ inputs.release_tag }}-${{ inputs.source_sha }}-${{ inputs.original_run_id }}-${{ github.run_id }}
+          path: ${{ runner.temp }}/effectstream-release-bundle.publish-result.json
+          if-no-files-found: error
+          retention-days: 90
+          compression-level: 0
+
+      - name: Record recovery publication result artifact identity
+        if: ${{ always() && steps.recovery-result-upload.outcome == 'success' }}
+        shell: bash
+        env:
+          RESULT_ARTIFACT_ID: ${{ steps.recovery-result-upload.outputs.artifact-id }}
+          RESULT_SERVICE_DIGEST: ${{ steps.recovery-result-upload.outputs.artifact-digest }}
+        run: |
+          {
+            echo '### Secret-free recovery publication result'
+            echo "- artifact id: $RESULT_ARTIFACT_ID"
+            echo "- service digest: $RESULT_SERVICE_DIGEST"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Commit and push recovered version-only delta
         shell: bash

--- a/.github/workflows/release-recovery.yaml
+++ b/.github/workflows/release-recovery.yaml
@@ -1,0 +1,284 @@
+on:
+  workflow_dispatch:
+    inputs:
+      recovery_mode:
+        description: Exact audited state, or artifact-proof for the read-only rehearsal consumer
+        required: true
+        type: choice
+        options: [artifact-proof, partial-tag, complete-tag, partial-advanced, complete-advanced]
+      original_run_id:
+        description: Original producer run ID
+        required: true
+        type: string
+      artifact_id:
+        description: Immutable Actions artifact ID from the original producer
+        required: true
+        type: string
+      expected_service_digest:
+        description: Exact service-reported sha256 artifact digest
+        required: true
+        type: string
+      manifest_sha512:
+        description: Release manifest SHA-512; blank only for artifact-proof
+        required: false
+        type: string
+      release_tag:
+        description: Exact release tag; blank for artifact-proof
+        required: false
+        type: string
+      source_sha:
+        description: Exact original release source SHA; blank for artifact-proof
+        required: false
+        type: string
+      expected_current_branch_sha:
+        description: Exact approved current mapped-branch SHA; blank for artifact-proof
+        required: false
+        type: string
+      approval_refs:
+        description: Exact audit-ref|G4-authorization-ref pair; blank for artifact-proof
+        required: false
+        type: string
+      proof_digests:
+        description: Rehearsal manifest-sha256:payload-sha256; required only for artifact-proof
+        required: false
+        type: string
+
+name: Effectstream Release Recovery
+
+permissions:
+  actions: read
+  contents: read
+
+concurrency:
+  group: release-publish
+  cancel-in-progress: false
+
+jobs:
+  artifact-proof:
+    if: ${{ inputs.recovery_mode == 'artifact-proof' }}
+    permissions:
+      actions: read
+      contents: read
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    steps:
+      - name: Reject mutation inputs and require rehearsal digests
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          SOURCE_SHA: ${{ inputs.source_sha }}
+          BRANCH_SHA: ${{ inputs.expected_current_branch_sha }}
+          MANIFEST_SHA512: ${{ inputs.manifest_sha512 }}
+          APPROVAL_REFS: ${{ inputs.approval_refs }}
+          PROOF_DIGESTS: ${{ inputs.proof_digests }}
+        run: |
+          set -euo pipefail
+          test -z "$RELEASE_TAG$SOURCE_SHA$BRANCH_SHA$MANIFEST_SHA512$APPROVAL_REFS"
+          [[ "$PROOF_DIGESTS" =~ ^[0-9a-f]{64}:[0-9a-f]{64}$ ]]
+
+      - name: Download independent rehearsal artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          artifact-ids: ${{ inputs.artifact_id }}
+          run-id: ${{ inputs.original_run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path: ${{ runner.temp }}/artifact-proof
+
+      - name: Verify service, manifest, and payload digests
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ARTIFACT_ID: ${{ inputs.artifact_id }}
+          EXPECTED_SERVICE_DIGEST: ${{ inputs.expected_service_digest }}
+          PROOF_DIGESTS: ${{ inputs.proof_digests }}
+        run: |
+          set -euo pipefail
+          EXPECTED_MANIFEST="${PROOF_DIGESTS%%:*}"
+          EXPECTED_FILE="${PROOF_DIGESTS#*:}"
+          actual_service="$(gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts/$ARTIFACT_ID" --jq .digest)"
+          test "$actual_service" = "$EXPECTED_SERVICE_DIGEST"
+          test "$(sha256sum '${{ runner.temp }}/artifact-proof/manifest.json' | awk '{print $1}')" = "$EXPECTED_MANIFEST"
+          test "$(sha256sum '${{ runner.temp }}/artifact-proof/payload.txt' | awk '{print $1}')" = "$EXPECTED_FILE"
+          test "$(find '${{ runner.temp }}/artifact-proof' -type f | wc -l | tr -d ' ')" = 2
+
+  recover:
+    if: ${{ inputs.recovery_mode != 'artifact-proof' }}
+    permissions:
+      actions: read
+      contents: write
+    environment: npm-release-recovery
+    runs-on: ubuntu-22.04
+    timeout-minutes: 60
+    steps:
+      - name: Require the complete audited mutation identity
+        id: authorization
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          SOURCE_SHA: ${{ inputs.source_sha }}
+          BRANCH_SHA: ${{ inputs.expected_current_branch_sha }}
+          MANIFEST_SHA512: ${{ inputs.manifest_sha512 }}
+          APPROVAL_REFS: ${{ inputs.approval_refs }}
+          PROOF_DIGESTS: ${{ inputs.proof_digests }}
+        run: |
+          set -euo pipefail
+          test -n "$RELEASE_TAG" && test -n "$SOURCE_SHA" && test -n "$BRANCH_SHA"
+          test -n "$MANIFEST_SHA512" && test -n "$APPROVAL_REFS"
+          test -z "$PROOF_DIGESTS"
+          [[ "$SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$BRANCH_SHA" =~ ^[0-9a-f]{40}$ ]]
+          audit_ref="${APPROVAL_REFS%%|*}"
+          authorization_ref="${APPROVAL_REFS#*|}"
+          test -n "$audit_ref" && test -n "$authorization_ref"
+          test "$audit_ref|$authorization_ref" = "$APPROVAL_REFS"
+          echo "audit-ref=$audit_ref" >> "$GITHUB_OUTPUT"
+          echo "authorization-ref=$authorization_ref" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout exact approved current branch head
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ inputs.expected_current_branch_sha }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: 1.4.0
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Derive and verify mapped release identities
+        id: policy
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          SOURCE_SHA: ${{ inputs.source_sha }}
+          BRANCH_SHA: ${{ inputs.expected_current_branch_sha }}
+        run: |
+          set -euo pipefail
+          policy="$(bun run .github/publish-bun.effectstream.ts --policy --release-tag "$RELEASE_TAG")"
+          branch="$(jq -r .branch <<< "$policy")"
+          dist_tag="$(jq -r .distTag <<< "$policy")"
+          git fetch --force --no-tags origin \
+            "+refs/tags/$RELEASE_TAG:refs/tags/$RELEASE_TAG" \
+            "+refs/heads/$branch:refs/remotes/origin/$branch"
+          tag_ref="refs/tags/$RELEASE_TAG"
+          branch_ref="refs/remotes/origin/$branch"
+          test "$(git rev-parse "${tag_ref}^{commit}")" = "$SOURCE_SHA"
+          test "$(git rev-parse "${branch_ref}^{commit}")" = "$BRANCH_SHA"
+          test "$(git rev-parse 'HEAD^{commit}')" = "$BRANCH_SHA"
+          git merge-base --is-ancestor "$SOURCE_SHA" "$BRANCH_SHA"
+          echo "branch=$branch" >> "$GITHUB_OUTPUT"
+          echo "dist-tag=$dist_tag" >> "$GITHUB_OUTPUT"
+
+      - name: Download original immutable release bundle
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          artifact-ids: ${{ inputs.artifact_id }}
+          run-id: ${{ inputs.original_run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path: ${{ runner.temp }}/effectstream-release-bundle
+
+      - name: Verify original service and embedded identities
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ARTIFACT_ID: ${{ inputs.artifact_id }}
+          EXPECTED_SERVICE_DIGEST: ${{ inputs.expected_service_digest }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          SOURCE_SHA: ${{ inputs.source_sha }}
+          ORIGINAL_RUN_ID: ${{ inputs.original_run_id }}
+          MANIFEST_SHA512: ${{ inputs.manifest_sha512 }}
+        run: |
+          set -euo pipefail
+          actual_service="$(gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts/$ARTIFACT_ID" --jq .digest)"
+          test "$actual_service" = "$EXPECTED_SERVICE_DIGEST"
+          manifest='${{ runner.temp }}/effectstream-release-bundle/manifest.json'
+          test "$(sha512sum "$manifest" | awk '{print $1}')" = "$MANIFEST_SHA512"
+          test "$(jq -r .releaseTag "$manifest")" = "$RELEASE_TAG"
+          test "$(jq -r .sourceSha "$manifest")" = "$SOURCE_SHA"
+          test "$(jq -r .workflow.runId "$manifest")" = "$ORIGINAL_RUN_ID"
+          test "$(jq -r .branch "$manifest")" = '${{ steps.policy.outputs.branch }}'
+          test "$(jq -r .distTag "$manifest")" = '${{ steps.policy.outputs.dist-tag }}'
+
+      - name: Configure npm auth after all artifact and source checks
+        shell: bash
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: printf '//registry.npmjs.org/:_authToken=%s\n' "$NPM_TOKEN" > .npmrc
+
+      - name: Complete exact artifact publication and apply version delta
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          BUN_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          bun run .github/publish-bun.effectstream.ts --recover-bundle --publish \
+            --artifact-dir '${{ runner.temp }}/effectstream-release-bundle' \
+            --artifact-id '${{ inputs.artifact_id }}' \
+            --service-digest '${{ inputs.expected_service_digest }}' \
+            --manifest-sha512 '${{ inputs.manifest_sha512 }}' \
+            --expected-current-branch-sha '${{ inputs.expected_current_branch_sha }}' \
+            --recovery-mode '${{ inputs.recovery_mode }}' \
+            --audit-ref '${{ steps.authorization.outputs.audit-ref }}' \
+            --authorization-ref '${{ steps.authorization.outputs.authorization-ref }}'
+
+      - name: Commit and push recovered version-only delta
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          SOURCE_BRANCH: ${{ steps.policy.outputs.branch }}
+        run: |
+          set -euo pipefail
+          rm -f .npmrc
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add package.json ':(glob)packages/**/package.json'
+          if git diff --cached -U0 -- package.json ':(glob)packages/**/package.json' \
+               | grep -E '^[+-]' | grep -vE '^(\+\+\+|---)' \
+               | grep -vqE '^[+-][[:space:]]*"version":'; then
+            echo '::error::Recovered staged diff contains non-version changes.'
+            exit 1
+          fi
+          if ! git diff --cached --quiet; then
+            git commit -m "chore(release): $RELEASE_TAG (recovery)"
+            git push origin "HEAD:refs/heads/$SOURCE_BRANCH"
+          fi
+
+      - name: Emit secret-free final recovery manifest
+        shell: bash
+        env:
+          ORIGINAL_RUN_ID: ${{ inputs.original_run_id }}
+          ARTIFACT_ID: ${{ inputs.artifact_id }}
+          SERVICE_DIGEST: ${{ inputs.expected_service_digest }}
+          MANIFEST_SHA512: ${{ inputs.manifest_sha512 }}
+          RECOVERY_MODE: ${{ inputs.recovery_mode }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          SOURCE_SHA: ${{ inputs.source_sha }}
+          BRANCH: ${{ steps.policy.outputs.branch }}
+          DIST_TAG: ${{ steps.policy.outputs.dist-tag }}
+          AUDIT_REF: ${{ steps.authorization.outputs.audit-ref }}
+          AUTH_REF: ${{ steps.authorization.outputs.authorization-ref }}
+        run: |
+          set -euo pipefail
+          version_commit="$(git rev-parse 'HEAD^{commit}')"
+          jq -nS \
+            --arg originalRunId "$ORIGINAL_RUN_ID" \
+            --arg recoveryRunId "$GITHUB_RUN_ID" \
+            --arg artifactId "$ARTIFACT_ID" \
+            --arg serviceDigest "$SERVICE_DIGEST" \
+            --arg manifestSha512 "$MANIFEST_SHA512" \
+            --arg recoveryMode "$RECOVERY_MODE" \
+            --arg releaseTag "$RELEASE_TAG" \
+            --arg sourceSha "$SOURCE_SHA" \
+            --arg branch "$BRANCH" \
+            --arg distTag "$DIST_TAG" \
+            --arg versionCommit "$version_commit" \
+            --arg auditRef "$AUDIT_REF" \
+            --arg authorizationRef "$AUTH_REF" \
+            --slurpfile packageResults '${{ runner.temp }}/effectstream-release-bundle.publish-result.json' \
+            '{artifactId:$artifactId,auditRef:$auditRef,authorizationRef:$authorizationRef,branch:$branch,distTag:$distTag,latestPostcondition:"verified",manifestSha512:$manifestSha512,originalRunId:$originalRunId,packageResults:$packageResults[0].packages,recoveryMode:$recoveryMode,recoveryRunId:$recoveryRunId,releaseTag:$releaseTag,serviceDigest:$serviceDigest,sourceSha:$sourceSha,versionCommit:$versionCommit}' \
+            > '${{ runner.temp }}/recovery-final.json'
+          cat '${{ runner.temp }}/recovery-final.json' >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -99,6 +99,7 @@ jobs:
         run: printf '//registry.npmjs.org/:_authToken=%s\n' "$NPM_TOKEN" > .npmrc
 
       - name: Publish exact persisted tarballs and verify channel postcondition
+        id: publish
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           BUN_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -107,6 +108,30 @@ jobs:
           bun run .github/publish-bun.effectstream.ts --publish-bundle --publish \
             --artifact-dir '${{ runner.temp }}/effectstream-release-bundle' \
             --manifest-sha512 '${{ steps.prepare.outputs.manifest-sha512 }}'
+
+      - name: Persist secret-free publication result even after failure
+        id: result-upload
+        if: ${{ always() && steps.publish.outcome != 'skipped' }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: release-result-${{ github.event.release.tag_name }}-${{ steps.release-source.outputs.source-sha }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/effectstream-release-bundle.publish-result.json
+          if-no-files-found: error
+          retention-days: 90
+          compression-level: 0
+
+      - name: Record publication result artifact identity
+        if: ${{ always() && steps.result-upload.outcome == 'success' }}
+        shell: bash
+        env:
+          RESULT_ARTIFACT_ID: ${{ steps.result-upload.outputs.artifact-id }}
+          RESULT_SERVICE_DIGEST: ${{ steps.result-upload.outputs.artifact-digest }}
+        run: |
+          {
+            echo '### Secret-free publication result'
+            echo "- artifact id: $RESULT_ARTIFACT_ID"
+            echo "- service digest: $RESULT_SERVICE_DIGEST"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Commit and push version-only delta
         shell: bash

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,7 +5,7 @@ on:
 name: Effectstream Release Publish
 
 permissions:
-  contents: write          # needed to push the version-bump commit
+  contents: write
 
 concurrency:
   group: release-publish
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   publish:
     runs-on: ubuntu-22.04
-    timeout-minutes: 30
+    timeout-minutes: 60
     steps:
       - name: Checkout exact release tag
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -27,14 +27,16 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          printf '%s  %s\n' 'affd55aab609d4db7d6c6f38925859586d1ce67fd50f790d97c5dc027214af11' '.github/verify-release-source.sh' \
+          printf '%s  %s\n' 'f1c6f21dd0bfe03ee5fbf469c099e8bbc203e2adce61d819e3f5f1f1e33d8e20' '.github/verify-release-source.sh' \
             | sha256sum --check --strict
 
       - name: Verify immutable release source identity
+        id: release-source
         shell: bash
         env:
           RELEASE_TAG: ${{ github.event.release.tag_name }}
           RELEASE_TARGET_COMMITISH: ${{ github.event.release.target_commitish }}
+          RELEASE_PRERELEASE: ${{ github.event.release.prerelease }}
         run: bash .github/verify-release-source.sh
 
       - name: Setup Bun
@@ -45,58 +47,86 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: Configure npm auth
-        run: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc
+      - name: Preflight registry and prepare exact release bundle
+        id: prepare
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          BUNDLE_DIR: ${{ runner.temp }}/effectstream-release-bundle
+        run: |
+          bun run .github/publish-bun.effectstream.ts --prepare \
+            --release-tag '${{ github.event.release.tag_name }}' \
+            --source-sha '${{ steps.release-source.outputs.source-sha }}' \
+            --source-branch '${{ steps.release-source.outputs.branch }}' \
+            --dist-tag '${{ steps.release-source.outputs.dist-tag }}' \
+            --github-prerelease '${{ github.event.release.prerelease }}' \
+            --run-id '${{ github.run_id }}' \
+            --run-attempt '${{ github.run_attempt }}' \
+            --artifact-dir "$BUNDLE_DIR"
 
-      # All version validation (semver + strictly-greater), root bump, per-package
-      # bump, channel validation, dep pinning, publish, and version-only cleanup
-      # live in the script. GitHub's release metadata selects the generic channel,
-      # and the script independently enforces stable/prerelease safety.
-      # No --allow-uncommitted: the tree is clean at the script's git-check, since
-      # it writes the root version only after that check (.npmrc is gitignored).
-      - name: Select release channel
-        id: release-channel
+      - name: Upload immutable release bundle before authentication or mutation
+        id: upload
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: ${{ steps.prepare.outputs.artifact-name }}
+          path: ${{ runner.temp }}/effectstream-release-bundle
+          if-no-files-found: error
+          retention-days: 90
+          compression-level: 0
+
+      - name: Record immutable artifact identity
         shell: bash
         env:
-          PRERELEASE: ${{ github.event.release.prerelease }}
+          ORIGINAL_RUN: ${{ github.run_id }}
+          ORIGINAL_ATTEMPT: ${{ github.run_attempt }}
+          ARTIFACT_ID: ${{ steps.upload.outputs.artifact-id }}
+          SERVICE_DIGEST: ${{ steps.upload.outputs.artifact-digest }}
+          MANIFEST_SHA512: ${{ steps.prepare.outputs.manifest-sha512 }}
+          PACKAGE_COUNT: ${{ steps.prepare.outputs.package-count }}
         run: |
-          set -euo pipefail
-          if [[ "$PRERELEASE" == "true" ]]; then
-            DIST_TAG="next"
-          else
-            DIST_TAG="latest"
-          fi
-          echo "dist-tag=$DIST_TAG" >> "$GITHUB_OUTPUT"
+          {
+            echo '### Immutable release bundle'
+            echo "- original run: $ORIGINAL_RUN attempt $ORIGINAL_ATTEMPT"
+            echo "- artifact id: $ARTIFACT_ID"
+            echo "- service digest: $SERVICE_DIGEST"
+            echo "- manifest sha512: $MANIFEST_SHA512"
+            echo "- package count: $PACKAGE_COUNT"
+            echo '- recovery: use the separate recovery workflow; do not rerun this failed run after upload.'
+          } >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Publish
-        run: bun run .github/publish-bun.effectstream.ts --publish --release-version "${{ github.event.release.tag_name }}" --dist-tag "${{ steps.release-channel.outputs.dist-tag }}"
+      - name: Configure npm auth
+        shell: bash
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: printf '//registry.npmjs.org/:_authToken=%s\n' "$NPM_TOKEN" > .npmrc
+
+      - name: Publish exact persisted tarballs and verify channel postcondition
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           BUN_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - name: Commit & push version bumps
+          NPM_CONFIG_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          git config user.name  "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          # Stage ONLY package.json files (root + every package, ANY depth).
-          # Quote the pathspec and use git's :(glob) magic so `**` matches nested
-          # dirs (packages/node-sdk/node/...) — bash globstar is off in CI, which
-          # would otherwise collapse `**` to one level and miss most packages.
+          bun run .github/publish-bun.effectstream.ts --publish-bundle --publish \
+            --artifact-dir '${{ runner.temp }}/effectstream-release-bundle' \
+            --manifest-sha512 '${{ steps.prepare.outputs.manifest-sha512 }}'
+
+      - name: Commit and push version-only delta
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          SOURCE_BRANCH: ${{ steps.release-source.outputs.branch }}
+        run: |
+          set -euo pipefail
+          rm -f .npmrc
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
           git add package.json ':(glob)packages/**/package.json'
-          # Safety net: if anything other than a `version:` line slipped into the
-          # staged diff, abort rather than commit unexpected content.
           if git diff --cached -U0 -- package.json ':(glob)packages/**/package.json' \
                | grep -E '^[+-]' | grep -vE '^(\+\+\+|---)' \
                | grep -vqE '^[+-][[:space:]]*"version":'; then
-            echo "::error::Staged diff contains non-version changes — aborting commit."
+            echo '::error::Staged diff contains non-version changes.'
             git --no-pager diff --cached
             exit 1
           fi
-          if git diff --cached --quiet; then
-            echo "no version changes to commit"
-          else
-            git commit -m "chore(release): ${{ github.event.release.tag_name }}"
-            git push origin HEAD:refs/heads/v-next
+          if ! git diff --cached --quiet; then
+            git commit -m "chore(release): $RELEASE_TAG"
+            git push origin "HEAD:refs/heads/$SOURCE_BRANCH"
           fi


### PR DESCRIPTION
## Release operator breaking change

**BREAKING FOR RELEASE OPERATORS/AUTOMATION: `--dist-tag` is now required.
Stable `0.104.x` accepts only `midnight-1`; stable `0.200.x` accepts only
`latest`; retained Node-2 prereleases accept only `next`. Legacy implicit-
`latest` invocations fail before mutation.**

This changes generic CI/release operator automation; it does not break
EffectStream package or runtime APIs.

## What changes

- Treats `midnight-1` and `v-next` as explicit long-lived compatibility
  lines in CI selection.
- Routes stable `0.104.x` only from `midnight-1` to npm tag `midnight-1`.
- Keeps stable `0.200.x` on default branch `v-next` under npm tag `latest`.
- Retains only the reviewed Node-2 prerelease form under npm tag `next`.
- Fails closed on implicit, swapped, unsupported, stale-SHA, tag, branch, or
  channel inputs before registry mutation.
- Adds immutable publish artifacts and a separate protected recovery flow
  sharing the non-cancelling `release-publish` lock.
- Adds an upload-only hosted artifact rehearsal and an isolated read-only
  recovery artifact-proof mode; neither can publish npm or mutate source.

## Maintenance line

The separately audited durable branch `midnight-1` starts at the final
Midnight Node-1/Ledger-v8-compatible commit and contains only reviewed
cherry-picks/manual ports. Its root README begins with a warning explaining
the branch, npm tag, backport policy, support, and EOL contract.

## Verification

- Routing candidate: `49d8c5a4789dd15601b3a676698af7e90e14f337`.
- Local routing suite: 102 tests / 351 assertions / 0 failures.
- Independent routing delivery audit: PASS, 0 BLOCKER / 0 MAJOR.
- Independent maintenance delivery audit: PASS, 0 BLOCKER / 0 MAJOR.
- Independent cross-line readiness audit: PASS, 0 BLOCKER / 0 MAJOR.

This PR does not publish packages, move npm dist-tags, or create a release.
