### PR TITLE
fix(release): poll npm package visibility

### DIFF
--- a/.github/publish-bun.effectstream.test.ts
+++ b/.github/publish-bun.effectstream.test.ts
@@ -10,7 +10,9 @@ import {
   compareSemver,
   parseSemver,
   planRegistryCompletion,
+  pollRegistryPostconditions,
   preflightOrdinary,
+  readRegistryVisibilityState,
   resolveDistTag,
   resolveReleasePolicy,
   resolveReleaseVersion,
@@ -70,6 +72,327 @@ function manifest(policy: ReleasePolicy): ReleaseManifest {
     })),
   };
 }
+
+type VisibilityReader = (
+  registry: string,
+  name: string,
+  targetVersion: string,
+  signal: AbortSignal,
+) => Promise<RegistryPackageState & { documentReadable: boolean }>;
+
+type VisibilityPollingOptions = {
+  timeoutMs: number;
+  initialBackoffMs: number;
+  maxBackoffMs: number;
+  reader: VisibilityReader;
+  now: () => number;
+  sleep: (ms: number, signal: AbortSignal) => Promise<void>;
+  scheduleDeadline: (ms: number, onDeadline: () => void) => () => void;
+};
+
+async function pollPostconditions(
+  item: ReleaseManifest,
+  options: VisibilityPollingOptions,
+): Promise<void> {
+  await pollRegistryPostconditions(item, "https://registry.example.test", options);
+}
+
+function visibleState(
+  item: ReleaseManifest,
+  name: string,
+  overrides: Partial<RegistryPackageState & { documentReadable: boolean }> = {},
+): RegistryPackageState & { documentReadable: boolean } {
+  const pkg = item.packages.find((candidate) => candidate.name === name)!;
+  const latest = item.kind === "node2-stable" ? item.version : item.latestBefore[name];
+  return {
+    name,
+    documentReadable: true,
+    targetIntegrity: pkg.integrity,
+    distTags: { latest, [item.distTag]: item.version },
+    ...overrides,
+  };
+}
+
+function fakeTiming() {
+  let current = 0;
+  const sleeps: number[] = [];
+  return {
+    now: () => current,
+    setNow: (value: number) => { current = value; },
+    sleeps,
+    sleep: async (ms: number, signal: AbortSignal) => {
+      if (signal.aborted) throw signal.reason;
+      sleeps.push(ms);
+      current += ms;
+    },
+    scheduleDeadline: (_ms: number, _onDeadline: () => void) => () => {},
+  };
+}
+
+describe("post-publish visibility polling", () => {
+  test("registry reads distinguish true 404 and request fresh metadata", async () => {
+    let requestInit: RequestInit | undefined;
+    const state = await readRegistryVisibilityState(
+      "https://registry.example.test",
+      "@effectstream/missing",
+      "0.200.5",
+      (async (_input: string | URL | Request, init?: RequestInit) => {
+        requestInit = init;
+        return new Response(null, { status: 404 });
+      }) as typeof fetch,
+    );
+    expect((state as RegistryPackageState & { documentReadable?: boolean }).documentReadable).toBe(false);
+    expect(requestInit?.cache).toBe("no-store");
+    const headers = new Headers(requestInit?.headers);
+    expect(headers.get("cache-control")).toContain("no-cache");
+    expect(headers.get("pragma")).toBe("no-cache");
+  });
+
+  test("retries two absent reads and succeeds only on one coherent round", async () => {
+    const item = manifest(resolveReleasePolicy("v0.200.3"));
+    const timing = fakeTiming();
+    const reads = new Map<string, number>();
+    await pollPostconditions(item, {
+      timeoutMs: 100,
+      initialBackoffMs: 5,
+      maxBackoffMs: 20,
+      ...timing,
+      reader: async (_registry, name) => {
+        const count = (reads.get(name) ?? 0) + 1;
+        reads.set(name, count);
+        if (name === packageNames[0] && count < 3) {
+          return visibleState(item, name, { targetIntegrity: null, distTags: { latest: "0.200.2" } });
+        }
+        return visibleState(item, name);
+      },
+    });
+    expect(reads.get(packageNames[0])).toBe(3);
+    expect(timing.sleeps).toEqual([5, 10]);
+    expect(new Set(reads.values())).toEqual(new Set([3]));
+  });
+
+  test("waits for the required tag after exact integrity is visible", async () => {
+    const item = manifest(resolveReleasePolicy("v0.104.2"));
+    const timing = fakeTiming();
+    let targetReads = 0;
+    await pollPostconditions(item, {
+      timeoutMs: 100,
+      initialBackoffMs: 5,
+      maxBackoffMs: 20,
+      ...timing,
+      reader: async (_registry, name) => {
+        if (name !== packageNames[0]) return visibleState(item, name);
+        targetReads++;
+        return targetReads === 1
+          ? visibleState(item, name, { distTags: { latest: "0.200.2", "midnight-1": "0.104.1" } })
+          : visibleState(item, name);
+      },
+    });
+    expect(targetReads).toBe(2);
+    expect(timing.sleeps).toEqual([5]);
+  });
+
+  test("does not accumulate per-package success across incoherent rounds", async () => {
+    const item = manifest(resolveReleasePolicy("v0.200.3"));
+    const timing = fakeTiming();
+    let round = 0;
+    await expect(pollPostconditions(item, {
+      timeoutMs: 15,
+      initialBackoffMs: 5,
+      maxBackoffMs: 5,
+      ...timing,
+      reader: async (_registry, name) => {
+        if (name === packageNames[0]) {
+          return round === 0 ? visibleState(item, name) : visibleState(item, name, { targetIntegrity: null, distTags: { latest: "0.200.2" } });
+        }
+        if (name === packageNames[1]) {
+          const state = round === 0
+            ? visibleState(item, name, { targetIntegrity: null, distTags: { latest: "0.200.2" } })
+            : visibleState(item, name);
+          round++;
+          return state;
+        }
+        return visibleState(item, name);
+      },
+    })).rejects.toThrow(/visibility timeout/i);
+  });
+
+  test("uses one deadline and names every package still pending", async () => {
+    const item = manifest(resolveReleasePolicy("v0.200.3-rc.1"));
+    const timing = fakeTiming();
+    const pending = new Set([packageNames[2], packageNames[17]]);
+    let error: unknown;
+    try {
+      await pollPostconditions(item, {
+        timeoutMs: 25,
+        initialBackoffMs: 10,
+        maxBackoffMs: 20,
+        ...timing,
+        reader: async (_registry, name) => pending.has(name)
+          ? visibleState(item, name, { targetIntegrity: null, distTags: { latest: "0.200.2" } })
+          : visibleState(item, name),
+      });
+    } catch (caught) {
+      error = caught;
+    }
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toMatch(/visibility timeout/i);
+    expect((error as Error).message).toContain(packageNames[2]);
+    expect((error as Error).message).toContain(packageNames[17]);
+    expect(timing.now()).toBe(25);
+    expect(timing.sleeps).toEqual([10, 15]);
+  });
+
+  test("fails immediately on a visible non-null integrity conflict", async () => {
+    const item = manifest(resolveReleasePolicy("v0.200.3"));
+    const timing = fakeTiming();
+    await expect(pollPostconditions(item, {
+      timeoutMs: 100,
+      initialBackoffMs: 5,
+      maxBackoffMs: 20,
+      ...timing,
+      reader: async (_registry, name) => name === packageNames[4]
+        ? visibleState(item, name, { targetIntegrity: "sha512-different" })
+        : visibleState(item, name),
+    })).rejects.toThrow(/integrity conflict/i);
+    expect(timing.sleeps).toEqual([]);
+    expect(timing.now()).toBe(0);
+  });
+
+  test.each([
+    ["v0.200.3", "0.200.1"],
+    ["v0.200.3", undefined],
+    ["v0.104.2", "0.200.1"],
+    ["v0.200.3-rc.1", "0.200.1"],
+  ])("fails immediately on a readable hidden-target channel conflict for %s", async (tag, latest) => {
+    const item = manifest(resolveReleasePolicy(tag));
+    const timing = fakeTiming();
+    await expect(pollPostconditions(item, {
+      timeoutMs: 100,
+      initialBackoffMs: 5,
+      maxBackoffMs: 20,
+      ...timing,
+      reader: async (_registry, name) => name === packageNames[6]
+        ? visibleState(item, name, { targetIntegrity: null, distTags: latest ? { latest } : {} })
+        : visibleState(item, name),
+    })).rejects.toThrow(/channel conflict/i);
+    expect(timing.sleeps).toEqual([]);
+  });
+
+  test.each([
+    ["v0.200.3", "0.200.2", undefined],
+    ["v0.200.3", "0.200.3", undefined],
+    ["v0.104.2", "0.200.2", "0.104.1"],
+    ["v0.200.3-rc.1", "0.200.2", "0.200.2-rc.9"],
+  ])("keeps permitted readable hidden-target state pending for %s", async (tag, latest, priorRequiredTag) => {
+    const item = manifest(resolveReleasePolicy(tag));
+    const timing = fakeTiming();
+    let targetReads = 0;
+    await pollPostconditions(item, {
+      timeoutMs: 100,
+      initialBackoffMs: 5,
+      maxBackoffMs: 20,
+      ...timing,
+      reader: async (_registry, name) => {
+        if (name !== packageNames[7]) return visibleState(item, name);
+        targetReads++;
+        if (targetReads > 1) return visibleState(item, name);
+        return visibleState(item, name, {
+          targetIntegrity: null,
+          distTags: {
+            latest,
+            ...(priorRequiredTag ? { [item.distTag]: priorRequiredTag } : {}),
+          },
+        });
+      },
+    });
+    expect(targetReads).toBe(2);
+    expect(timing.sleeps).toEqual([5]);
+  });
+
+  test("treats a true 404 as pending without trusting its channel fields", async () => {
+    const item = manifest(resolveReleasePolicy("v0.200.3"));
+    const timing = fakeTiming();
+    let targetReads = 0;
+    await pollPostconditions(item, {
+      timeoutMs: 100,
+      initialBackoffMs: 5,
+      maxBackoffMs: 20,
+      ...timing,
+      reader: async (_registry, name) => {
+        if (name !== packageNames[8]) return visibleState(item, name);
+        targetReads++;
+        return targetReads === 1
+          ? { name, documentReadable: false, targetIntegrity: null, distTags: { latest: "impossible" } }
+          : visibleState(item, name);
+      },
+    });
+    expect(targetReads).toBe(2);
+  });
+
+  test("propagates a conflict and aborts a never-settling peer immediately", async () => {
+    const item = manifest(resolveReleasePolicy("v0.200.3"));
+    const timing = fakeTiming();
+    let peerAborted = false;
+    await expect(pollPostconditions(item, {
+      timeoutMs: 100,
+      initialBackoffMs: 5,
+      maxBackoffMs: 20,
+      ...timing,
+      reader: async (_registry, name, _version, signal) => {
+        if (name === packageNames[0]) return visibleState(item, name, { targetIntegrity: "sha512-conflict" });
+        if (name === packageNames[1]) {
+          return await new Promise((_, reject) => signal.addEventListener("abort", () => {
+            peerAborted = true;
+            reject(signal.reason);
+          }, { once: true }));
+        }
+        return visibleState(item, name);
+      },
+    })).rejects.toThrow(/integrity conflict/i);
+    expect(peerAborted).toBe(true);
+    expect(timing.sleeps).toEqual([]);
+    expect(timing.now()).toBe(0);
+  });
+
+  test("aborts a never-settling read at the shared deadline and reports it pending", async () => {
+    const item = manifest(resolveReleasePolicy("v0.200.3"));
+    const timing = fakeTiming();
+    let peerAborted = false;
+    let error: unknown;
+    try {
+      await pollPostconditions(item, {
+        timeoutMs: 50,
+        initialBackoffMs: 5,
+        maxBackoffMs: 20,
+        ...timing,
+        scheduleDeadline: (ms, onDeadline) => {
+          const handle = setTimeout(() => {
+            timing.setNow(ms);
+            onDeadline();
+          }, 0);
+          return () => clearTimeout(handle);
+        },
+        reader: async (_registry, name, _version, signal) => {
+          if (name !== packageNames[9]) return visibleState(item, name);
+          return await new Promise((_, reject) => signal.addEventListener("abort", () => {
+            peerAborted = true;
+            reject(signal.reason);
+          }, { once: true }));
+        },
+      });
+    } catch (caught) {
+      error = caught;
+    }
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toMatch(/visibility timeout/i);
+    expect((error as Error).message).toContain(packageNames[9]);
+    expect((error as Error).message).not.toContain(packageNames[10]);
+    expect(peerAborted).toBe(true);
+    expect(timing.sleeps).toEqual([]);
+    expect(timing.now()).toBe(50);
+  });
+});
 
 describe("strict SemVer", () => {
   test("orders core and prerelease values without precision loss", () => {

--- a/.github/publish-bun.effectstream.ts
+++ b/.github/publish-bun.effectstream.ts
@@ -23,6 +23,9 @@ const ROOT = resolve(import.meta.dir, "..");
 export const EXPECTED_PACKAGE_COUNT = 39;
 export const STABLE_DIST_TAG = "latest";
 export const RELEASE_BUNDLE_SCHEMA = 1;
+export const DEFAULT_VISIBILITY_TIMEOUT_MS = 30 * 60 * 1000;
+const DEFAULT_VISIBILITY_INITIAL_BACKOFF_MS = 250;
+const DEFAULT_VISIBILITY_MAX_BACKOFF_MS = 5000;
 const DEPRECATED = new Set(["@effectstream/explorer"]);
 const LICENSE_FILES = ["LICENSE-MIT", "LICENSE-APACHE"] as const;
 const MIN_README_CHARS = 400;
@@ -53,6 +56,9 @@ export type RegistryPackageState = {
   name: string;
   targetIntegrity: string | null;
   distTags: Record<string, string>;
+};
+export type RegistryPackageReadState = RegistryPackageState & {
+  documentReadable: boolean;
 };
 export type ManifestPackage = {
   name: string;
@@ -261,6 +267,27 @@ export async function readRegistryState(registry: string, name: string, targetVe
   const document = (await response.json()) as any;
   return { name, targetIntegrity: document.versions?.[targetVersion]?.dist?.integrity ?? null, distTags: document["dist-tags"] ?? {} };
 }
+export async function readRegistryVisibilityState(
+  registry: string,
+  name: string,
+  targetVersion: string,
+  request: typeof fetch = fetch,
+  signal?: AbortSignal,
+): Promise<RegistryPackageReadState> {
+  const response = await request(packageRegistryUrl(registry, name), {
+    cache: "no-store",
+    signal,
+    headers: {
+      accept: "application/vnd.npm.install-v1+json, application/json",
+      "cache-control": "no-cache, no-store, max-age=0",
+      pragma: "no-cache",
+    },
+  });
+  if (response.status === 404) return { name, documentReadable: false, targetIntegrity: null, distTags: {} };
+  if (!response.ok) throw new Error(`Registry query failed for ${name}: HTTP ${response.status}`);
+  const document = (await response.json()) as any;
+  return { name, documentReadable: true, targetIntegrity: document.versions?.[targetVersion]?.dist?.integrity ?? null, distTags: document["dist-tags"] ?? {} };
+}
 function assertUniformNode2Latest(states: RegistryPackageState[]): Record<string, string> {
   const snapshot: Record<string, string> = {};
   const values = new Set<string>();
@@ -293,6 +320,181 @@ export function verifyLatestPostcondition(manifest: ReleaseManifest, states: Reg
       throw new Error(`${state.name} latest changed from ${manifest.latestBefore[state.name]} to ${latest ?? "missing"}`);
     }
     if (state.distTags[manifest.distTag] !== manifest.version) throw new Error(`${state.name} ${manifest.distTag}=${state.distTags[manifest.distTag] ?? "missing"}, expected ${manifest.version}`);
+  }
+}
+export class RegistryVisibilityTimeoutError extends Error {
+  constructor(public readonly pendingPackages: string[]) {
+    super(`Registry visibility timeout; pending packages: ${pendingPackages.join(", ")}`);
+    this.name = "RegistryVisibilityTimeoutError";
+  }
+}
+export class RegistryIntegrityConflictError extends Error {
+  constructor(name: string, version: string, expected: string, observed: string) {
+    super(`Registry integrity conflict for ${name}@${version}: expected ${expected}, observed ${observed}`);
+    this.name = "RegistryIntegrityConflictError";
+  }
+}
+export class RegistryChannelConflictError extends Error {
+  constructor(message: string) {
+    super(`Registry channel conflict: ${message}`);
+    this.name = "RegistryChannelConflictError";
+  }
+}
+type RegistryVisibilityReader = (
+  registry: string,
+  name: string,
+  targetVersion: string,
+  signal: AbortSignal,
+) => Promise<RegistryPackageReadState>;
+export type RegistryVisibilityPollingOptions = {
+  timeoutMs?: number;
+  initialBackoffMs?: number;
+  maxBackoffMs?: number;
+  reader?: RegistryVisibilityReader;
+  now?: () => number;
+  sleep?: (ms: number, signal: AbortSignal) => Promise<void>;
+  scheduleDeadline?: (ms: number, onDeadline: () => void) => () => void;
+};
+
+class RegistryPollingDeadlineReached extends Error {}
+
+function defaultVisibilitySleep(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolveSleep, rejectSleep) => {
+    if (signal.aborted) {
+      rejectSleep(signal.reason);
+      return;
+    }
+    const timeout = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolveSleep();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timeout);
+      rejectSleep(signal.reason);
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+function defaultDeadlineScheduler(ms: number, onDeadline: () => void): () => void {
+  const timeout = setTimeout(onDeadline, ms);
+  return () => clearTimeout(timeout);
+}
+
+async function runWithinRegistryDeadline<T>(
+  remainingMs: number,
+  scheduleDeadline: (ms: number, onDeadline: () => void) => () => void,
+  operation: (signal: AbortSignal) => Promise<T>,
+): Promise<T> {
+  if (remainingMs <= 0) throw new RegistryPollingDeadlineReached();
+  const controller = new AbortController();
+  const deadlineError = new RegistryPollingDeadlineReached();
+  let cancelDeadline = () => {};
+  const deadline = new Promise<never>((_resolve, reject) => {
+    cancelDeadline = scheduleDeadline(remainingMs, () => {
+      controller.abort(deadlineError);
+      reject(deadlineError);
+    });
+  });
+  const work = operation(controller.signal).catch((error) => {
+    controller.abort(error);
+    throw error;
+  });
+  try {
+    return await Promise.race([work, deadline]);
+  } finally {
+    cancelDeadline();
+  }
+}
+
+function classifyRegistryPostcondition(
+  manifest: ReleaseManifest,
+  pkg: ManifestPackage,
+  state: RegistryPackageReadState,
+): "ready" | "pending" {
+  if (state.name !== pkg.name) {
+    throw new RegistryChannelConflictError(`reader returned ${state.name} for ${pkg.name}`);
+  }
+  if (!state.documentReadable) return "pending";
+  const latest = state.distTags.latest;
+  const latestBefore = manifest.latestBefore[pkg.name];
+  if (manifest.kind === "node2-stable") {
+    if (latest !== latestBefore && latest !== manifest.version) {
+      throw new RegistryChannelConflictError(
+        `${pkg.name} latest=${latest ?? "missing"}, expected persisted ${latestBefore} or target ${manifest.version}`,
+      );
+    }
+  } else if (latest !== latestBefore) {
+    throw new RegistryChannelConflictError(
+      `${pkg.name} latest changed from ${latestBefore} to ${latest ?? "missing"}`,
+    );
+  }
+  if (state.targetIntegrity === null) return "pending";
+  if (state.targetIntegrity !== pkg.integrity) {
+    throw new RegistryIntegrityConflictError(pkg.name, manifest.version, pkg.integrity, state.targetIntegrity);
+  }
+  if (state.distTags[manifest.distTag] !== manifest.version) return "pending";
+  return "ready";
+}
+
+export async function pollRegistryPostconditions(
+  manifest: ReleaseManifest,
+  registry: string,
+  options: RegistryVisibilityPollingOptions = {},
+): Promise<void> {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_VISIBILITY_TIMEOUT_MS;
+  const initialBackoffMs = options.initialBackoffMs ?? DEFAULT_VISIBILITY_INITIAL_BACKOFF_MS;
+  const maxBackoffMs = options.maxBackoffMs ?? DEFAULT_VISIBILITY_MAX_BACKOFF_MS;
+  if (timeoutMs <= 0 || initialBackoffMs <= 0 || maxBackoffMs <= 0) {
+    throw new Error("Registry visibility timeout and backoff values must be positive");
+  }
+  const now = options.now ?? (() => performance.now());
+  const sleep = options.sleep ?? defaultVisibilitySleep;
+  const scheduleDeadline = options.scheduleDeadline ?? defaultDeadlineScheduler;
+  const reader = options.reader ?? ((source, name, version, signal) =>
+    readRegistryVisibilityState(source, name, version, fetch, signal));
+  const cutoff = now() + timeoutMs;
+  let backoffMs = Math.min(initialBackoffMs, maxBackoffMs);
+  let pendingPackages = manifest.packages.map((pkg) => pkg.name);
+
+  while (true) {
+    const readRemainingMs = cutoff - now();
+    if (readRemainingMs <= 0) throw new RegistryVisibilityTimeoutError(pendingPackages);
+    const pendingThisRound = new Set(manifest.packages.map((pkg) => pkg.name));
+    try {
+      await runWithinRegistryDeadline(readRemainingMs, scheduleDeadline, async (signal) => {
+        await Promise.all(manifest.packages.map(async (pkg) => {
+          const state = await reader(registry, pkg.name, manifest.version, signal);
+          if (classifyRegistryPostcondition(manifest, pkg, state) === "ready") {
+            pendingThisRound.delete(pkg.name);
+          }
+        }));
+      });
+    } catch (error) {
+      if (error instanceof RegistryPollingDeadlineReached) {
+        throw new RegistryVisibilityTimeoutError(
+          manifest.packages.filter((pkg) => pendingThisRound.has(pkg.name)).map((pkg) => pkg.name),
+        );
+      }
+      throw error;
+    }
+    pendingPackages = manifest.packages
+      .filter((pkg) => pendingThisRound.has(pkg.name))
+      .map((pkg) => pkg.name);
+    if (pendingPackages.length === 0) return;
+
+    const sleepRemainingMs = cutoff - now();
+    if (sleepRemainingMs <= 0) throw new RegistryVisibilityTimeoutError(pendingPackages);
+    const delayMs = Math.min(backoffMs, sleepRemainingMs);
+    try {
+      await runWithinRegistryDeadline(sleepRemainingMs, scheduleDeadline, (signal) => sleep(delayMs, signal));
+    } catch (error) {
+      if (error instanceof RegistryPollingDeadlineReached) {
+        throw new RegistryVisibilityTimeoutError(pendingPackages);
+      }
+      throw error;
+    }
+    backoffMs = Math.min(backoffMs * 2, maxBackoffMs);
   }
 }
 export function planRegistryCompletion(manifest: ReleaseManifest, states: RegistryPackageState[], recovery: boolean): { missing: string[]; existing: string[] } {
@@ -475,6 +677,10 @@ export async function publishFromBundle(options: { artifactDir: string; registry
     writeResults();
   }
   if (!options.publish) return { published, skipped: completion.existing };
+  if (!options.recovery) {
+    await pollRegistryPostconditions(manifest, options.registry);
+    return { published, skipped: completion.existing };
+  }
   const complete = await Promise.all(manifest.packages.map((pkg) => readRegistryState(options.registry, pkg.name, manifest.version)));
   for (const pkg of manifest.packages) {
     const state = complete.find((candidate) => candidate.name === pkg.name)!;


### PR DESCRIPTION
## Summary

- replace the ordinary release's one-shot npm registry post-publish check with bounded, coherent polling across all 39 manifest packages
- use one monotonic 30-minute deadline, fresh no-cache metadata reads, bounded backoff, and abortable read rounds/sleeps
- keep exact integrity and release-channel conflicts fail-closed while treating only legitimate processing/propagation states as pending

## Incident

The `v0.200.4` ordinary release successfully published all 39 packages through npm Trusted Publishing/OIDC. The release job then failed because an immediate registry read observed `@effectstream/npm-avail-light-client` while npm was still processing it. Independent artifact and live-registry verification proved all 39 publications completed with exact tarball bytes, SRI, `latest=0.200.4`, and provenance.

This change prevents that successful publication from being reported as a failure solely because npm visibility has not converged yet.

## Scope and safety

- ordinary publication only; recovery retains its existing integrity read, direct tag-repair loop, and final channel verification
- authentication, OIDC, release workflows, package manifests, package versions, runtime code, `bun.lock`, artifact/result schema, and publish commands are unchanged
- success requires one coherent round where every package has exact integrity and valid channel state
- visible non-null integrity conflicts and impossible channel states still fail immediately and abort unresolved peers
- this is non-breaking

`v0.200.4` is already complete and must **not** be rerun or recovered. Source versions intentionally remain `0.200.2`; the next successful release will advance them to its own version.

## Verification

- focused polling: 17/17
- publisher unit suite: 76/76, 187 assertions
- local fake registry: 7/7, 100 assertions
- recovery: 8/8, 79 assertions
- release source guard: 5 positive, 16 fail-closed negative, 2 race cases
- independent cross-run producer and consumer: 7/7 each
- pinned actionlint: passed
- exact diff: only `.github/publish-bun.effectstream.ts` and `.github/publish-bun.effectstream.test.ts`

Independent delivery audit: REVIEW-COMPLETED / PASS with zero BLOCKER, MAJOR, or minor findings at commit `a882762e59810ab2fbb7f44ca638d01ef6b38e41`.
