### PR TITLE
fix(midnight): add explicit Stagenet service profile

### DIFF
--- a/packages/chains/midnight-contracts/src/midnight-env.ts
+++ b/packages/chains/midnight-contracts/src/midnight-env.ts
@@ -84,7 +84,17 @@ if (env("MIDNIGHT_WALLET_SEED")) {
   walletSeed = selectedNetworkConfig.genesisWalletSeed;
 }
 
-export const midnightNetworkConfig = {
+export type MidnightNetworkConfig = {
+  id: NetworkId.NetworkId;
+  indexer: string;
+  indexerWS: string;
+  node: string;
+  proofServer: string;
+  faucetUrl?: string;
+  walletSeed: string;
+};
+
+export const midnightNetworkConfig: MidnightNetworkConfig = {
   id: selectedNetworkConfig.networkId,
   indexer: env("MIDNIGHT_INDEXER_HTTP", selectedNetworkConfig.indexer),
   indexerWS: env("MIDNIGHT_INDEXER_WS", selectedNetworkConfig.indexerWS),
@@ -96,6 +106,3 @@ export const midnightNetworkConfig = {
 
 const isLocalProofServer = !!midnightNetworkConfig.proofServer.match(/(localhost|127\.0\.0\.1)/);
 export const isExternalProofServerConfigured = !isLocalProofServer;
-
-// Set this using MIDNIGHT_NETWORK_ID=<network-id>
-export type MidnightNetworkConfig = typeof midnightNetworkConfig;

--- a/packages/chains/midnight-contracts/src/midnight-env.ts
+++ b/packages/chains/midnight-contracts/src/midnight-env.ts
@@ -23,6 +23,7 @@ export type NetworkConfig = {
     indexerWS: string;
     node: string;
     proofServer: string;
+    faucetUrl?: string;
     networkId: NetworkId.NetworkId;
     genesisWalletSeed: string;
 }
@@ -47,17 +48,28 @@ const deployedNetworkConfig = (networkId: NetworkId.NetworkId): NetworkConfig =>
     genesisWalletSeed: '',
 });
 
+const stagenetNetworkConfig = Object.freeze({
+    indexer: "https://indexer.stagenet.shielded.tools/api/v4/graphql",
+    indexerWS: "wss://indexer.stagenet.shielded.tools/api/v4/graphql/ws",
+    node: "wss://rpc.stagenet.shielded.tools",
+    proofServer: "http://127.0.0.1:6300",
+    faucetUrl: "https://faucet.stagenet.shielded.tools/api/drips",
+    networkId: "stagenet" as NetworkId.NetworkId,
+    genesisWalletSeed: '',
+}) satisfies NetworkConfig;
+
 /**
- * Resolve defaults for every wallet-SDK network ID. Only `undeployed` uses
- * loopback services; every deployed or future network ID follows the hosted
- * Midnight endpoint convention instead of being restricted to `stagenet`.
+ * Resolve defaults for every wallet-SDK network ID. `undeployed` uses loopback
+ * services, Stagenet uses its explicit Shielded Tools profile, and every other
+ * deployed or future ID follows the hosted Midnight endpoint convention.
  */
 export const defaultMidnightNetworkConfig = (
   networkId: NetworkId.NetworkId,
-): NetworkConfig =>
-  networkId === "undeployed"
-    ? undeployedNetworkConfig
-    : deployedNetworkConfig(networkId);
+): NetworkConfig => {
+  if (networkId === "undeployed") return undeployedNetworkConfig;
+  if (networkId === "stagenet") return stagenetNetworkConfig;
+  return deployedNetworkConfig(networkId);
+};
 
 const networkId = (env("MIDNIGHT_NETWORK_ID") || "undeployed") as NetworkId.NetworkId;
 const selectedNetworkConfig = defaultMidnightNetworkConfig(networkId);
@@ -78,6 +90,7 @@ export const midnightNetworkConfig = {
   indexerWS: env("MIDNIGHT_INDEXER_WS", selectedNetworkConfig.indexerWS),
   node: env("MIDNIGHT_NODE_HTTP", selectedNetworkConfig.node),
   proofServer: env(["MIDNIGHT_PROOF_SERVER_URL", "MIDNIGHT_PROOF_SERVER"], selectedNetworkConfig.proofServer),
+  faucetUrl: selectedNetworkConfig.faucetUrl,
   walletSeed,
 };
 

--- a/packages/chains/midnight-contracts/test/migration.test.ts
+++ b/packages/chains/midnight-contracts/test/migration.test.ts
@@ -191,29 +191,159 @@ describe("wallet-v2 migration", () => {
 });
 
 describe("network defaults", () => {
-  test("undeployed uses local GraphQL v4 endpoints", () => {
-    const config = defaultMidnightNetworkConfig("undeployed");
-    expect(config.indexer).toBe("http://127.0.0.1:8088/api/v4/graphql");
-    expect(config.indexerWS).toBe("ws://127.0.0.1:8088/api/v4/graphql/ws");
+  test("stagenet uses the complete explicit Shielded Tools profile", () => {
+    expect(defaultMidnightNetworkConfig("stagenet")).toEqual({
+      indexer: "https://indexer.stagenet.shielded.tools/api/v4/graphql",
+      indexerWS: "wss://indexer.stagenet.shielded.tools/api/v4/graphql/ws",
+      node: "wss://rpc.stagenet.shielded.tools",
+      proofServer: "http://127.0.0.1:6300",
+      faucetUrl: "https://faucet.stagenet.shielded.tools/api/drips",
+      networkId: "stagenet",
+      genesisWalletSeed: "",
+    });
   });
 
-  for (const networkId of [
-    "mainnet",
-    "testnet",
-    "devnet",
-    "qanet",
-    "preview",
-    "preprod",
-    "stagenet",
-    "future-network",
-  ]) {
-    test(`preserves deployed network ID ${networkId}`, () => {
-      const config = defaultMidnightNetworkConfig(networkId);
-      expect(config.networkId).toBe(networkId);
-      expect(config.indexer).toBe(
-        `https://indexer.${networkId}.midnight.network/api/v4/graphql`,
-      );
-      expect(config.node).toBe(`https://rpc.${networkId}.midnight.network`);
+  test("undeployed retains the complete loopback v4 profile", () => {
+    expect(defaultMidnightNetworkConfig("undeployed")).toEqual({
+      indexer: "http://127.0.0.1:8088/api/v4/graphql",
+      indexerWS: "ws://127.0.0.1:8088/api/v4/graphql/ws",
+      node: "http://127.0.0.1:9944",
+      proofServer: "http://127.0.0.1:6300",
+      networkId: "undeployed",
+      genesisWalletSeed: "0000000000000000000000000000000000000000000000000000000000000001",
+    });
+  });
+
+  for (const networkId of ["preview", "preprod"] as const) {
+    test(`preserves node-1.x network ID ${networkId} without remapping`, () => {
+      expect(defaultMidnightNetworkConfig(networkId)).toEqual({
+        indexer: `https://indexer.${networkId}.midnight.network/api/v4/graphql`,
+        indexerWS: `wss://indexer.${networkId}.midnight.network/api/v4/graphql/ws`,
+        node: `https://rpc.${networkId}.midnight.network`,
+        proofServer: "http://127.0.0.1:6300",
+        networkId,
+        genesisWalletSeed: "",
+      });
     });
   }
+
+  test("preserves an arbitrary future network ID and hosted convention", () => {
+    expect(defaultMidnightNetworkConfig("future-network")).toEqual({
+      indexer: "https://indexer.future-network.midnight.network/api/v4/graphql",
+      indexerWS: "wss://indexer.future-network.midnight.network/api/v4/graphql/ws",
+      node: "https://rpc.future-network.midnight.network",
+      proofServer: "http://127.0.0.1:6300",
+      networkId: "future-network",
+      genesisWalletSeed: "",
+    });
+  });
+
+  test("selected stagenet defaults expose inert faucet metadata without fetch", async () => {
+    const moduleUrl = new URL("../src/midnight-env.ts", import.meta.url).href;
+    const probe = Bun.spawn([
+      process.execPath,
+      "--eval",
+      `
+        let networkCalls = 0;
+        globalThis.fetch = () => {
+          networkCalls += 1;
+          throw new Error("unexpected network call");
+        };
+        const { midnightNetworkConfig } = await import(${JSON.stringify(moduleUrl)});
+        console.log(JSON.stringify({ midnightNetworkConfig, networkCalls }));
+      `,
+    ], {
+      env: {
+        ...process.env,
+        MIDNIGHT_NETWORK_ID: "stagenet",
+        MIDNIGHT_INDEXER_HTTP: "",
+        MIDNIGHT_INDEXER_WS: "",
+        MIDNIGHT_NODE_HTTP: "",
+        MIDNIGHT_PROOF_SERVER_URL: "",
+        MIDNIGHT_PROOF_SERVER: "",
+        MIDNIGHT_WALLET_SEED: "",
+        MIDNIGHT_WALLET_MNEMONIC: "",
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [exitCode, stdout, stderr] = await Promise.all([
+      probe.exited,
+      new Response(probe.stdout).text(),
+      new Response(probe.stderr).text(),
+    ]);
+
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+    expect(JSON.parse(stdout)).toEqual({
+      midnightNetworkConfig: {
+        id: "stagenet",
+        indexer: "https://indexer.stagenet.shielded.tools/api/v4/graphql",
+        indexerWS: "wss://indexer.stagenet.shielded.tools/api/v4/graphql/ws",
+        node: "wss://rpc.stagenet.shielded.tools",
+        proofServer: "http://127.0.0.1:6300",
+        faucetUrl: "https://faucet.stagenet.shielded.tools/api/drips",
+        walletSeed: "",
+      },
+      networkCalls: 0,
+    });
+  });
+
+  test("selected stagenet environment overrides win while faucet stays inert", async () => {
+    const moduleUrl = new URL("../src/midnight-env.ts", import.meta.url).href;
+    const probe = Bun.spawn([
+      process.execPath,
+      "--eval",
+      `
+        let networkCalls = 0;
+        globalThis.fetch = () => {
+          networkCalls += 1;
+          throw new Error("unexpected network call");
+        };
+        const { midnightNetworkConfig } = await import(${JSON.stringify(moduleUrl)});
+        console.log(JSON.stringify({ midnightNetworkConfig, networkCalls }));
+      `,
+    ], {
+      env: {
+        ...process.env,
+        MIDNIGHT_NETWORK_ID: "stagenet",
+        MIDNIGHT_INDEXER_HTTP: "https://override.example/indexer",
+        MIDNIGHT_INDEXER_WS: "wss://override.example/indexer/ws",
+        MIDNIGHT_NODE_HTTP: "wss://override.example/node",
+        MIDNIGHT_PROOF_SERVER_URL: "http://override.example/proof",
+        MIDNIGHT_PROOF_SERVER: "http://ignored.example/proof",
+        MIDNIGHT_WALLET_SEED: "seed-override",
+        MIDNIGHT_WALLET_MNEMONIC: "invalid mnemonic must remain unused",
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [exitCode, stdout, stderr] = await Promise.all([
+      probe.exited,
+      new Response(probe.stdout).text(),
+      new Response(probe.stderr).text(),
+    ]);
+
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+    const { midnightNetworkConfig, networkCalls } = JSON.parse(stdout);
+    expect({
+      id: midnightNetworkConfig.id,
+      indexer: midnightNetworkConfig.indexer,
+      indexerWS: midnightNetworkConfig.indexerWS,
+      node: midnightNetworkConfig.node,
+      proofServer: midnightNetworkConfig.proofServer,
+      walletSeed: midnightNetworkConfig.walletSeed,
+    }).toEqual({
+      id: "stagenet",
+      indexer: "https://override.example/indexer",
+      indexerWS: "wss://override.example/indexer/ws",
+      node: "wss://override.example/node",
+      proofServer: "http://override.example/proof",
+      walletSeed: "seed-override",
+    });
+    expect(networkCalls).toBe(0);
+  });
 });

--- a/packages/chains/midnight-contracts/test/migration.test.ts
+++ b/packages/chains/midnight-contracts/test/migration.test.ts
@@ -19,7 +19,10 @@ import {
   resolveFacadeDustFundsReadiness,
   waitForDustFunds,
 } from "../src/get-wallet-info.ts";
-import { defaultMidnightNetworkConfig } from "../src/midnight-env.ts";
+import {
+  defaultMidnightNetworkConfig,
+  type MidnightNetworkConfig,
+} from "../src/midnight-env.ts";
 import type { WalletResult } from "../src/types.ts";
 
 describe("ledger-v9 compatibility traps", () => {
@@ -191,6 +194,19 @@ describe("wallet-v2 migration", () => {
 });
 
 describe("network defaults", () => {
+  test("public config type accepts the complete pre-faucet object shape", () => {
+    const preFaucetConfig: MidnightNetworkConfig = {
+      id: "undeployed",
+      indexer: "http://127.0.0.1:8088/api/v4/graphql",
+      indexerWS: "ws://127.0.0.1:8088/api/v4/graphql/ws",
+      node: "http://127.0.0.1:9944",
+      proofServer: "http://127.0.0.1:6300",
+      walletSeed: "legacy-wallet-seed",
+    };
+
+    expect(Object.hasOwn(preFaucetConfig, "faucetUrl")).toBe(false);
+  });
+
   test("stagenet uses the complete explicit Shielded Tools profile", () => {
     expect(defaultMidnightNetworkConfig("stagenet")).toEqual({
       indexer: "https://indexer.stagenet.shielded.tools/api/v4/graphql",


### PR DESCRIPTION
## Summary

- Resolve `stagenet` through one explicit Midnight service profile in `packages/chains/midnight-contracts/src/midnight-env.ts` instead of the generic `*.midnight.network` convention.
- Keep the existing resolver and override precedence for undeployed and all other deployed/future network IDs.
- Expose `faucetUrl` as optional, inert metadata on the public resolved-config type; no faucet or other network call is made while importing or resolving the profile.

## Exact Stagenet profile

- node: `wss://rpc.stagenet.shielded.tools`
- indexer: `https://indexer.stagenet.shielded.tools/api/v4/graphql`
- indexer WebSocket: `wss://indexer.stagenet.shielded.tools/api/v4/graphql/ws`
- faucet metadata: `https://faucet.stagenet.shielded.tools/api/drips`
- proof server remains `http://127.0.0.1:6300`, network ID remains `stagenet`, and the genesis seed remains empty.

## Verification

- Red-first Docker proof: the test-only candidate produced the two intended Stagenet failures (`13 pass`, `2 fail`, exit 1) while undeployed, Preview, Preprod, future-network, precedence, and zero-fetch guards passed.
- Final independently audited `linux/amd64` Docker image: `sha256:9baae7c72d4afcd8a7e991b311dd8642df7214ab8252a8e8f3c3f643f7ead800`.
- Disposable `--rm --network none` runs: focused migration test `16 pass / 0 fail / 46 assertions`; complete package suite `16 pass / 0 fail / 46 assertions`; package typecheck with zero diagnostics.
- Both isolated import/resolution probes installed a throwing `fetch` trap and observed `networkCalls: 0`, including the environment-override case.
- A non-test repository search found each exact Stagenet URL once and only in `midnight-env.ts`; a separate search found no production `faucetUrl` caller outside that owner.
- Complete-object tests preserve undeployed, Preview, Preprod, and `future-network` behavior, plus endpoint, proof-server, and wallet-seed precedence.
- The base-to-head diff contains exactly the two intended files and no lockfile, manifest, generated, workflow, template, generic-config, or documentation change.

## Review records

The approved organizer specification and audits are not published together at immutable public URLs, so this PR does not invent links. Exact project filenames and immutable SHA-256 pins are:

- Approved spec: `spec/00026-midnight-stagenet-profile.md` — `acbfe29f6912fed07c21a49f6c8e007a89911aab358dc4c64d9e9fb83b3647f7`
- Plan-design audit (`REVIEW-COMPLETED / PASS`): `audits/00026-midnight-stagenet-profile-plan-design.md` — `be0a48f29950d09bea1f3047faf13cc62a8de915f44e8834fc3113e742bdf894`
- First delivery audit (`REVIEW-COMPLETED / FAIL`, one MAJOR later remediated): `audits/00026-midnight-stagenet-profile-delivery.md` — `2cf5d11af7aebd09ae79ad79a4f281b39c473335d757af82d04ba2721010a39b`
- Remediation delivery audit (`REVIEW-COMPLETED / PASS`, zero findings): `audits/00026-midnight-stagenet-profile-delivery-r2.md` — `cdbb642a7967deecf0b3c38585d0044611f01c6870471efee5a169e184c9d055`
- Independently audited source pin: `a2d597323616182fa968e0cd40f50adf6604dce7`, tree `9d4706abcbc46482bd0b760e3b684d6888b2a153`.

## Compatibility and scope

**No breaking changes.** The six legacy public properties remain required; `faucetUrl` is the only optional key, and a complete pre-faucet consumer object remains assignable. The Stagenet default correction replaces previously unusable synthesized endpoints without changing other network profiles.

Out of scope: runnable Preview/Preprod application profiles, wallet creation or funding, deployment, faucet invocation, live endpoint availability, and public transactions.
