### PR TITLE
feat(midnight): add bounded tip query

### DIFF
--- a/docs/site/docs/home/500-packages/520-node/sync.md
+++ b/docs/site/docs/home/500-packages/520-node/sync.md
@@ -189,6 +189,34 @@ application code drives them through `genSyncProtocols` rather than
 instantiating them directly. Reach for them only if you're writing a
 custom orchestration layer.
 
+## One-shot Midnight tip
+
+`getMidnightTip()` performs one bounded query for the Midnight indexer's
+current block height. The caller must supply the absolute HTTP(S) `indexer`;
+the helper has no network or endpoint default.
+
+```typescript
+import { getMidnightTip } from "@effectstream/sync";
+
+const { height } = await getMidnightTip({
+  indexer: midnight.indexer,
+  requestTimeoutMs: 15_000, // optional; 15 seconds by default
+  signal,
+});
+```
+
+The operation sends exactly one `query { block { height } }` POST and returns
+one validated non-negative safe integer. It never retries, polls, caches, or
+persists a partial or successful result.
+
+Failures are `MidnightTipError` instances with stable codes:
+`INVALID_OPTIONS`, `ABORTED`, `TIMEOUT`, `NETWORK`, `HTTP`, `GRAPHQL`, and
+`INVALID_RESPONSE`. Caller abort preserves `signal.reason`; network and JSON
+parse failures preserve their original cause; HTTP failures expose
+`status`/`statusText`; and GraphQL failures expose a frozen `graphqlErrors`
+copy. Caller abort and the operation deadline use first-winner semantics and
+release their timer, listener, and request on every settlement.
+
 ## Examples
 
 End-to-end sync test (boots a node, reads blocks, asserts the DB):

--- a/packages/node-sdk/sync/README.md
+++ b/packages/node-sdk/sync/README.md
@@ -181,6 +181,34 @@ application code drives them through `genSyncProtocols` rather than
 instantiating them directly. Reach for them only if you're writing a
 custom orchestration layer.
 
+## One-shot Midnight tip
+
+`getMidnightTip()` performs one bounded query for the Midnight indexer's
+current block height. The caller must supply the absolute HTTP(S) `indexer`;
+the helper has no network or endpoint default.
+
+```typescript
+import { getMidnightTip } from "@effectstream/sync";
+
+const { height } = await getMidnightTip({
+  indexer: midnight.indexer,
+  requestTimeoutMs: 15_000, // optional; 15 seconds by default
+  signal,
+});
+```
+
+The operation sends exactly one `query { block { height } }` POST and returns
+one validated non-negative safe integer. It never retries, polls, caches, or
+persists a partial or successful result.
+
+Failures are `MidnightTipError` instances with stable codes:
+`INVALID_OPTIONS`, `ABORTED`, `TIMEOUT`, `NETWORK`, `HTTP`, `GRAPHQL`, and
+`INVALID_RESPONSE`. Caller abort preserves `signal.reason`; network and JSON
+parse failures preserve their original cause; HTTP failures expose
+`status`/`statusText`; and GraphQL failures expose a frozen `graphqlErrors`
+copy. Caller abort and the operation deadline use first-winner semantics and
+release their timer, listener, and request on every settlement.
+
 ## Examples
 
 End-to-end sync test (boots a node, reads blocks, asserts the DB):

--- a/packages/node-sdk/sync/src/sync-protocols/midnight/tip.ts
+++ b/packages/node-sdk/sync/src/sync-protocols/midnight/tip.ts
@@ -1,0 +1,269 @@
+const DEFAULT_REQUEST_TIMEOUT_MS = 15_000;
+const MAX_TIMER_DELAY_MS = 2_147_483_647;
+
+export type GetMidnightTipOptions = {
+  indexer: string;
+  requestTimeoutMs?: number;
+  signal?: AbortSignal;
+};
+
+export type MidnightTip = { height: number };
+
+export type MidnightTipErrorCode =
+  | "INVALID_OPTIONS"
+  | "ABORTED"
+  | "TIMEOUT"
+  | "NETWORK"
+  | "HTTP"
+  | "GRAPHQL"
+  | "INVALID_RESPONSE";
+
+export class MidnightTipError extends Error {
+  readonly code: MidnightTipErrorCode;
+  override readonly cause?: unknown;
+  readonly status?: number;
+  readonly statusText?: string;
+  readonly graphqlErrors?: readonly unknown[];
+
+  constructor(
+    code: MidnightTipErrorCode,
+    message: string,
+    options: {
+      cause?: unknown;
+      status?: number;
+      statusText?: string;
+      graphqlErrors?: readonly unknown[];
+    } = {},
+  ) {
+    super(message, options.cause === undefined ? undefined : { cause: options.cause });
+    this.name = "MidnightTipError";
+    this.code = code;
+    this.cause = options.cause;
+    this.status = options.status;
+    this.statusText = options.statusText;
+    this.graphqlErrors = options.graphqlErrors;
+  }
+}
+
+function validateOptions(options: GetMidnightTipOptions): {
+  indexer: string;
+  requestTimeoutMs: number;
+  signal?: AbortSignal;
+} {
+  if (options == null || typeof options !== "object") {
+    throw new MidnightTipError("INVALID_OPTIONS", "Options must be an object");
+  }
+  if (typeof options.indexer !== "string") {
+    throw new MidnightTipError(
+      "INVALID_OPTIONS",
+      "indexer must be an absolute HTTP(S) URL",
+    );
+  }
+
+  let url: URL;
+  try {
+    url = new URL(options.indexer);
+  } catch {
+    throw new MidnightTipError(
+      "INVALID_OPTIONS",
+      "indexer must be an absolute HTTP(S) URL",
+    );
+  }
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new MidnightTipError("INVALID_OPTIONS", "indexer must use HTTP or HTTPS");
+  }
+
+  const requestTimeoutMs = options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
+  if (
+    !Number.isSafeInteger(requestTimeoutMs) ||
+    !Number.isFinite(requestTimeoutMs) ||
+    requestTimeoutMs <= 0
+  ) {
+    throw new MidnightTipError(
+      "INVALID_OPTIONS",
+      "requestTimeoutMs must be a positive finite safe integer",
+    );
+  }
+
+  const signal = options.signal;
+  if (
+    signal !== undefined &&
+    (typeof signal !== "object" ||
+      typeof signal.addEventListener !== "function" ||
+      typeof signal.removeEventListener !== "function" ||
+      typeof signal.aborted !== "boolean")
+  ) {
+    throw new MidnightTipError("INVALID_OPTIONS", "signal must be an AbortSignal");
+  }
+
+  return { indexer: url.href, requestTimeoutMs, signal };
+}
+
+function invalidResponse(message: string, cause?: unknown): MidnightTipError {
+  return new MidnightTipError("INVALID_RESPONSE", message, { cause });
+}
+
+/**
+ * Split deadlines at the maximum delay supported consistently by Node and Bun.
+ * Larger delays are otherwise clamped and can fire years too early.
+ */
+function scheduleDeadline(delayMs: number, onDeadline: () => void): () => void {
+  let remainingMs = delayMs;
+  let active = true;
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+
+  const scheduleNext = (): void => {
+    const chunkMs = Math.min(remainingMs, MAX_TIMER_DELAY_MS);
+    remainingMs -= chunkMs;
+    timeout = setTimeout(() => {
+      if (!active) return;
+      timeout = undefined;
+      if (remainingMs > 0) {
+        scheduleNext();
+        return;
+      }
+      active = false;
+      onDeadline();
+    }, chunkMs);
+  };
+
+  scheduleNext();
+  return () => {
+    if (!active) return;
+    active = false;
+    if (timeout !== undefined) clearTimeout(timeout);
+    timeout = undefined;
+  };
+}
+
+function aborted(reason: unknown): MidnightTipError {
+  return new MidnightTipError("ABORTED", "Midnight tip query was aborted", {
+    cause: reason,
+  });
+}
+
+function timedOut(): MidnightTipError {
+  return new MidnightTipError("TIMEOUT", "Midnight tip query timed out");
+}
+
+/** Query one validated numeric block height from an explicit Midnight indexer. */
+export async function getMidnightTip(
+  options: GetMidnightTipOptions,
+): Promise<MidnightTip> {
+  const validated = validateOptions(options);
+  if (validated.signal?.aborted) throw aborted(validated.signal.reason);
+
+  const requestController = new AbortController();
+  let winner: "ABORTED" | "TIMEOUT" | undefined;
+  let callerReason: unknown;
+
+  const onCallerAbort = (): void => {
+    if (winner !== undefined) return;
+    winner = "ABORTED";
+    callerReason = validated.signal?.reason;
+    requestController.abort(callerReason);
+  };
+
+  validated.signal?.addEventListener("abort", onCallerAbort, { once: true });
+  // Close the listener-registration race before allocating a timer or doing I/O.
+  if (validated.signal?.aborted) onCallerAbort();
+  if (winner === "ABORTED") {
+    validated.signal?.removeEventListener("abort", onCallerAbort);
+    throw aborted(callerReason);
+  }
+
+  const clearDeadline = scheduleDeadline(validated.requestTimeoutMs, () => {
+    if (winner !== undefined) return;
+    winner = "TIMEOUT";
+    requestController.abort();
+  });
+
+  const throwIfCancelled = (): void => {
+    if (winner === "ABORTED") throw aborted(callerReason);
+    if (winner === "TIMEOUT") throw timedOut();
+  };
+
+  try {
+    let response: Response;
+    try {
+      response = await fetch(validated.indexer, {
+        method: "POST",
+        body: JSON.stringify({ query: "query { block { height } }" }),
+        headers: { "Content-Type": "application/json" },
+        signal: requestController.signal,
+      });
+    } catch (error) {
+      throwIfCancelled();
+      throw new MidnightTipError("NETWORK", "Midnight tip query failed", {
+        cause: error,
+      });
+    }
+    throwIfCancelled();
+
+    if (!response.ok) {
+      // A fetch resolves after response headers. Explicitly cancel an unread
+      // body so an HTTP failure cannot leave its streaming request/socket live.
+      try {
+        await response.body?.cancel();
+      } catch {
+        // Classification is based on the already-received HTTP response.
+      }
+      throwIfCancelled();
+      throw new MidnightTipError(
+        "HTTP",
+        `Midnight indexer returned ${response.status} ${response.statusText}`,
+        { status: response.status, statusText: response.statusText },
+      );
+    }
+
+    let body: unknown;
+    try {
+      body = await response.json();
+    } catch (error) {
+      throwIfCancelled();
+      throw invalidResponse("Midnight indexer returned malformed JSON", error);
+    }
+    throwIfCancelled();
+
+    if (body == null || typeof body !== "object" || Array.isArray(body)) {
+      throw invalidResponse("Midnight indexer returned a non-object GraphQL response");
+    }
+
+    if ("errors" in body) {
+      const errors = (body as { errors?: unknown }).errors;
+      if (!Array.isArray(errors)) {
+        throw invalidResponse("Midnight indexer returned a malformed GraphQL errors field");
+      }
+      if (errors.length > 0) {
+        throw new MidnightTipError("GRAPHQL", "Midnight indexer returned GraphQL errors", {
+          graphqlErrors: Object.freeze(errors.slice()),
+        });
+      }
+    }
+
+    const data = (body as { data?: unknown }).data;
+    if (data == null || typeof data !== "object" || Array.isArray(data)) {
+      throw invalidResponse("Midnight indexer response is missing data");
+    }
+
+    const block = (data as { block?: unknown }).block;
+    if (block == null || typeof block !== "object" || Array.isArray(block)) {
+      throw invalidResponse("Midnight indexer response is missing block");
+    }
+
+    const height = (block as { height?: unknown }).height;
+    if (
+      typeof height !== "number" ||
+      !Number.isFinite(height) ||
+      !Number.isSafeInteger(height) ||
+      height < 0
+    ) {
+      throw invalidResponse("Midnight indexer returned an invalid block height");
+    }
+
+    return { height };
+  } finally {
+    clearDeadline();
+    validated.signal?.removeEventListener("abort", onCallerAbort);
+  }
+}

--- a/packages/node-sdk/sync/src/sync-protocols/midnight/tip.ts
+++ b/packages/node-sdk/sync/src/sync-protocols/midnight/tip.ts
@@ -73,7 +73,10 @@ function validateOptions(options: GetMidnightTipOptions): {
     throw new MidnightTipError("INVALID_OPTIONS", "indexer must use HTTP or HTTPS");
   }
 
-  const requestTimeoutMs = options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
+  const requestTimeoutMs =
+    options.requestTimeoutMs === undefined
+      ? DEFAULT_REQUEST_TIMEOUT_MS
+      : options.requestTimeoutMs;
   if (
     !Number.isSafeInteger(requestTimeoutMs) ||
     !Number.isFinite(requestTimeoutMs) ||
@@ -88,7 +91,8 @@ function validateOptions(options: GetMidnightTipOptions): {
   const signal = options.signal;
   if (
     signal !== undefined &&
-    (typeof signal !== "object" ||
+    (signal === null ||
+      typeof signal !== "object" ||
       typeof signal.addEventListener !== "function" ||
       typeof signal.removeEventListener !== "function" ||
       typeof signal.aborted !== "boolean")
@@ -190,6 +194,7 @@ export async function getMidnightTip(
         method: "POST",
         body: JSON.stringify({ query: "query { block { height } }" }),
         headers: { "Content-Type": "application/json" },
+        redirect: "manual",
         signal: requestController.signal,
       });
     } catch (error) {

--- a/packages/node-sdk/sync/src/sync-protocols/midnight/tip.ts
+++ b/packages/node-sdk/sync/src/sync-protocols/midnight/tip.ts
@@ -1,3 +1,6 @@
+import { Type } from "@sinclair/typebox";
+import { Value } from "@sinclair/typebox/value";
+
 const DEFAULT_REQUEST_TIMEOUT_MS = 15_000;
 const MAX_TIMER_DELAY_MS = 2_147_483_647;
 
@@ -244,6 +247,24 @@ async function postJsonRequest(
   }
 }
 
+/**
+ * Checked before the tip shape so a non-empty errors array classifies as
+ * GRAPHQL even when data is absent, and a malformed errors field (or a
+ * non-object body) classifies as INVALID_RESPONSE.
+ */
+const GraphQLEnvelopeSchema = Type.Object({
+  errors: Type.Optional(Type.Array(Type.Unknown())),
+});
+
+const TipResponseSchema = Type.Object({
+  data: Type.Object({
+    block: Type.Object({
+      // minimum + maximum encode Number.isSafeInteger(height) && height >= 0.
+      height: Type.Integer({ minimum: 0, maximum: Number.MAX_SAFE_INTEGER }),
+    }),
+  }),
+});
+
 /** Query one validated numeric block height from an explicit Midnight indexer. */
 export async function getMidnightTip(
   options: GetMidnightTipOptions,
@@ -256,41 +277,19 @@ export async function getMidnightTip(
     validated.signal,
   );
 
-  if (body == null || typeof body !== "object" || Array.isArray(body)) {
-    throw invalidResponse("Midnight indexer returned a non-object GraphQL response");
+  if (!Value.Check(GraphQLEnvelopeSchema, body)) {
+    throw invalidResponse("Midnight indexer returned a malformed GraphQL response");
   }
 
-  if ("errors" in body) {
-    const errors = (body as { errors?: unknown }).errors;
-    if (!Array.isArray(errors)) {
-      throw invalidResponse("Midnight indexer returned a malformed GraphQL errors field");
-    }
-    if (errors.length > 0) {
-      throw new MidnightTipError("GRAPHQL", "Midnight indexer returned GraphQL errors", {
-        graphqlErrors: Object.freeze(errors.slice()),
-      });
-    }
+  if (body.errors !== undefined && body.errors.length > 0) {
+    throw new MidnightTipError("GRAPHQL", "Midnight indexer returned GraphQL errors", {
+      graphqlErrors: Object.freeze(body.errors.slice()),
+    });
   }
 
-  const data = (body as { data?: unknown }).data;
-  if (data == null || typeof data !== "object" || Array.isArray(data)) {
-    throw invalidResponse("Midnight indexer response is missing data");
+  if (!Value.Check(TipResponseSchema, body)) {
+    throw invalidResponse("Midnight indexer returned an invalid tip response");
   }
 
-  const block = (data as { block?: unknown }).block;
-  if (block == null || typeof block !== "object" || Array.isArray(block)) {
-    throw invalidResponse("Midnight indexer response is missing block");
-  }
-
-  const height = (block as { height?: unknown }).height;
-  if (
-    typeof height !== "number" ||
-    !Number.isFinite(height) ||
-    !Number.isSafeInteger(height) ||
-    height < 0
-  ) {
-    throw invalidResponse("Midnight indexer returned an invalid block height");
-  }
-
-  return { height };
+  return { height: body.data.block.height };
 }

--- a/packages/node-sdk/sync/src/sync-protocols/midnight/tip.ts
+++ b/packages/node-sdk/sync/src/sync-protocols/midnight/tip.ts
@@ -150,12 +150,19 @@ function timedOut(): MidnightTipError {
   return new MidnightTipError("TIMEOUT", "Midnight tip query timed out");
 }
 
-/** Query one validated numeric block height from an explicit Midnight indexer. */
-export async function getMidnightTip(
-  options: GetMidnightTipOptions,
-): Promise<MidnightTip> {
-  const validated = validateOptions(options);
-  if (validated.signal?.aborted) throw aborted(validated.signal.reason);
+/**
+ * POST a JSON body and return the parsed JSON response. Owns all the
+ * network plumbing — caller abort, request timeout, HTTP-status failures,
+ * unread-body cleanup, JSON parsing — and maps every failure to a
+ * MidnightTipError so callers only deal with the decoded payload.
+ */
+async function postJsonRequest(
+  url: string,
+  requestBody: unknown,
+  requestTimeoutMs: number,
+  signal?: AbortSignal,
+): Promise<unknown> {
+  if (signal?.aborted) throw aborted(signal.reason);
 
   const requestController = new AbortController();
   let winner: "ABORTED" | "TIMEOUT" | undefined;
@@ -164,19 +171,19 @@ export async function getMidnightTip(
   const onCallerAbort = (): void => {
     if (winner !== undefined) return;
     winner = "ABORTED";
-    callerReason = validated.signal?.reason;
+    callerReason = signal?.reason;
     requestController.abort(callerReason);
   };
 
-  validated.signal?.addEventListener("abort", onCallerAbort, { once: true });
+  signal?.addEventListener("abort", onCallerAbort, { once: true });
   // Close the listener-registration race before allocating a timer or doing I/O.
-  if (validated.signal?.aborted) onCallerAbort();
+  if (signal?.aborted) onCallerAbort();
   if (winner === "ABORTED") {
-    validated.signal?.removeEventListener("abort", onCallerAbort);
+    signal?.removeEventListener("abort", onCallerAbort);
     throw aborted(callerReason);
   }
 
-  const clearDeadline = scheduleDeadline(validated.requestTimeoutMs, () => {
+  const clearDeadline = scheduleDeadline(requestTimeoutMs, () => {
     if (winner !== undefined) return;
     winner = "TIMEOUT";
     requestController.abort();
@@ -190,9 +197,9 @@ export async function getMidnightTip(
   try {
     let response: Response;
     try {
-      response = await fetch(validated.indexer, {
+      response = await fetch(url, {
         method: "POST",
-        body: JSON.stringify({ query: "query { block { height } }" }),
+        body: JSON.stringify(requestBody),
         headers: { "Content-Type": "application/json" },
         redirect: "manual",
         signal: requestController.signal,
@@ -230,45 +237,60 @@ export async function getMidnightTip(
     }
     throwIfCancelled();
 
-    if (body == null || typeof body !== "object" || Array.isArray(body)) {
-      throw invalidResponse("Midnight indexer returned a non-object GraphQL response");
-    }
-
-    if ("errors" in body) {
-      const errors = (body as { errors?: unknown }).errors;
-      if (!Array.isArray(errors)) {
-        throw invalidResponse("Midnight indexer returned a malformed GraphQL errors field");
-      }
-      if (errors.length > 0) {
-        throw new MidnightTipError("GRAPHQL", "Midnight indexer returned GraphQL errors", {
-          graphqlErrors: Object.freeze(errors.slice()),
-        });
-      }
-    }
-
-    const data = (body as { data?: unknown }).data;
-    if (data == null || typeof data !== "object" || Array.isArray(data)) {
-      throw invalidResponse("Midnight indexer response is missing data");
-    }
-
-    const block = (data as { block?: unknown }).block;
-    if (block == null || typeof block !== "object" || Array.isArray(block)) {
-      throw invalidResponse("Midnight indexer response is missing block");
-    }
-
-    const height = (block as { height?: unknown }).height;
-    if (
-      typeof height !== "number" ||
-      !Number.isFinite(height) ||
-      !Number.isSafeInteger(height) ||
-      height < 0
-    ) {
-      throw invalidResponse("Midnight indexer returned an invalid block height");
-    }
-
-    return { height };
+    return body;
   } finally {
     clearDeadline();
-    validated.signal?.removeEventListener("abort", onCallerAbort);
+    signal?.removeEventListener("abort", onCallerAbort);
   }
+}
+
+/** Query one validated numeric block height from an explicit Midnight indexer. */
+export async function getMidnightTip(
+  options: GetMidnightTipOptions,
+): Promise<MidnightTip> {
+  const validated = validateOptions(options);
+  const body = await postJsonRequest(
+    validated.indexer,
+    { query: "query { block { height } }" },
+    validated.requestTimeoutMs,
+    validated.signal,
+  );
+
+  if (body == null || typeof body !== "object" || Array.isArray(body)) {
+    throw invalidResponse("Midnight indexer returned a non-object GraphQL response");
+  }
+
+  if ("errors" in body) {
+    const errors = (body as { errors?: unknown }).errors;
+    if (!Array.isArray(errors)) {
+      throw invalidResponse("Midnight indexer returned a malformed GraphQL errors field");
+    }
+    if (errors.length > 0) {
+      throw new MidnightTipError("GRAPHQL", "Midnight indexer returned GraphQL errors", {
+        graphqlErrors: Object.freeze(errors.slice()),
+      });
+    }
+  }
+
+  const data = (body as { data?: unknown }).data;
+  if (data == null || typeof data !== "object" || Array.isArray(data)) {
+    throw invalidResponse("Midnight indexer response is missing data");
+  }
+
+  const block = (data as { block?: unknown }).block;
+  if (block == null || typeof block !== "object" || Array.isArray(block)) {
+    throw invalidResponse("Midnight indexer response is missing block");
+  }
+
+  const height = (block as { height?: unknown }).height;
+  if (
+    typeof height !== "number" ||
+    !Number.isFinite(height) ||
+    !Number.isSafeInteger(height) ||
+    height < 0
+  ) {
+    throw invalidResponse("Midnight indexer returned an invalid block height");
+  }
+
+  return { height };
 }

--- a/packages/node-sdk/sync/src/sync-protocols/mod.ts
+++ b/packages/node-sdk/sync/src/sync-protocols/mod.ts
@@ -3,6 +3,7 @@ export * from "./evm/state.ts";
 
 export * from "./midnight/fetcher.ts";
 export * from "./midnight/state.ts";
+export * from "./midnight/tip.ts";
 
 export * from "./avail/fetcher.ts";
 export * from "./avail/state.ts";

--- a/packages/node-sdk/sync/test/examples.test.ts
+++ b/packages/node-sdk/sync/test/examples.test.ts
@@ -15,4 +15,6 @@ test("README: per-chain fetchers and states are exported", () => {
   expect("AvailFetcher" in sync).toBe(true);
   expect("UtxoRpcFetcher" in sync).toBe(true);
   expect("CelestiaFetcher" in sync).toBe(true);
+  expect(typeof sync.getMidnightTip).toBe("function");
+  expect(typeof sync.MidnightTipError).toBe("function");
 });

--- a/packages/node-sdk/sync/test/midnight-tip.test.ts
+++ b/packages/node-sdk/sync/test/midnight-tip.test.ts
@@ -172,6 +172,46 @@ describe("getMidnightTip request contract", () => {
     },
   );
 
+  test.each([
+    [301, "Moved Permanently"],
+    [307, "Temporary Redirect"],
+  ])(
+    "treats redirect status %d as HTTP without following the target",
+    async (status, statusText) => {
+      const target = await startFixture(() =>
+        json({ data: { block: { height: 999 } } }));
+      const origin = await startFixture(() =>
+        new Response(null, {
+          status,
+          statusText,
+          headers: { Location: target.url },
+        }));
+
+      let value: unknown;
+      let caught: unknown;
+      try {
+        value = await getMidnightTip({ indexer: origin.url });
+      } catch (error) {
+        caught = error;
+      }
+
+      expect({ originHits: origin.hits, targetHits: target.hits, value }).toEqual({
+        originHits: 1,
+        targetHits: 0,
+        value: undefined,
+      });
+      expect(caught).toBeInstanceOf(MidnightTipError);
+      const error = caught as MidnightTipError;
+      expect(error.code).toBe("HTTP");
+      expect(error.status).toBe(status);
+      expect(error.statusText).toBe(statusText);
+      expect(error.cause).toBeUndefined();
+      expect(error.graphqlErrors).toBeUndefined();
+      await expectFixtureIdle(origin);
+      await expectFixtureIdle(target);
+    },
+  );
+
   test("reports HTTP before attempting body parsing", async () => {
     const fixture = await startFixture(() =>
       new Response("not-json", { status: 503, statusText: "Service Unavailable" }));
@@ -334,11 +374,13 @@ describe("getMidnightTip option and transport failures", () => {
     ["fractional timeout", { indexer: "http://127.0.0.1:10001", requestTimeoutMs: 1.5 }],
     ["infinite timeout", { indexer: "http://127.0.0.1:10001", requestTimeoutMs: Infinity }],
     ["NaN timeout", { indexer: "http://127.0.0.1:10001", requestTimeoutMs: NaN }],
+    ["null timeout", { indexer: "http://127.0.0.1:10001", requestTimeoutMs: null }],
     [
       "unsafe timeout",
       { indexer: "http://127.0.0.1:10001", requestTimeoutMs: Number.MAX_SAFE_INTEGER + 1 },
     ],
     ["invalid signal", { indexer: "http://127.0.0.1:10001", signal: {} }],
+    ["null signal", { indexer: "http://127.0.0.1:10001", signal: null }],
   ])("validates %s before timer or I/O allocation", async (_name, options) => {
     const runtime = globalThis as any;
     const originalFetch = runtime.fetch;

--- a/packages/node-sdk/sync/test/midnight-tip.test.ts
+++ b/packages/node-sdk/sync/test/midnight-tip.test.ts
@@ -1,0 +1,652 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  getMidnightTip,
+  MidnightTipError,
+} from "../src/sync-protocols/midnight/tip.ts";
+
+type TestServer = ReturnType<typeof Bun.serve>;
+
+type Fixture = {
+  server: TestServer;
+  url: string;
+  port: number;
+  hits: number;
+  activeRequests: number;
+};
+
+const fixtures = new Set<Fixture>();
+
+async function startFixture(
+  handler: (request: Request) => Response | Promise<Response>,
+): Promise<Fixture> {
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt < 50; attempt++) {
+    try {
+      let fixture!: Fixture;
+      const server = Bun.serve({
+        hostname: "127.0.0.1",
+        port: 0,
+        async fetch(request) {
+          fixture.hits++;
+          fixture.activeRequests++;
+          try {
+            return await handler(request);
+          } finally {
+            fixture.activeRequests--;
+          }
+        },
+      });
+      const port = server.port;
+      if (port <= 10_000) {
+        await server.stop(true);
+        continue;
+      }
+
+      fixture = {
+        server,
+        url: `http://127.0.0.1:${port}/graphql`,
+        port,
+        hits: 0,
+        activeRequests: 0,
+      };
+      fixtures.add(fixture);
+      return fixture;
+    } catch (error) {
+      lastError = error;
+    }
+  }
+
+  throw lastError ?? new Error("Unable to allocate a loopback fixture port above 10000");
+}
+
+async function stopFixture(fixture: Fixture): Promise<void> {
+  fixtures.delete(fixture);
+  await fixture.server.stop(true);
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  label: string,
+  timeoutMs = 2_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() >= deadline) throw new Error(`Timed out waiting for ${label}`);
+    await Bun.sleep(5);
+  }
+}
+
+async function expectFixtureIdle(fixture: Fixture): Promise<void> {
+  await waitFor(
+    () =>
+      fixture.activeRequests === 0 &&
+      Number((fixture.server as TestServer & { pendingRequests?: number }).pendingRequests ?? 0) === 0,
+    "fixture request cleanup",
+  );
+}
+
+function json(value: unknown, status = 200): Response {
+  return Response.json(value, { status });
+}
+
+async function expectTipError(
+  promise: Promise<unknown>,
+  code: MidnightTipError["code"],
+): Promise<MidnightTipError> {
+  try {
+    await promise;
+  } catch (error) {
+    expect(error).toBeInstanceOf(MidnightTipError);
+    expect((error as MidnightTipError).code).toBe(code);
+    return error as MidnightTipError;
+  }
+  throw new Error(`Expected MidnightTipError(${code}) without a partial value`);
+}
+
+function trackedAbortSignal(): {
+  signal: AbortSignal;
+  abort: (reason?: unknown) => void;
+  listenerCount: () => number;
+} {
+  const controller = new AbortController();
+  const listeners = new Set<EventListenerOrEventListenerObject>();
+  const signal = {
+    get aborted() {
+      return controller.signal.aborted;
+    },
+    get reason() {
+      return controller.signal.reason;
+    },
+    addEventListener(
+      type: string,
+      listener: EventListenerOrEventListenerObject,
+      options?: AddEventListenerOptions | boolean,
+    ) {
+      if (type === "abort") listeners.add(listener);
+      controller.signal.addEventListener(type, listener, options);
+    },
+    removeEventListener(
+      type: string,
+      listener: EventListenerOrEventListenerObject,
+      options?: EventListenerOptions | boolean,
+    ) {
+      if (type === "abort") listeners.delete(listener);
+      controller.signal.removeEventListener(type, listener, options);
+    },
+  } as AbortSignal;
+
+  return {
+    signal,
+    abort: (reason?: unknown) => controller.abort(reason),
+    listenerCount: () => listeners.size,
+  };
+}
+
+afterEach(async () => {
+  const remaining = [...fixtures];
+  fixtures.clear();
+  for (const fixture of remaining) await fixture.server.stop(true);
+});
+
+describe("getMidnightTip request contract", () => {
+  test.each([0, 917_331, Number.MAX_SAFE_INTEGER])(
+    "performs one exact POST and accepts height %d",
+    async (height) => {
+      let method: string | undefined;
+      let body: string | undefined;
+      let contentType: string | null | undefined;
+      const fixture = await startFixture(async (request) => {
+        method = request.method;
+        body = await request.text();
+        contentType = request.headers.get("content-type");
+        return json({ data: { block: { height } } });
+      });
+
+      await expect(getMidnightTip({ indexer: fixture.url })).resolves.toEqual({ height });
+      expect(fixture.hits).toBe(1);
+      expect(method).toBe("POST");
+      expect(body).toBe('{"query":"query { block { height } }"}');
+      expect(contentType).toBe("application/json");
+      await expectFixtureIdle(fixture);
+    },
+  );
+
+  test("reports HTTP before attempting body parsing", async () => {
+    const fixture = await startFixture(() =>
+      new Response("not-json", { status: 503, statusText: "Service Unavailable" }));
+
+    const error = await expectTipError(getMidnightTip({ indexer: fixture.url }), "HTTP");
+    expect(error.status).toBe(503);
+    expect(error.statusText).toBe("Service Unavailable");
+    expect(error.cause).toBeUndefined();
+    expect(error.graphqlErrors).toBeUndefined();
+    expect(fixture.hits).toBe(1);
+    await expectFixtureIdle(fixture);
+  });
+
+  test("cancels an unread streaming body before settling HTTP", async () => {
+    const runtime = globalThis as typeof globalThis & { fetch: typeof fetch };
+    const originalFetch = runtime.fetch;
+    let attempts = 0;
+    let streamCancelled = 0;
+    runtime.fetch = (async () => {
+      attempts++;
+      return new Response(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode("not-json"));
+          },
+          cancel() {
+            streamCancelled++;
+          },
+        }),
+        { status: 503, statusText: "Service Unavailable" },
+      );
+    }) as typeof fetch;
+
+    try {
+      const error = await expectTipError(
+        getMidnightTip({ indexer: "http://127.0.0.1:10001/graphql" }),
+        "HTTP",
+      );
+      expect(error.status).toBe(503);
+      expect(error.statusText).toBe("Service Unavailable");
+      expect(attempts).toBe(1);
+      expect(streamCancelled).toBe(1);
+    } finally {
+      runtime.fetch = originalFetch;
+    }
+  });
+
+  test("GraphQL errors win over partial data", async () => {
+    const fixture = await startFixture(() =>
+      json({
+        errors: [{ message: "bad query" }],
+        data: { block: { height: 42 } },
+      }));
+
+    const error = await expectTipError(getMidnightTip({ indexer: fixture.url }), "GRAPHQL");
+    expect(error.graphqlErrors).toEqual([{ message: "bad query" }]);
+    expect(Object.isFrozen(error.graphqlErrors)).toBe(true);
+    expect(error.status).toBeUndefined();
+    expect(error.cause).toBeUndefined();
+    expect(fixture.hits).toBe(1);
+    await expectFixtureIdle(fixture);
+  });
+
+  test("GraphQL error details are a frozen shallow copy", async () => {
+    const runtime = globalThis as typeof globalThis & { fetch: typeof fetch };
+    const originalFetch = runtime.fetch;
+    const detail = { message: "same object" };
+    const details = [detail];
+    let attempts = 0;
+    runtime.fetch = (async () => {
+      attempts++;
+      return {
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        json: async () => ({ errors: details }),
+      } as Response;
+    }) as typeof fetch;
+
+    try {
+      const error = await expectTipError(
+        getMidnightTip({ indexer: "http://127.0.0.1:10001/graphql" }),
+        "GRAPHQL",
+      );
+      expect(attempts).toBe(1);
+      expect(error.graphqlErrors).not.toBe(details);
+      expect(error.graphqlErrors?.[0]).toBe(detail);
+      expect(Object.isFrozen(error.graphqlErrors)).toBe(true);
+    } finally {
+      runtime.fetch = originalFetch;
+    }
+  });
+
+  test("an empty GraphQL errors array does not mask valid data", async () => {
+    const fixture = await startFixture(() =>
+      json({ errors: [], data: { block: { height: 42 } } }));
+    await expect(getMidnightTip({ indexer: fixture.url })).resolves.toEqual({ height: 42 });
+    expect(fixture.hits).toBe(1);
+    await expectFixtureIdle(fixture);
+  });
+
+  test("malformed JSON is INVALID_RESPONSE and preserves the parser cause", async () => {
+    const fixture = await startFixture(() =>
+      new Response("{", { headers: { "Content-Type": "application/json" } }));
+    const error = await expectTipError(
+      getMidnightTip({ indexer: fixture.url }),
+      "INVALID_RESPONSE",
+    );
+    expect(error.cause).toBeInstanceOf(Error);
+    expect(error.status).toBeUndefined();
+    expect(error.graphqlErrors).toBeUndefined();
+    expect(fixture.hits).toBe(1);
+    await expectFixtureIdle(fixture);
+  });
+
+  test.each([
+    ["array body", "[]"],
+    ["null body", "null"],
+    ["scalar body", "true"],
+    ["present non-array errors", '{"errors":{}}'],
+    ["present null errors", '{"errors":null}'],
+    ["missing data", "{}"],
+    ["null data", '{"data":null}'],
+    ["array data", '{"data":[]}'],
+    ["missing block", '{"data":{}}'],
+    ["null block", '{"data":{"block":null}}'],
+    ["array block", '{"data":{"block":[]}}'],
+    ["missing height", '{"data":{"block":{}}}'],
+    ["null height", '{"data":{"block":{"height":null}}}'],
+    ["string height", '{"data":{"block":{"height":"12"}}}'],
+    ["fractional height", '{"data":{"block":{"height":1.5}}}'],
+    ["negative height", '{"data":{"block":{"height":-1}}}'],
+    ["non-finite height", '{"data":{"block":{"height":1e400}}}'],
+    ["unsafe height", '{"data":{"block":{"height":9007199254740992}}}'],
+  ])("rejects %s without retry or partial data", async (_name, rawBody) => {
+    const fixture = await startFixture(() =>
+      new Response(rawBody, { headers: { "Content-Type": "application/json" } }));
+    const error = await expectTipError(
+      getMidnightTip({ indexer: fixture.url }),
+      "INVALID_RESPONSE",
+    );
+    expect(error.status).toBeUndefined();
+    expect(error.graphqlErrors).toBeUndefined();
+    expect(fixture.hits).toBe(1);
+    await expectFixtureIdle(fixture);
+  });
+});
+
+describe("getMidnightTip option and transport failures", () => {
+  test.each([
+    ["missing options", undefined],
+    ["null options", null],
+    ["missing indexer", {}],
+    ["non-string indexer", { indexer: new URL("http://127.0.0.1:10001") }],
+    ["empty URL", { indexer: "" }],
+    ["relative URL", { indexer: "/graphql" }],
+    ["unsupported protocol", { indexer: "ftp://127.0.0.1:10001/graphql" }],
+    ["zero timeout", { indexer: "http://127.0.0.1:10001", requestTimeoutMs: 0 }],
+    ["negative timeout", { indexer: "http://127.0.0.1:10001", requestTimeoutMs: -1 }],
+    ["fractional timeout", { indexer: "http://127.0.0.1:10001", requestTimeoutMs: 1.5 }],
+    ["infinite timeout", { indexer: "http://127.0.0.1:10001", requestTimeoutMs: Infinity }],
+    ["NaN timeout", { indexer: "http://127.0.0.1:10001", requestTimeoutMs: NaN }],
+    [
+      "unsafe timeout",
+      { indexer: "http://127.0.0.1:10001", requestTimeoutMs: Number.MAX_SAFE_INTEGER + 1 },
+    ],
+    ["invalid signal", { indexer: "http://127.0.0.1:10001", signal: {} }],
+  ])("validates %s before timer or I/O allocation", async (_name, options) => {
+    const runtime = globalThis as any;
+    const originalFetch = runtime.fetch;
+    const originalSetTimeout = runtime.setTimeout;
+    let fetches = 0;
+    let timers = 0;
+    runtime.fetch = () => {
+      fetches++;
+      throw new Error("fetch must not be called");
+    };
+    runtime.setTimeout = (...args: unknown[]) => {
+      timers++;
+      return originalSetTimeout(...args);
+    };
+
+    try {
+      await expectTipError(getMidnightTip(options as any), "INVALID_OPTIONS");
+      expect(fetches).toBe(0);
+      expect(timers).toBe(0);
+    } finally {
+      runtime.fetch = originalFetch;
+      runtime.setTimeout = originalSetTimeout;
+    }
+  });
+
+  test("already-aborted input preserves its reason and performs no timer or fetch", async () => {
+    const runtime = globalThis as any;
+    const originalFetch = runtime.fetch;
+    const originalSetTimeout = runtime.setTimeout;
+    const caller = trackedAbortSignal();
+    const reason = new Error("caller stopped");
+    let fetches = 0;
+    let timers = 0;
+    caller.abort(reason);
+    runtime.fetch = () => {
+      fetches++;
+      throw new Error("fetch must not be called");
+    };
+    runtime.setTimeout = (...args: unknown[]) => {
+      timers++;
+      return originalSetTimeout(...args);
+    };
+
+    try {
+      const error = await expectTipError(
+        getMidnightTip({ indexer: "http://127.0.0.1:10001", signal: caller.signal }),
+        "ABORTED",
+      );
+      expect(error.cause).toBe(reason);
+      expect(error.status).toBeUndefined();
+      expect(error.graphqlErrors).toBeUndefined();
+      expect(fetches).toBe(0);
+      expect(timers).toBe(0);
+      expect(caller.listenerCount()).toBe(0);
+    } finally {
+      runtime.fetch = originalFetch;
+      runtime.setTimeout = originalSetTimeout;
+    }
+  });
+
+  test("a local connection rejection is NETWORK with the original cause and one attempt", async () => {
+    const fixture = await startFixture(() => json({ data: { block: { height: 1 } } }));
+    const { url, port } = fixture;
+    await stopFixture(fixture);
+
+    const runtime = globalThis as typeof globalThis & { fetch: typeof fetch };
+    const originalFetch = runtime.fetch;
+    let attempts = 0;
+    runtime.fetch = ((input: URL | RequestInfo, init?: RequestInit) => {
+      attempts++;
+      return originalFetch(input, init);
+    }) as typeof fetch;
+
+    try {
+      const error = await expectTipError(
+        getMidnightTip({ indexer: url, requestTimeoutMs: 500 }),
+        "NETWORK",
+      );
+      expect(attempts).toBe(1);
+      expect(error.cause).toBeDefined();
+      expect(error.status).toBeUndefined();
+      expect(error.graphqlErrors).toBeUndefined();
+    } finally {
+      runtime.fetch = originalFetch;
+    }
+
+    const rebound = Bun.serve({
+      hostname: "127.0.0.1",
+      port,
+      fetch: () => new Response(),
+    });
+    await rebound.stop(true);
+  });
+});
+
+describe("getMidnightTip cancellation, deadline, and cleanup", () => {
+  async function stalledResponse(request: Request): Promise<Response> {
+    await new Promise<void>((resolve) => {
+      if (request.signal.aborted) {
+        resolve();
+        return;
+      }
+      const onAbort = () => {
+        request.signal.removeEventListener("abort", onAbort);
+        resolve();
+      };
+      request.signal.addEventListener("abort", onAbort, { once: true });
+    });
+    return new Response(null, { status: 499 });
+  }
+
+  test("caller abort wins after one request and releases request/listener/timer ownership", async () => {
+    const fixture = await startFixture(stalledResponse);
+    const caller = trackedAbortSignal();
+    const reason = { caller: true };
+    const pending = getMidnightTip({
+      indexer: fixture.url,
+      signal: caller.signal,
+      requestTimeoutMs: 1_000,
+    });
+    await waitFor(() => fixture.hits === 1, "caller-abort fixture request");
+    expect(caller.listenerCount()).toBe(1);
+    caller.abort(reason);
+
+    const error = await expectTipError(pending, "ABORTED");
+    expect(error.cause).toBe(reason);
+    expect(error.status).toBeUndefined();
+    expect(error.graphqlErrors).toBeUndefined();
+    expect(fixture.hits).toBe(1);
+    expect(caller.listenerCount()).toBe(0);
+    await expectFixtureIdle(fixture);
+  });
+
+  test("timeout wins after one request and stays authoritative over a later caller abort", async () => {
+    const fixture = await startFixture(stalledResponse);
+    const caller = trackedAbortSignal();
+    const lateReason = new Error("late caller abort");
+    const pending = getMidnightTip({
+      indexer: fixture.url,
+      signal: caller.signal,
+      requestTimeoutMs: 300,
+    });
+    await waitFor(() => fixture.hits === 1, "timeout fixture request");
+
+    const error = await expectTipError(pending, "TIMEOUT");
+    caller.abort(lateReason);
+    expect(error.cause).toBeUndefined();
+    expect(error.status).toBeUndefined();
+    expect(error.graphqlErrors).toBeUndefined();
+    expect(fixture.hits).toBe(1);
+    expect(caller.listenerCount()).toBe(0);
+    await expectFixtureIdle(fixture);
+  });
+
+  test("default and host-boundary deadlines are exact, chunked, and cleared", async () => {
+    type CapturedTimer = {
+      callback: () => void;
+      delay: number;
+      cleared: boolean;
+    };
+    const runtime = globalThis as any;
+    const originalSetTimeout = runtime.setTimeout;
+    const originalClearTimeout = runtime.clearTimeout;
+    const originalFetch = runtime.fetch;
+    const timers: CapturedTimer[] = [];
+    let fetchMode: "pending" | "success" = "pending";
+    let activeFetches = 0;
+
+    runtime.setTimeout = (callback: () => void, delay: number) => {
+      const timer = { callback, delay, cleared: false };
+      timers.push(timer);
+      return timer;
+    };
+    runtime.clearTimeout = (timer: CapturedTimer) => {
+      timer.cleared = true;
+    };
+    runtime.fetch = (_input: unknown, init?: RequestInit) => {
+      if (fetchMode === "success") {
+        return Promise.resolve(json({ data: { block: { height: 99 } } }));
+      }
+      activeFetches++;
+      const signal = init?.signal;
+      return new Promise<Response>((_resolve, reject) => {
+        const rejectAbort = () => {
+          activeFetches--;
+          reject(signal?.reason);
+        };
+        if (signal?.aborted) rejectAbort();
+        else signal?.addEventListener("abort", rejectAbort, { once: true });
+      });
+    };
+
+    try {
+      fetchMode = "success";
+      await expect(getMidnightTip({
+        indexer: "http://127.0.0.1:10001/graphql",
+      })).resolves.toEqual({ height: 99 });
+      expect(timers).toHaveLength(1);
+      expect(timers[0].delay).toBe(15_000);
+      expect(timers[0].cleared).toBe(true);
+
+      timers.length = 0;
+      fetchMode = "pending";
+      const exactMax = getMidnightTip({
+        indexer: "http://127.0.0.1:10001/graphql",
+        requestTimeoutMs: 2_147_483_647,
+      });
+      expect(timers).toHaveLength(1);
+      expect(timers[0].delay).toBe(2_147_483_647);
+      timers[0].callback();
+      await expectTipError(exactMax, "TIMEOUT");
+      expect(activeFetches).toBe(0);
+
+      timers.length = 0;
+      const aboveMax = getMidnightTip({
+        indexer: "http://127.0.0.1:10001/graphql",
+        requestTimeoutMs: 2_147_483_648,
+      });
+      let aboveMaxSettled = false;
+      void aboveMax.then(
+        () => { aboveMaxSettled = true; },
+        () => { aboveMaxSettled = true; },
+      );
+      expect(timers).toHaveLength(1);
+      expect(timers[0].delay).toBe(2_147_483_647);
+      timers[0].callback();
+      expect(timers).toHaveLength(2);
+      expect(timers[1].delay).toBe(1);
+      await Promise.resolve();
+      expect(aboveMaxSettled).toBe(false);
+      timers[1].callback();
+      await expectTipError(aboveMax, "TIMEOUT");
+      expect(activeFetches).toBe(0);
+
+      timers.length = 0;
+      const caller = trackedAbortSignal();
+      const reason = new Error("caller cancelled long deadline");
+      const aborted = getMidnightTip({
+        indexer: "http://127.0.0.1:10001/graphql",
+        requestTimeoutMs: 2_147_483_648,
+        signal: caller.signal,
+      });
+      expect(caller.listenerCount()).toBe(1);
+      expect(timers[0].delay).toBe(2_147_483_647);
+      caller.abort(reason);
+      const abortedError = await expectTipError(aborted, "ABORTED");
+      expect(abortedError.cause).toBe(reason);
+      expect(timers[0].cleared).toBe(true);
+      expect(caller.listenerCount()).toBe(0);
+      expect(activeFetches).toBe(0);
+    } finally {
+      runtime.setTimeout = originalSetTimeout;
+      runtime.clearTimeout = originalClearTimeout;
+      runtime.fetch = originalFetch;
+    }
+  });
+
+  test("deadline and caller listener are cleared across non-cancellation settlements", async () => {
+    type CapturedTimer = { cleared: boolean };
+    const runtime = globalThis as any;
+    const originalSetTimeout = runtime.setTimeout;
+    const originalClearTimeout = runtime.clearTimeout;
+    const originalFetch = runtime.fetch;
+    const outcomes: Array<{
+      code?: MidnightTipError["code"];
+      fetch: () => Promise<Response>;
+    }> = [
+      { fetch: async () => json({ data: { block: { height: 7 } } }) },
+      { code: "NETWORK", fetch: async () => { throw new Error("network"); } },
+      { code: "HTTP", fetch: async () => new Response(null, { status: 503 }) },
+      { code: "GRAPHQL", fetch: async () => json({ errors: [{ message: "bad" }] }) },
+      { code: "INVALID_RESPONSE", fetch: async () => json({ data: null }) },
+    ];
+
+    try {
+      for (const outcome of outcomes) {
+        const timers: CapturedTimer[] = [];
+        const caller = trackedAbortSignal();
+        let attempts = 0;
+        runtime.setTimeout = () => {
+          const timer = { cleared: false };
+          timers.push(timer);
+          return timer;
+        };
+        runtime.clearTimeout = (timer: CapturedTimer) => {
+          timer.cleared = true;
+        };
+        runtime.fetch = () => {
+          attempts++;
+          return outcome.fetch();
+        };
+
+        const pending = getMidnightTip({
+          indexer: "http://127.0.0.1:10001/graphql",
+          signal: caller.signal,
+        });
+        if (outcome.code) await expectTipError(pending, outcome.code);
+        else await expect(pending).resolves.toEqual({ height: 7 });
+
+        expect(attempts).toBe(1);
+        expect(timers).toHaveLength(1);
+        expect(timers[0].cleared).toBe(true);
+        expect(caller.listenerCount()).toBe(0);
+      }
+    } finally {
+      runtime.setTimeout = originalSetTimeout;
+      runtime.clearTimeout = originalClearTimeout;
+      runtime.fetch = originalFetch;
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Export `getMidnightTip({ indexer, requestTimeoutMs?, signal? }): Promise<{ height: number }>` and `MidnightTipError` from the public `@effectstream/sync` chain.
- Perform exactly one bounded POST with JSON body `{ "query": "query { block { height } }" }` to the mandatory caller-supplied absolute HTTP(S) indexer.
- Return only a validated non-negative safe-integer height; classify failures with stable `INVALID_OPTIONS`, `ABORTED`, `TIMEOUT`, `NETWORK`, `HTTP`, `GRAPHQL`, and `INVALID_RESPONSE` codes.
- Own and clean the request controller, caller abort listener, chunked deadline, and unread non-2xx response body. Automatic redirects are disabled, so redirects remain one-request `HTTP` failures. There is no retry, polling, cache, persistence, endpoint selection, or partial return.

## Audit remediation

Delivery-audit Cycle 1 identified three gaps. The second commit closes all three without amending the first commit:

- F1: set `redirect: "manual"`; deterministic 301 and 307 fixtures prove one origin hit, zero redirect-target hits, original HTTP status, and no partial value.
- F2: default `requestTimeoutMs` only for strict `undefined`; `null` now returns `INVALID_OPTIONS` before timer or fetch allocation.
- F3: reject `signal: null` as `INVALID_OPTIONS` before member access, timer allocation, or fetch.

Independent Cycle 2 review is **PASS** with **BLOCKER 0 / MAJOR 0 / MINOR 0 / NIT 0** at audited head `5f61efee0f4346c0a316fe8f7a4353d3a8e2391d` and tree `d9d53ba61da8e4b20de58f90ee752beb9af5ee7b`.

## Verification

Authoritative disposable `linux/amd64` Docker runs used Bun `1.3.10`, `--rm`, `--network none`, no published ports, and loopback-only fixtures on OS-selected ports above 10000:

- focused helper plus public exports: **53 pass / 0 fail / 309 assertions**;
- three fresh focused repeats: **51 pass / 0 fail / 300 assertions** each;
- complete sync suite: **80 pass / 0 fail / 447 assertions**;
- separate public examples: **2 pass / 0 fail / 9 assertions**.

The repository-wide `bun test ./packages` command is recorded honestly as nonzero: **460 pass / 4 skip / 27 fail / 11 errors / 1380 assertions**. All 51 Midnight-tip cases passed. Known unchanged DB/PGlite loader, timing/close, and runtime subprocess failure classes recur. The only additional broad-run Cardano seed-connect timeout is in an unchanged path and dependency seam; alternating isolation gave base 3/3 passes at 5.461s, 5.223s, and 4.463s, while the candidate gave 2/3 passes at 5.139s and 5.125s plus one 6.031s timeout. Independent re-audit then reproduced the same candidate image both timing out at the exact 5.001s cutoff and passing fresh at 4.669s, classifying it as amd64 threshold instability rather than a deterministic feature regression.

The full README generator check remains nonzero on both exact base and candidate with byte-identical output naming only four pre-existing unrelated drifts: `midnight-contracts.md`, `midnight-indexer.md`, `midnight-node.md`, and `midnight-proof-server.md`. A scoped write proves committed `docs/site/docs/home/500-packages/520-node/sync.md` is byte-identical to generated output; the four unrelated pages are excluded.

Structural gates pass: `git diff --check`; exactly **6 changed paths / 1027 insertions / no deletions**:

- `packages/node-sdk/sync/src/sync-protocols/midnight/tip.ts`
- `packages/node-sdk/sync/src/sync-protocols/mod.ts`
- `packages/node-sdk/sync/test/midnight-tip.test.ts`
- `packages/node-sdk/sync/test/examples.test.ts`
- `packages/node-sdk/sync/README.md`
- `docs/site/docs/home/500-packages/520-node/sync.md`

No `MidnightClient`, fetcher/state, `midnight-env.ts`, generic config/runtime/schema/database, node source, manifest, lockfile, template, workflow, Docker, or unrelated documentation path changes. Searches find no endpoint literal, network/profile selection, retry, polling, cache, persistence, or `"latest"` policy in the helper.

## Planning and review records

- [Approved specification](https://github.com/acedward/plans-and-todos/blob/main/Effectstream/spec/00028-midnight-tip-query.md)
- [Master plan](https://github.com/acedward/plans-and-todos/blob/main/Effectstream/plans/00028-midnight-tip-query.md)
- [Plan-design audit](https://github.com/acedward/plans-and-todos/blob/main/Effectstream/audits/00028-midnight-tip-query-plan-design.md)
- [Delivery audit](https://github.com/acedward/plans-and-todos/blob/main/Effectstream/audits/00028-midnight-tip-query-delivery.md)

## Scope boundary

Profiles/endpoints, `"latest"` policy, persistence/provenance, primitive inheritance, templates, wallets/funding/faucets, deployment, release/publication, and merge are explicitly out of scope. No live Midnight endpoint was queried.

**No breaking changes.**

This PR targets `v-next`, is intentionally non-draft, and must remain open and unmerged; auto-merge is not enabled.