### PR TITLE
fix(events): make EventBroker lifecycle awaitable

### DIFF
--- a/docs/site/docs/home/500-packages/520-node/event-server.md
+++ b/docs/site/docs/home/500-packages/520-node/event-server.md
@@ -59,11 +59,18 @@ both transports are accepting connections. If either bind fails, any transport
 already acquired by that start is closed before the Promise rejects.
 
 `shutdown()` is awaitable and idempotent: concurrent and repeated calls share
-one cached result, including the same rejection. It stops new connections,
-closes this broker's authenticated MQTT contexts without publishing their Will
-messages, closes active TCP and WebSocket connections, and waits for its
-listeners and connection finalizers. Cleanup attempts continue after an error;
-multiple failures reject with `AggregateError` in stable cleanup order.
+one cached result, including the same rejection. It stops new connections
+(late `CONNECT`s are refused with `serverUnavailable`), closes this broker's
+authenticated MQTT contexts without publishing their Will messages, closes
+active TCP and WebSocket connections, and waits for its listeners and
+connection finalizers. Cleanup attempts continue after an error; multiple
+failures reject with `AggregateError` in stable cleanup order.
+
+While the broker is running, a broker-initiated disconnect (for example a
+keepalive timeout) closes the client's transport immediately. Connection
+cleanup failures during normal operation are logged when they happen and
+retained (up to 128 records, then counted) so that `shutdown()` reports them;
+an otherwise clean shutdown still rejects with those retained errors.
 
 A stopped or failed instance cannot be started again. To restart after
 shutdown, construct a fresh `EventBroker`; once shutdown resolves, the

--- a/docs/site/docs/home/500-packages/520-node/event-server.md
+++ b/docs/site/docs/home/500-packages/520-node/event-server.md
@@ -16,7 +16,8 @@ subscribe via `@effectstream/event-client`.
 - Localhost-only MQTT broker (opifex) for Effectstream events.
 - Publishes from non-loopback connections are rejected at the broker.
 - Paired with `@effectstream/event-client` on the consuming side.
-- The engine starts a single broker (`"effectstream-engine"`). A batcher that enables its own event system runs a separate `EventBroker` instance in its own process.
+- Separate `"effectstream-engine"` and `"Batcher"` instances use their own
+  configured TCP and WebSocket ports.
 
 ## Install
 
@@ -38,7 +39,9 @@ import { EventBroker } from "@effectstream/event-server";
 // Ports are read from MQTT_ENGINE_BROKER_PORT / MQTT_ENGINE_BROKER_WS_PORT
 // (or the _BATCHER_ equivalents when constructed with "Batcher").
 const broker = new EventBroker("effectstream-engine");
-await broker.start(); // listens on the configured TCP + WS ports
+await broker.start(); // resolves after the configured TCP + WS ports are ready
+// ...publish and subscribe...
+await broker.shutdown(); // resolves after this instance releases its resources
 ```
 
 Once running, you can connect to it from `@effectstream/event-client`
@@ -49,17 +52,33 @@ and subscribe to events.
 > the broker level. Subscriptions are unrestricted; gate them at the
 > network layer if you don't want public consumers.
 
-## Inside EffectStream
+## Lifecycle
 
-The runtime instantiates two `EventBroker`s (engine and batcher) so
-state-machine and batcher events flow on separate topic namespaces. Apps
-publish through `EventManager.Instance.sendMessage(...)` in
-`@effectstream/event-client`, which writes against the local broker
-exposed here.
+Concurrent calls to `start()` share the same Promise. A successful start means
+both transports are accepting connections. If either bind fails, any transport
+already acquired by that start is closed before the Promise rejects.
+
+`shutdown()` is awaitable and idempotent: concurrent and repeated calls share
+one cached result, including the same rejection. It stops new connections,
+closes this broker's authenticated MQTT contexts without publishing their Will
+messages, closes active TCP and WebSocket connections, and waits for its
+listeners and connection finalizers. Cleanup attempts continue after an error;
+multiple failures reject with `AggregateError` in stable cleanup order.
+
+A stopped or failed instance cannot be started again. To restart after
+shutdown, construct a fresh `EventBroker`; once shutdown resolves, the
+replacement can use the same configured ports. This boundary covers resources
+owned by that broker instance, not unrelated application or process handles.
+
+`createServer()` and `stop()` remain `void` compatibility wrappers. They start
+the same asynchronous work and log any rejection, but callers that need a
+deterministic lifecycle boundary should await `start()` and `shutdown()`.
 
 ## Key exports
 
-- `EventBroker` - broker class. Constructor takes `"effectstream-engine" | "Batcher"`. Methods: `start()` (async; binds the configured TCP + WS ports), `createServer()` (fire-and-forget wrapper around `start()`), `stop()`. Clients publish and subscribe via the MQTT protocol, not direct class methods.
+- `EventBroker` - broker class. Constructor takes
+  `"effectstream-engine" | "Batcher"`; clients publish and subscribe through
+  MQTT rather than direct class methods.
 
 ## Examples
 

--- a/packages/node-sdk/events/README.md
+++ b/packages/node-sdk/events/README.md
@@ -51,11 +51,18 @@ both transports are accepting connections. If either bind fails, any transport
 already acquired by that start is closed before the Promise rejects.
 
 `shutdown()` is awaitable and idempotent: concurrent and repeated calls share
-one cached result, including the same rejection. It stops new connections,
-closes this broker's authenticated MQTT contexts without publishing their Will
-messages, closes active TCP and WebSocket connections, and waits for its
-listeners and connection finalizers. Cleanup attempts continue after an error;
-multiple failures reject with `AggregateError` in stable cleanup order.
+one cached result, including the same rejection. It stops new connections
+(late `CONNECT`s are refused with `serverUnavailable`), closes this broker's
+authenticated MQTT contexts without publishing their Will messages, closes
+active TCP and WebSocket connections, and waits for its listeners and
+connection finalizers. Cleanup attempts continue after an error; multiple
+failures reject with `AggregateError` in stable cleanup order.
+
+While the broker is running, a broker-initiated disconnect (for example a
+keepalive timeout) closes the client's transport immediately. Connection
+cleanup failures during normal operation are logged when they happen and
+retained (up to 128 records, then counted) so that `shutdown()` reports them;
+an otherwise clean shutdown still rejects with those retained errors.
 
 A stopped or failed instance cannot be started again. To restart after
 shutdown, construct a fresh `EventBroker`; once shutdown resolves, the

--- a/packages/node-sdk/events/README.md
+++ b/packages/node-sdk/events/README.md
@@ -8,7 +8,8 @@ subscribe via `@effectstream/event-client`.
 - Localhost-only MQTT broker (opifex) for Effectstream events.
 - Publishes from non-loopback connections are rejected at the broker.
 - Paired with `@effectstream/event-client` on the consuming side.
-- The engine starts a single broker (`"effectstream-engine"`). A batcher that enables its own event system runs a separate `EventBroker` instance in its own process.
+- Separate `"effectstream-engine"` and `"Batcher"` instances use their own
+  configured TCP and WebSocket ports.
 
 ## Install
 
@@ -30,7 +31,9 @@ import { EventBroker } from "@effectstream/event-server";
 // Ports are read from MQTT_ENGINE_BROKER_PORT / MQTT_ENGINE_BROKER_WS_PORT
 // (or the _BATCHER_ equivalents when constructed with "Batcher").
 const broker = new EventBroker("effectstream-engine");
-await broker.start(); // listens on the configured TCP + WS ports
+await broker.start(); // resolves after the configured TCP + WS ports are ready
+// ...publish and subscribe...
+await broker.shutdown(); // resolves after this instance releases its resources
 ```
 
 Once running, you can connect to it from `@effectstream/event-client`
@@ -41,17 +44,33 @@ and subscribe to events.
 > the broker level. Subscriptions are unrestricted; gate them at the
 > network layer if you don't want public consumers.
 
-## Inside EffectStream
+## Lifecycle
 
-The runtime instantiates two `EventBroker`s (engine and batcher) so
-state-machine and batcher events flow on separate topic namespaces. Apps
-publish through `EventManager.Instance.sendMessage(...)` in
-`@effectstream/event-client`, which writes against the local broker
-exposed here.
+Concurrent calls to `start()` share the same Promise. A successful start means
+both transports are accepting connections. If either bind fails, any transport
+already acquired by that start is closed before the Promise rejects.
+
+`shutdown()` is awaitable and idempotent: concurrent and repeated calls share
+one cached result, including the same rejection. It stops new connections,
+closes this broker's authenticated MQTT contexts without publishing their Will
+messages, closes active TCP and WebSocket connections, and waits for its
+listeners and connection finalizers. Cleanup attempts continue after an error;
+multiple failures reject with `AggregateError` in stable cleanup order.
+
+A stopped or failed instance cannot be started again. To restart after
+shutdown, construct a fresh `EventBroker`; once shutdown resolves, the
+replacement can use the same configured ports. This boundary covers resources
+owned by that broker instance, not unrelated application or process handles.
+
+`createServer()` and `stop()` remain `void` compatibility wrappers. They start
+the same asynchronous work and log any rejection, but callers that need a
+deterministic lifecycle boundary should await `start()` and `shutdown()`.
 
 ## Key exports
 
-- `EventBroker` - broker class. Constructor takes `"effectstream-engine" | "Batcher"`. Methods: `start()` (async; binds the configured TCP + WS ports), `createServer()` (fire-and-forget wrapper around `start()`), `stop()`. Clients publish and subscribe via the MQTT protocol, not direct class methods.
+- `EventBroker` - broker class. Constructor takes
+  `"effectstream-engine" | "Batcher"`; clients publish and subscribe through
+  MQTT rather than direct class methods.
 
 ## Examples
 

--- a/packages/node-sdk/events/src/event-broker.ts
+++ b/packages/node-sdk/events/src/event-broker.ts
@@ -1,4 +1,4 @@
-import { createServer, type Server } from 'node:net';
+import { createServer, type Server, type Socket } from 'node:net';
 import { MqttServer, AuthenticationResult } from '@seriousme/opifex/server';
 import type { Context, SockConn, Handlers } from '@seriousme/opifex/server';
 import { ENV } from '@effectstream/utils/node-env';
@@ -7,13 +7,28 @@ function isLocalhost(addr: string): boolean {
   return addr === '127.0.0.1' || addr === '::1' || addr.startsWith('::ffff:127.');
 }
 
+function copyBytes(bytes: Uint8Array): Uint8Array<ArrayBuffer> {
+  const copy = new Uint8Array(bytes.byteLength);
+  copy.set(bytes);
+  return copy;
+}
+
 function wrapNodeSocket(socket: import('node:net').Socket): SockConn {
+  let readableController: ReadableByteStreamController | null = null;
+  const closeReadable = (error?: Error) => {
+    try {
+      if (error) readableController?.error(error);
+      else readableController?.close();
+    } catch { /* controller already closed */ }
+    readableController = null;
+  };
   const readable = new ReadableStream<Uint8Array>({
     type: 'bytes',
     start(controller) {
+      readableController = controller as ReadableByteStreamController;
       socket.on('data', (data: Uint8Array) => {
         try {
-          controller.enqueue(data);
+          controller.enqueue(copyBytes(data));
           if ((controller.desiredSize ?? 0) <= 0) socket.pause();
         } catch { /* controller already closed */ }
       });
@@ -21,10 +36,10 @@ function wrapNodeSocket(socket: import('node:net').Socket): SockConn {
         try { controller.error(err); } catch { /* already closed */ }
       });
       socket.on('end', () => {
-        try { controller.close(); } catch { /* already closed */ }
+        closeReadable(new Error('TCP transport ended'));
       });
       socket.on('close', () => {
-        try { controller.close(); } catch { /* already closed */ }
+        closeReadable(new Error('TCP transport closed'));
       });
     },
     pull: () => { if (!socket.destroyed) socket.resume(); },
@@ -43,13 +58,15 @@ function wrapNodeSocket(socket: import('node:net').Socket): SockConn {
   const remoteAddr = {
     hostname: socket.remoteAddress || '',
     port: socket.remotePort || 0,
-    transport: 'tcp',
+    transport: 'tcp' as const,
   };
 
   return {
     readable,
     writable,
     close: () => {
+      try { readableController?.enqueue(new Uint8Array([0xe0, 0x00])); } catch {}
+      closeReadable();
       if (!socket.destroyed && !socket.writableEnded) {
         try { socket.end(); } catch { /* already ended */ }
       }
@@ -62,7 +79,32 @@ type WsConnectionState = {
   controller: ReadableByteStreamController | null;
 };
 
-function createWsServer(port: number, mqttServer: MqttServer): ReturnType<typeof Bun.serve> {
+type Outcome = { ok: true } | { ok: false; error: unknown };
+
+type TrackedConnection = {
+  sequence: number;
+  transport: 'tcp' | 'ws';
+  conn: SockConn;
+  context?: Context;
+  contextFinalization?: Promise<Outcome>;
+  outcome: Promise<void>;
+};
+
+type ConnectionFailure = {
+  sequence: number;
+  contextFailed?: boolean;
+  contextError?: unknown;
+  transportFailed?: boolean;
+  transportError?: unknown;
+  serveFailed?: boolean;
+  serveError?: unknown;
+};
+
+function createWsServer(
+  port: number,
+  serveConnection: (conn: SockConn) => void,
+  isStopping: () => boolean,
+): ReturnType<typeof Bun.serve> {
   return Bun.serve({
     port,
     hostname: '127.0.0.1',
@@ -86,40 +128,49 @@ function createWsServer(port: number, mqttServer: MqttServer): ReturnType<typeof
       return new Response('MQTT WebSocket endpoint', { status: 200 });
     },
     websocket: {
-      binaryType: 'arraybuffer',
       open(ws) {
         const state = ws.data as WsConnectionState;
 
         const readable = new ReadableStream<Uint8Array>({
           type: 'bytes',
           start(controller) {
-            state.controller = controller;
+            state.controller = controller as ReadableByteStreamController;
           },
           cancel() {
             try { ws.close(); } catch { /* already closed */ }
           },
         });
-
         const writable = new WritableStream<Uint8Array>({
           write(chunk) {
             // Same guard as wrapNodeSocket — peer-initiated close must not
             // crash Opifex's writer.
             if (ws.readyState !== WebSocket.OPEN) return;
-            try { ws.send(chunk); } catch { /* closed between check and send */ }
+            try { ws.send(copyBytes(chunk)); } catch { /* closed between check and send */ }
           },
-          close() {
-            try { ws.close(); } catch { /* already closed */ }
-          },
+          // Opifex closes its writer immediately before SockConn.close(). The
+          // latter owns the coordinated readable wake-up and transport close.
+          close() {},
         });
 
         const sockConn: SockConn = {
           readable,
           writable,
           close: () => {
-            try { ws.close(); } catch { /* already closed */ }
+            // Bun's byte-stream controller does not always settle a pending
+            // BYOB read when it is only closed. Rejecting the read wakes the
+            // Opifex serve loop after Context.close(false) has suppressed the
+            // Will and cleared its keepalive timer.
+            try { state.controller?.error(new Error('WebSocket transport closed')); } catch { /* already closed */ }
+            state.controller = null;
+            // Bun 1.3.10's Server.stop(true) does not settle if the upgraded
+            // socket was manually closed first. During broker shutdown it owns
+            // the force-close; outside shutdown this connection closes itself.
+            if (!isStopping()) {
+              try { ws.close(); } catch { /* already closed */ }
+            }
           },
         };
-        mqttServer.serve(sockConn);
+        serveConnection(sockConn);
       },
       message(ws, message) {
         const state = ws.data as WsConnectionState;
@@ -137,11 +188,12 @@ function createWsServer(port: number, mqttServer: MqttServer): ReturnType<typeof
         } else {
           data = new Uint8Array(message as ArrayBuffer);
         }
-        state.controller?.enqueue(data);
+        state.controller?.enqueue(copyBytes(data));
       },
       close(ws) {
         const state = ws.data as WsConnectionState;
-        try { state.controller?.close(); } catch { /* already closed */ }
+        try { state.controller?.error(new Error('WebSocket transport closed by peer')); } catch { /* already closed */ }
+        state.controller = null;
       },
     },
   });
@@ -151,12 +203,24 @@ export class EventBroker {
   private mqttServer: MqttServer;
   private tcpServer: Server | null = null;
   private wsServer: ReturnType<typeof Bun.serve> | null = null;
+  private readonly tcpSockets = new Set<Socket>();
+  private readonly connections = new Map<SockConn, TrackedConnection>();
+  private readonly connectionFailures = new Map<number, ConnectionFailure>();
+  private connectionSequence = 0;
+  private state: 'NEW' | 'STARTING' | 'STARTED' | 'STOPPING' | 'STOPPED' = 'NEW';
+  private startPromise: Promise<void> | null = null;
+  private shutdownPromise: Promise<void> | null = null;
+  private stopRequested = false;
+  private tcpListenOutcome: Promise<Outcome> | null = null;
 
   constructor(private broker: 'effectstream-engine' | 'Batcher') {
     this.checkEnabled();
 
     const handlers: Handlers = {
-      isAuthenticated: () => AuthenticationResult.ok,
+      isAuthenticated: (ctx: Context) => {
+        this.registerContext(ctx);
+        return AuthenticationResult.ok;
+      },
       isAuthorizedToPublish: (ctx: Context) => {
         const addr = ctx.mqttConn.remoteAddress;
         if (isLocalhost(addr)) return true;
@@ -170,30 +234,246 @@ export class EventBroker {
   }
 
   public createServer(): void {
-    void this.start();
+    void this.start().catch((error) => {
+      console.error(`MQTT server [${this.broker}] failed to start:`, error);
+    });
   }
 
-  public async start(): Promise<void> {
+  public start(): Promise<void> {
+    if (this.startPromise && (this.state === 'STARTING' || this.state === 'STARTED')) {
+      return this.startPromise;
+    }
+    if (this.state !== 'NEW') {
+      return Promise.reject(new Error(`MQTT server cannot start from state ${this.state}`));
+    }
+    this.state = 'STARTING';
+    this.startPromise = this.startInternal();
+    return this.startPromise;
+  }
+
+  private async startInternal(): Promise<void> {
     const tcpPort = this.getTcpPort();
     const wsPort = this.getWsPort();
 
     this.tcpServer = createServer((sock) => {
-      this.mqttServer.serve(wrapNodeSocket(sock));
+      this.tcpSockets.add(sock);
+      sock.once('close', () => this.tcpSockets.delete(sock));
+      this.serveConnection(wrapNodeSocket(sock), 'tcp');
     });
 
-    await new Promise<void>((resolve) => {
-      this.tcpServer!.on('listening', () => resolve());
-      this.tcpServer!.listen(tcpPort, '127.0.0.1');
+    this.tcpListenOutcome = new Promise<Outcome>((resolve) => {
+      let settled = false;
+      const finish = (outcome: Outcome) => {
+        if (settled) return;
+        settled = true;
+        this.tcpServer?.removeListener('listening', onListening);
+        this.tcpServer?.removeListener('error', onError);
+        resolve(outcome);
+      };
+      const onListening = () => finish({ ok: true });
+      const onError = (error: unknown) => finish({ ok: false, error });
+      this.tcpServer!.once('listening', onListening);
+      this.tcpServer!.once('error', onError);
+      try {
+        this.tcpServer!.listen(tcpPort, '127.0.0.1');
+      } catch (error) {
+        finish({ ok: false, error });
+      }
     });
-    console.log(`MQTT TCP Server [${this.broker}] started on port ${tcpPort}`);
 
-    this.wsServer = createWsServer(wsPort, this.mqttServer);
-    console.log(`MQTT WS Server [${this.broker}] started on port ${wsPort}`);
+    try {
+      const tcpOutcome = await this.tcpListenOutcome;
+      if (tcpOutcome.ok === false) throw tcpOutcome.error;
+      if (this.stopRequested) throw new Error('MQTT server start cancelled by shutdown');
+      console.log(`MQTT TCP Server [${this.broker}] started on port ${tcpPort}`);
+
+      this.wsServer = createWsServer(
+        wsPort,
+        (conn) => this.serveConnection(conn, 'ws'),
+        () => this.stopRequested,
+      );
+      if (this.stopRequested) throw new Error('MQTT server start cancelled by shutdown');
+      console.log(`MQTT WS Server [${this.broker}] started on port ${wsPort}`);
+      this.state = 'STARTED';
+    } catch (startError) {
+      const cleanup = await this.captureOutcome(() => this.beginShutdown());
+      if (cleanup.ok === false) {
+        const cleanupErrors = cleanup.error instanceof AggregateError
+          ? cleanup.error.errors
+          : [cleanup.error];
+        throw new AggregateError(
+          [startError, ...cleanupErrors],
+          'MQTT start and partial shutdown both failed',
+        );
+      }
+      throw startError;
+    }
   }
 
   public stop(): void {
-    this.tcpServer?.close();
-    this.wsServer?.stop(true);
+    void this.shutdown().catch((error) => {
+      console.error(`MQTT server [${this.broker}] failed to stop:`, error);
+    });
+  }
+
+  public shutdown(): Promise<void> {
+    return this.beginShutdown();
+  }
+
+  private beginShutdown(): Promise<void> {
+    if (this.shutdownPromise) return this.shutdownPromise;
+    this.stopRequested = true;
+    this.state = 'STOPPING';
+    this.shutdownPromise = this.shutdownInternal().then(
+      () => {
+        this.state = 'STOPPED';
+      },
+      (error) => {
+        this.state = 'STOPPED';
+        throw error;
+      },
+    );
+    return this.shutdownPromise;
+  }
+
+  private captureOutcome(action: () => unknown): Promise<Outcome> {
+    return Promise.resolve().then(action).then(
+      () => ({ ok: true }),
+      (error) => ({ ok: false, error }),
+    );
+  }
+
+  private registerContext(context: Context): void {
+    const tracked = this.connections.get(context.conn);
+    if (tracked) tracked.context = context;
+  }
+
+  private finalizeContext(tracked: TrackedConnection): Promise<Outcome> {
+    if (tracked.contextFinalization) return tracked.contextFinalization;
+    if (!tracked.context) return Promise.resolve({ ok: true });
+    tracked.contextFinalization = this.captureOutcome(
+      () => tracked.context!.close(false),
+    );
+    return tracked.contextFinalization;
+  }
+
+  private rememberFailure(
+    tracked: TrackedConnection,
+    kind: 'context' | 'transport' | 'serve',
+    error: unknown,
+  ): void {
+    const failure = this.connectionFailures.get(tracked.sequence) ?? {
+      sequence: tracked.sequence,
+    };
+    if (kind === 'context') {
+      failure.contextFailed = true;
+      failure.contextError = error;
+    } else if (kind === 'transport') {
+      failure.transportFailed = true;
+      failure.transportError = error;
+    } else {
+      failure.serveFailed = true;
+      failure.serveError = error;
+    }
+    this.connectionFailures.set(tracked.sequence, failure);
+  }
+
+  private serveConnection(conn: SockConn, transport: 'tcp' | 'ws'): void {
+    const tracked: TrackedConnection = {
+      sequence: ++this.connectionSequence,
+      transport,
+      conn,
+      outcome: Promise.resolve(),
+    };
+    this.connections.set(conn, tracked);
+
+    const serveOutcome = this.captureOutcome(() => this.mqttServer.serve(conn));
+    tracked.outcome = serveOutcome.then(async (outcome) => {
+      const contextOutcome = await this.finalizeContext(tracked);
+      if (contextOutcome.ok === false) {
+        this.rememberFailure(tracked, 'context', contextOutcome.error);
+      }
+      if (outcome.ok === false) this.rememberFailure(tracked, 'serve', outcome.error);
+      this.connections.delete(conn);
+    });
+  }
+
+  private async shutdownInternal(): Promise<void> {
+    // Coordinate only through the normalized listen outcome. startInternal
+    // awaits this cleanup on failure, so waiting on the start Promise here
+    // would create a start/shutdown dependency cycle.
+    if (this.tcpListenOutcome) await this.tcpListenOutcome;
+
+    let tcpCloseOutcome: Promise<Outcome> | null = null;
+    if (this.tcpServer?.listening) {
+      tcpCloseOutcome = new Promise<Outcome>((resolve) => {
+        let settled = false;
+        const finish = (outcome: Outcome) => {
+          if (settled) return;
+          settled = true;
+          resolve(outcome);
+        };
+        try {
+          this.tcpServer!.close((error?: Error) => {
+            finish(error === undefined ? { ok: true } : { ok: false, error });
+          });
+        } catch (error) {
+          finish({ ok: false, error });
+        }
+      });
+    }
+
+    const trackedInOrder = [...this.connections.values()]
+      .sort((left, right) => left.sequence - right.sequence);
+    for (const tracked of trackedInOrder) {
+      const outcome = await this.finalizeContext(tracked);
+      if (outcome.ok === false) this.rememberFailure(tracked, 'context', outcome.error);
+    }
+
+    for (const tracked of trackedInOrder) {
+      const outcome = await this.captureOutcome(() => tracked.conn.close());
+      if (outcome.ok === false) this.rememberFailure(tracked, 'transport', outcome.error);
+    }
+    for (const socket of this.tcpSockets) socket.destroy();
+    this.tcpSockets.clear();
+
+    const wsOutcomePromise = this.wsServer
+      ? this.captureOutcome(() => this.wsServer!.stop(true))
+      : Promise.resolve({ ok: true } as Outcome);
+
+    const tcpOutcome = tcpCloseOutcome ? await tcpCloseOutcome : { ok: true } as Outcome;
+    // Successful and failed serve wrappers both remove themselves after their
+    // captured Context has been finalized. Loop because a connection callback
+    // already queued when ingress stopped can register between snapshots.
+    while (this.connections.size > 0) {
+      await Promise.all([...this.connections.values()].map((tracked) => tracked.outcome));
+    }
+    const wsOutcome = await wsOutcomePromise;
+
+    const orderedConnectionFailures = [...this.connectionFailures.values()]
+      .sort((left, right) => left.sequence - right.sequence);
+    const failures: unknown[] = [];
+    for (const failure of orderedConnectionFailures) {
+      if (failure.contextFailed) failures.push(failure.contextError);
+    }
+    if (tcpOutcome.ok === false) failures.push(tcpOutcome.error);
+    for (const failure of orderedConnectionFailures) {
+      if (failure.transportFailed) failures.push(failure.transportError);
+    }
+    if (wsOutcome.ok === false) failures.push(wsOutcome.error);
+    for (const failure of orderedConnectionFailures) {
+      if (
+        failure.serveFailed &&
+        !(failure.contextFailed && Object.is(failure.serveError, failure.contextError))
+      ) {
+        failures.push(failure.serveError);
+      }
+    }
+
+    if (failures.length === 1) throw failures[0];
+    if (failures.length > 1) {
+      throw new AggregateError(failures, 'Multiple MQTT resources failed to close');
+    }
   }
 
   private checkEnabled(): void {

--- a/packages/node-sdk/events/src/event-broker.ts
+++ b/packages/node-sdk/events/src/event-broker.ts
@@ -86,7 +86,9 @@ type TrackedConnection = {
   transport: 'tcp' | 'ws';
   conn: SockConn;
   context?: Context;
-  contextFinalization?: Promise<Outcome>;
+  contextFinalization?: { executeWill: boolean; outcome: Promise<Outcome> };
+  timerFinalization?: Promise<Outcome>;
+  transportFinalization?: Promise<Outcome>;
   outcome: Promise<void>;
 };
 
@@ -94,6 +96,8 @@ type ConnectionFailure = {
   sequence: number;
   contextFailed?: boolean;
   contextError?: unknown;
+  timerFailed?: boolean;
+  timerError?: unknown;
   transportFailed?: boolean;
   transportError?: unknown;
   serveFailed?: boolean;
@@ -109,6 +113,9 @@ function createWsServer(
     port,
     hostname: '127.0.0.1',
     fetch(req, server) {
+      if (isStopping()) {
+        return new Response('MQTT WebSocket endpoint is stopping', { status: 503 });
+      }
       // MQTT-over-WebSocket (RFC 6455 + MQTT 3.1.1 §6.0): the client sends
       // `Sec-WebSocket-Protocol: mqtt` (or `mqttv3.1`). RFC 6455 requires the
       // server to echo back one of the offered subprotocols, otherwise
@@ -129,6 +136,12 @@ function createWsServer(
     },
     websocket: {
       open(ws) {
+        if (isStopping()) {
+          // Server.stop(true) owns the close once STOPPING has been claimed.
+          // Manually closing an upgraded socket while Bun is force-stopping it
+          // can strand the stop Promise on Bun 1.3.10.
+          return;
+        }
         const state = ws.data as WsConnectionState;
 
         const readable = new ReadableStream<Uint8Array>({
@@ -148,7 +161,8 @@ function createWsServer(
             try { ws.send(copyBytes(chunk)); } catch { /* closed between check and send */ }
           },
           // Opifex closes its writer immediately before SockConn.close(). The
-          // latter owns the coordinated readable wake-up and transport close.
+          // latter wakes the readable side; Bun retains the upgraded transport
+          // itself until the broker stops the server.
           close() {},
         });
 
@@ -158,16 +172,20 @@ function createWsServer(
           close: () => {
             // Bun's byte-stream controller does not always settle a pending
             // BYOB read when it is only closed. Rejecting the read wakes the
-            // Opifex serve loop after Context.close(false) has suppressed the
-            // Will and cleared its keepalive timer.
+            // Opifex serve loop after the cached peer- or broker-owned Context
+            // close mode has performed its routing and initial timer cleanup.
             try { state.controller?.error(new Error('WebSocket transport closed')); } catch { /* already closed */ }
             state.controller = null;
-            // Bun 1.3.10's Server.stop(true) does not settle if the upgraded
-            // socket was manually closed first. During broker shutdown it owns
-            // the force-close; outside shutdown this connection closes itself.
-            if (!isStopping()) {
-              try { ws.close(); } catch { /* already closed */ }
-            }
+            // Bun 1.3.10's Server.stop(true) can remain pending if an upgraded
+            // socket was manually closed first. The readable wake-up settles
+            // Opifex; the Bun server retains transport ownership until stop.
+          },
+          remoteAddr: {
+            // This listener is bound exclusively to 127.0.0.1, so retaining
+            // that address preserves the existing localhost-only Will policy.
+            hostname: '127.0.0.1',
+            port: 0,
+            transport: 'tcp',
           },
         };
         serveConnection(sockConn);
@@ -212,6 +230,8 @@ export class EventBroker {
   private shutdownPromise: Promise<void> | null = null;
   private stopRequested = false;
   private tcpListenOutcome: Promise<Outcome> | null = null;
+  private tcpErrorObserver: ((error: unknown) => void) | null = null;
+  private readonly tcpRuntimeErrors: unknown[] = [];
 
   constructor(private broker: 'effectstream-engine' | 'Batcher') {
     this.checkEnabled();
@@ -256,6 +276,10 @@ export class EventBroker {
     const wsPort = this.getWsPort();
 
     this.tcpServer = createServer((sock) => {
+      if (this.stopRequested) {
+        sock.destroy();
+        return;
+      }
       this.tcpSockets.add(sock);
       sock.once('close', () => this.tcpSockets.delete(sock));
       this.serveConnection(wrapNodeSocket(sock), 'tcp');
@@ -267,13 +291,20 @@ export class EventBroker {
         if (settled) return;
         settled = true;
         this.tcpServer?.removeListener('listening', onListening);
-        this.tcpServer?.removeListener('error', onError);
+        if (outcome.ok === false) {
+          this.tcpServer?.removeListener('error', onError);
+          if (this.tcpErrorObserver === onError) this.tcpErrorObserver = null;
+        }
         resolve(outcome);
       };
       const onListening = () => finish({ ok: true });
-      const onError = (error: unknown) => finish({ ok: false, error });
+      const onError = (error: unknown) => {
+        if (!settled) finish({ ok: false, error });
+        else this.tcpRuntimeErrors.push(error);
+      };
+      this.tcpErrorObserver = onError;
       this.tcpServer!.once('listening', onListening);
-      this.tcpServer!.once('error', onError);
+      this.tcpServer!.on('error', onError);
       try {
         this.tcpServer!.listen(tcpPort, '127.0.0.1');
       } catch (error) {
@@ -324,6 +355,13 @@ export class EventBroker {
     if (this.shutdownPromise) return this.shutdownPromise;
     this.stopRequested = true;
     this.state = 'STOPPING';
+    // Claim broker-owned close mode synchronously. Context.close(false) clears
+    // the currently armed keepalive before shutdownInternal's first await; the
+    // independent post-serve timer boundary catches any later handler reset.
+    for (const tracked of [...this.connections.values()]
+      .sort((left, right) => left.sequence - right.sequence)) {
+      void this.finalizeContext(tracked, false);
+    }
     this.shutdownPromise = this.shutdownInternal().then(
       () => {
         this.state = 'STOPPED';
@@ -345,21 +383,50 @@ export class EventBroker {
 
   private registerContext(context: Context): void {
     const tracked = this.connections.get(context.conn);
-    if (tracked) tracked.context = context;
+    if (tracked) {
+      tracked.context = context;
+      if (this.stopRequested) void this.finalizeContext(tracked, false);
+    }
   }
 
-  private finalizeContext(tracked: TrackedConnection): Promise<Outcome> {
-    if (tracked.contextFinalization) return tracked.contextFinalization;
+  private finalizeContext(
+    tracked: TrackedConnection,
+    executeWill: boolean,
+  ): Promise<Outcome> {
+    if (tracked.contextFinalization) return tracked.contextFinalization.outcome;
     if (!tracked.context) return Promise.resolve({ ok: true });
-    tracked.contextFinalization = this.captureOutcome(
-      () => tracked.context!.close(false),
+    let settle!: (outcome: Outcome) => void;
+    const outcome = new Promise<Outcome>((resolve) => { settle = resolve; });
+    tracked.contextFinalization = { executeWill, outcome };
+    try {
+      Promise.resolve(tracked.context.close(executeWill)).then(
+        () => settle({ ok: true }),
+        (error) => settle({ ok: false, error }),
+      );
+    } catch (error) {
+      settle({ ok: false, error });
+    }
+    return outcome;
+  }
+
+  private finalizeTimer(tracked: TrackedConnection): Promise<Outcome> {
+    if (tracked.timerFinalization) return tracked.timerFinalization;
+    if (!tracked.context) return Promise.resolve({ ok: true });
+    tracked.timerFinalization = this.captureOutcome(
+      () => tracked.context!.timer?.clear(),
     );
-    return tracked.contextFinalization;
+    return tracked.timerFinalization;
+  }
+
+  private finalizeTransport(tracked: TrackedConnection): Promise<Outcome> {
+    if (tracked.transportFinalization) return tracked.transportFinalization;
+    tracked.transportFinalization = this.captureOutcome(() => tracked.conn.close());
+    return tracked.transportFinalization;
   }
 
   private rememberFailure(
     tracked: TrackedConnection,
-    kind: 'context' | 'transport' | 'serve',
+    kind: 'context' | 'timer' | 'transport' | 'serve',
     error: unknown,
   ): void {
     const failure = this.connectionFailures.get(tracked.sequence) ?? {
@@ -368,6 +435,9 @@ export class EventBroker {
     if (kind === 'context') {
       failure.contextFailed = true;
       failure.contextError = error;
+    } else if (kind === 'timer') {
+      failure.timerFailed = true;
+      failure.timerError = error;
     } else if (kind === 'transport') {
       failure.transportFailed = true;
       failure.transportError = error;
@@ -379,6 +449,10 @@ export class EventBroker {
   }
 
   private serveConnection(conn: SockConn, transport: 'tcp' | 'ws'): void {
+    if (this.stopRequested) {
+      try { conn.close(); } catch { /* late connection was never admitted */ }
+      return;
+    }
     const tracked: TrackedConnection = {
       sequence: ++this.connectionSequence,
       transport,
@@ -389,13 +463,43 @@ export class EventBroker {
 
     const serveOutcome = this.captureOutcome(() => this.mqttServer.serve(conn));
     tracked.outcome = serveOutcome.then(async (outcome) => {
-      const contextOutcome = await this.finalizeContext(tracked);
+      const contextOutcome = await this.finalizeContext(tracked, !this.stopRequested);
       if (contextOutcome.ok === false) {
         this.rememberFailure(tracked, 'context', contextOutcome.error);
+      }
+      const timerOutcome = await this.finalizeTimer(tracked);
+      if (timerOutcome.ok === false) {
+        this.rememberFailure(tracked, 'timer', timerOutcome.error);
       }
       if (outcome.ok === false) this.rememberFailure(tracked, 'serve', outcome.error);
       this.connections.delete(conn);
     });
+  }
+
+  private async drainConnections(): Promise<void> {
+    while (this.connections.size > 0 || this.tcpSockets.size > 0) {
+      const trackedInOrder = [...this.connections.values()]
+        .sort((left, right) => left.sequence - right.sequence);
+      for (const tracked of trackedInOrder) {
+        const outcome = await this.finalizeContext(tracked, false);
+        if (outcome.ok === false) this.rememberFailure(tracked, 'context', outcome.error);
+      }
+      for (const tracked of trackedInOrder) {
+        const outcome = await this.finalizeTransport(tracked);
+        if (outcome.ok === false) this.rememberFailure(tracked, 'transport', outcome.error);
+      }
+
+      const sockets = [...this.tcpSockets];
+      const socketClosures = sockets.map((socket) => socket.destroyed
+        ? Promise.resolve()
+        : new Promise<void>((resolve) => socket.once('close', () => resolve())));
+      for (const socket of sockets) socket.destroy();
+      await Promise.all([
+        ...trackedInOrder.map((tracked) => tracked.outcome),
+        ...socketClosures,
+      ]);
+      for (const socket of sockets) this.tcpSockets.delete(socket);
+    }
   }
 
   private async shutdownInternal(): Promise<void> {
@@ -423,38 +527,28 @@ export class EventBroker {
       });
     }
 
-    const trackedInOrder = [...this.connections.values()]
-      .sort((left, right) => left.sequence - right.sequence);
-    for (const tracked of trackedInOrder) {
-      const outcome = await this.finalizeContext(tracked);
-      if (outcome.ok === false) this.rememberFailure(tracked, 'context', outcome.error);
-    }
-
-    for (const tracked of trackedInOrder) {
-      const outcome = await this.captureOutcome(() => tracked.conn.close());
-      if (outcome.ok === false) this.rememberFailure(tracked, 'transport', outcome.error);
-    }
-    for (const socket of this.tcpSockets) socket.destroy();
-    this.tcpSockets.clear();
-
     const wsOutcomePromise = this.wsServer
       ? this.captureOutcome(() => this.wsServer!.stop(true))
       : Promise.resolve({ ok: true } as Outcome);
 
+    await this.drainConnections();
     const tcpOutcome = tcpCloseOutcome ? await tcpCloseOutcome : { ok: true } as Outcome;
-    // Successful and failed serve wrappers both remove themselves after their
-    // captured Context has been finalized. Loop because a connection callback
-    // already queued when ingress stopped can register between snapshots.
-    while (this.connections.size > 0) {
-      await Promise.all([...this.connections.values()].map((tracked) => tracked.outcome));
-    }
     const wsOutcome = await wsOutcomePromise;
+    // Listener settlement closes the admission boundary. Repeat the ownership
+    // drain afterward so callbacks queued at that boundary cannot escape a
+    // one-time connection/task snapshot.
+    await this.drainConnections();
+    if (this.tcpErrorObserver) {
+      this.tcpServer?.removeListener('error', this.tcpErrorObserver);
+      this.tcpErrorObserver = null;
+    }
 
     const orderedConnectionFailures = [...this.connectionFailures.values()]
       .sort((left, right) => left.sequence - right.sequence);
-    const failures: unknown[] = [];
+    const failures: unknown[] = [...this.tcpRuntimeErrors];
     for (const failure of orderedConnectionFailures) {
       if (failure.contextFailed) failures.push(failure.contextError);
+      if (failure.timerFailed) failures.push(failure.timerError);
     }
     if (tcpOutcome.ok === false) failures.push(tcpOutcome.error);
     for (const failure of orderedConnectionFailures) {
@@ -462,12 +556,7 @@ export class EventBroker {
     }
     if (wsOutcome.ok === false) failures.push(wsOutcome.error);
     for (const failure of orderedConnectionFailures) {
-      if (
-        failure.serveFailed &&
-        !(failure.contextFailed && Object.is(failure.serveError, failure.contextError))
-      ) {
-        failures.push(failure.serveError);
-      }
+      if (failure.serveFailed) failures.push(failure.serveError);
     }
 
     if (failures.length === 1) throw failures[0];

--- a/packages/node-sdk/events/src/event-broker.ts
+++ b/packages/node-sdk/events/src/event-broker.ts
@@ -65,8 +65,12 @@ function wrapNodeSocket(socket: import('node:net').Socket): SockConn {
     readable,
     writable,
     close: () => {
-      try { readableController?.enqueue(new Uint8Array([0xe0, 0x00])); } catch {}
-      closeReadable();
+      // Bun's byte-stream controller does not always settle a pending BYOB
+      // read when it is only closed. Erroring it wakes the Opifex serve loop
+      // without fabricating inbound protocol bytes (a forged DISCONNECT would
+      // be parsed as genuine peer input if Opifex ever closes while the
+      // context is still connected, silently suppressing its Will).
+      closeReadable(new Error('TCP transport closed by broker'));
       if (!socket.destroyed && !socket.writableEnded) {
         try { socket.end(); } catch { /* already ended */ }
       }
@@ -86,7 +90,7 @@ type TrackedConnection = {
   transport: 'tcp' | 'ws';
   conn: SockConn;
   context?: Context;
-  contextFinalization?: { executeWill: boolean; outcome: Promise<Outcome> };
+  contextFinalization?: Promise<Outcome>;
   timerFinalization?: Promise<Outcome>;
   transportFinalization?: Promise<Outcome>;
   outcome: Promise<void>;
@@ -108,6 +112,8 @@ function createWsServer(
   port: number,
   serveConnection: (conn: SockConn) => void,
   isStopping: () => boolean,
+  trackSocket: (ws: unknown) => void,
+  releaseSocket: (ws: unknown) => void,
 ): ReturnType<typeof Bun.serve> {
   return Bun.serve({
     port,
@@ -136,6 +142,12 @@ function createWsServer(
     },
     websocket: {
       open(ws) {
+        // Track every upgraded socket that is not already closed so shutdown
+        // can observe transport completion directly (see the stop(true) race
+        // in shutdownInternal).
+        if ((ws as { readyState: number }).readyState !== WebSocket.CLOSED) {
+          trackSocket(ws);
+        }
         if (isStopping()) {
           // Server.stop(true) owns the close once STOPPING has been claimed.
           // Manually closing an upgraded socket while Bun is force-stopping it
@@ -158,11 +170,12 @@ function createWsServer(
             // Same guard as wrapNodeSocket — peer-initiated close must not
             // crash Opifex's writer.
             if (ws.readyState !== WebSocket.OPEN) return;
-            try { ws.send(copyBytes(chunk)); } catch { /* closed between check and send */ }
+            // Opifex hands over a freshly encoded per-packet buffer and Bun
+            // serializes synchronously, so no defensive copy is needed here.
+            try { ws.send(chunk); } catch { /* closed between check and send */ }
           },
-          // Opifex closes its writer immediately before SockConn.close(). The
-          // latter wakes the readable side; Bun retains the upgraded transport
-          // itself until the broker stops the server.
+          // Opifex closes its writer immediately before SockConn.close(),
+          // which owns waking the readable side and closing the transport.
           close() {},
         });
 
@@ -176,9 +189,15 @@ function createWsServer(
             // close mode has performed its routing and initial timer cleanup.
             try { state.controller?.error(new Error('WebSocket transport closed')); } catch { /* already closed */ }
             state.controller = null;
-            // Bun 1.3.10's Server.stop(true) can remain pending if an upgraded
-            // socket was manually closed first. The readable wake-up settles
-            // Opifex; the Bun server retains transport ownership until stop.
+            // Outside shutdown the evicted peer must actually be disconnected
+            // (clientId takeover, keepalive timeout, rejected CONNECT), or the
+            // stale client keeps a live socket whose frames are silently
+            // dropped. During shutdown Bun 1.3.10's Server.stop(true) owns the
+            // force-close instead: manually closing an upgraded socket while
+            // Bun is force-stopping can strand the stop Promise.
+            if (!isStopping()) {
+              try { ws.close(); } catch { /* already closed */ }
+            }
           },
         };
         serveConnection(sockConn);
@@ -205,6 +224,7 @@ function createWsServer(
         const state = ws.data as WsConnectionState;
         try { state.controller?.error(new Error('WebSocket transport closed by peer')); } catch { /* already closed */ }
         state.controller = null;
+        releaseSocket(ws);
       },
     },
   });
@@ -215,22 +235,34 @@ export class EventBroker {
   private tcpServer: Server | null = null;
   private wsServer: ReturnType<typeof Bun.serve> | null = null;
   private readonly tcpSockets = new Set<Socket>();
+  private readonly wsLiveSockets = new Set<unknown>();
+  private readonly wsDrainWaiters: Array<() => void> = [];
   private readonly connections = new Map<SockConn, TrackedConnection>();
   private readonly connectionFailures = new Map<number, ConnectionFailure>();
   private connectionSequence = 0;
-  private state: 'NEW' | 'STARTING' | 'STARTED' | 'STOPPING' | 'STOPPED' = 'NEW';
   private startPromise: Promise<void> | null = null;
   private shutdownPromise: Promise<void> | null = null;
-  private stopRequested = false;
   private tcpListenOutcome: Promise<Outcome> | null = null;
   private tcpErrorObserver: ((error: unknown) => void) | null = null;
   private readonly tcpRuntimeErrors: unknown[] = [];
+  private droppedTcpRuntimeErrors = 0;
+  private droppedConnectionFailures = 0;
+  // Failure records are retained until shutdown aggregates them; the cap keeps
+  // a long-lived broker's memory bounded (each dropped record is still logged
+  // at occurrence and surfaces as one summary error at shutdown).
+  private static readonly MAX_RETAINED_CLEANUP_FAILURES = 128;
 
   constructor(private broker: 'effectstream-engine' | 'Batcher') {
     this.checkEnabled();
 
     const handlers: Handlers = {
       isAuthenticated: (ctx: Context) => {
+        if (this.isStopping()) {
+          // A CONNECT racing shutdown must not register a session: Opifex
+          // calls this hook before ctx.connect(), so refusing here makes it
+          // send CONNACK serverUnavailable and close the context itself.
+          return AuthenticationResult.serverUnavailable;
+        }
         this.registerContext(ctx);
         return AuthenticationResult.ok;
       },
@@ -253,15 +285,28 @@ export class EventBroker {
   }
 
   public start(): Promise<void> {
-    if (this.startPromise && (this.state === 'STARTING' || this.state === 'STARTED')) {
-      return this.startPromise;
+    if (this.shutdownPromise) {
+      return Promise.reject(new Error('MQTT server cannot start after shutdown'));
     }
-    if (this.state !== 'NEW') {
-      return Promise.reject(new Error(`MQTT server cannot start from state ${this.state}`));
-    }
-    this.state = 'STARTING';
+    if (this.startPromise) return this.startPromise;
     this.startPromise = this.startInternal();
     return this.startPromise;
+  }
+
+  private isStopping(): boolean {
+    return this.shutdownPromise !== null;
+  }
+
+  private releaseWsSocket(ws: unknown): void {
+    this.wsLiveSockets.delete(ws);
+    if (this.wsLiveSockets.size === 0) {
+      for (const waiter of this.wsDrainWaiters.splice(0)) waiter();
+    }
+  }
+
+  private wsSocketsDrained(): Promise<void> {
+    if (this.wsLiveSockets.size === 0) return Promise.resolve();
+    return new Promise((resolve) => { this.wsDrainWaiters.push(resolve); });
   }
 
   private async startInternal(): Promise<void> {
@@ -269,7 +314,7 @@ export class EventBroker {
     const wsPort = this.getWsPort();
 
     this.tcpServer = createServer((sock) => {
-      if (this.stopRequested) {
+      if (this.isStopping()) {
         sock.destroy();
         return;
       }
@@ -292,8 +337,16 @@ export class EventBroker {
       };
       const onListening = () => finish({ ok: true });
       const onError = (error: unknown) => {
-        if (!settled) finish({ ok: false, error });
-        else this.tcpRuntimeErrors.push(error);
+        if (!settled) {
+          finish({ ok: false, error });
+          return;
+        }
+        console.error(`MQTT server [${this.broker}] TCP listener runtime error:`, error);
+        if (this.tcpRuntimeErrors.length < EventBroker.MAX_RETAINED_CLEANUP_FAILURES) {
+          this.tcpRuntimeErrors.push(error);
+        } else {
+          this.droppedTcpRuntimeErrors++;
+        }
       };
       this.tcpErrorObserver = onError;
       this.tcpServer!.once('listening', onListening);
@@ -308,17 +361,18 @@ export class EventBroker {
     try {
       const tcpOutcome = await this.tcpListenOutcome;
       if (tcpOutcome.ok === false) throw tcpOutcome.error;
-      if (this.stopRequested) throw new Error('MQTT server start cancelled by shutdown');
+      if (this.isStopping()) throw new Error('MQTT server start cancelled by shutdown');
       console.log(`MQTT TCP Server [${this.broker}] started on port ${tcpPort}`);
 
       this.wsServer = createWsServer(
         wsPort,
         (conn) => this.serveConnection(conn, 'ws'),
-        () => this.stopRequested,
+        () => this.isStopping(),
+        (ws) => this.wsLiveSockets.add(ws),
+        (ws) => this.releaseWsSocket(ws),
       );
-      if (this.stopRequested) throw new Error('MQTT server start cancelled by shutdown');
+      if (this.isStopping()) throw new Error('MQTT server start cancelled by shutdown');
       console.log(`MQTT WS Server [${this.broker}] started on port ${wsPort}`);
-      this.state = 'STARTED';
     } catch (startError) {
       const cleanup = await this.captureOutcome(() => this.beginShutdown());
       if (cleanup.ok === false) {
@@ -346,25 +400,18 @@ export class EventBroker {
 
   private beginShutdown(): Promise<void> {
     if (this.shutdownPromise) return this.shutdownPromise;
-    this.stopRequested = true;
-    this.state = 'STOPPING';
-    // Claim broker-owned close mode synchronously. Context.close(false) clears
+    // Assigning the cached Promise claims STOPPING for every isStopping()
+    // reader before any other statement runs. Context.close(false) then clears
     // the currently armed keepalive before shutdownInternal's first await; the
     // independent post-serve timer boundary catches any later handler reset.
+    const { promise, resolve, reject } = Promise.withResolvers<void>();
+    this.shutdownPromise = promise;
     for (const tracked of [...this.connections.values()]
       .sort((left, right) => left.sequence - right.sequence)) {
       void this.finalizeContext(tracked, false);
     }
-    this.shutdownPromise = this.shutdownInternal().then(
-      () => {
-        this.state = 'STOPPED';
-      },
-      (error) => {
-        this.state = 'STOPPED';
-        throw error;
-      },
-    );
-    return this.shutdownPromise;
+    this.shutdownInternal().then(resolve, reject);
+    return promise;
   }
 
   private captureOutcome(action: () => unknown): Promise<Outcome> {
@@ -376,30 +423,28 @@ export class EventBroker {
 
   private registerContext(context: Context): void {
     const tracked = this.connections.get(context.conn);
-    if (tracked) {
-      tracked.context = context;
-      if (this.stopRequested) void this.finalizeContext(tracked, false);
-    }
+    if (tracked) tracked.context = context;
   }
 
   private finalizeContext(
     tracked: TrackedConnection,
     executeWill: boolean,
   ): Promise<Outcome> {
-    if (tracked.contextFinalization) return tracked.contextFinalization.outcome;
+    if (tracked.contextFinalization) return tracked.contextFinalization;
     if (!tracked.context) return Promise.resolve({ ok: true });
-    let settle!: (outcome: Outcome) => void;
-    const outcome = new Promise<Outcome>((resolve) => { settle = resolve; });
-    tracked.contextFinalization = { executeWill, outcome };
+    const { promise, resolve } = Promise.withResolvers<Outcome>();
+    tracked.contextFinalization = promise;
     try {
+      // close() must be invoked synchronously here so the first shutdown call
+      // clears visible keepalive timers before its first asynchronous boundary.
       Promise.resolve(tracked.context.close(executeWill)).then(
-        () => settle({ ok: true }),
-        (error) => settle({ ok: false, error }),
+        () => resolve({ ok: true }),
+        (error) => resolve({ ok: false, error }),
       );
     } catch (error) {
-      settle({ ok: false, error });
+      resolve({ ok: false, error });
     }
-    return outcome;
+    return promise;
   }
 
   private finalizeTimer(tracked: TrackedConnection): Promise<Outcome> {
@@ -422,9 +467,19 @@ export class EventBroker {
     kind: 'context' | 'timer' | 'transport' | 'serve',
     error: unknown,
   ): void {
-    const failure = this.connectionFailures.get(tracked.sequence) ?? {
-      sequence: tracked.sequence,
-    };
+    console.error(
+      `MQTT server [${this.broker}] connection ${tracked.sequence} ${kind} cleanup failed:`,
+      error,
+    );
+    const existing = this.connectionFailures.get(tracked.sequence);
+    if (
+      !existing &&
+      this.connectionFailures.size >= EventBroker.MAX_RETAINED_CLEANUP_FAILURES
+    ) {
+      this.droppedConnectionFailures++;
+      return;
+    }
+    const failure = existing ?? { sequence: tracked.sequence };
     if (kind === 'context') {
       failure.contextFailed = true;
       failure.contextError = error;
@@ -442,7 +497,7 @@ export class EventBroker {
   }
 
   private serveConnection(conn: SockConn, transport: 'tcp' | 'ws'): void {
-    if (this.stopRequested) {
+    if (this.isStopping()) {
       try { conn.close(); } catch { /* late connection was never admitted */ }
       return;
     }
@@ -456,7 +511,7 @@ export class EventBroker {
 
     const serveOutcome = this.captureOutcome(() => this.mqttServer.serve(conn));
     tracked.outcome = serveOutcome.then(async (outcome) => {
-      const contextOutcome = await this.finalizeContext(tracked, !this.stopRequested);
+      const contextOutcome = await this.finalizeContext(tracked, !this.isStopping());
       if (contextOutcome.ok === false) {
         this.rememberFailure(tracked, 'context', contextOutcome.error);
       }
@@ -521,7 +576,18 @@ export class EventBroker {
     }
 
     const wsOutcomePromise = this.wsServer
-      ? this.captureOutcome(() => this.wsServer!.stop(true))
+      ? this.captureOutcome(() => {
+        // Bun (verified on 1.3.10 and 1.3.11) never settles stop(true)'s
+        // Promise once any upgraded socket was closed server-side (a runtime
+        // eviction), even though it still force-closes remaining sockets and
+        // releases the listener. Transport completion is therefore also
+        // observed directly through the per-socket close callbacks; a stop
+        // failure that arrives after the drain signal wins is still observed
+        // so it cannot become an unhandled rejection.
+        const stopping = Promise.resolve(this.wsServer!.stop(true));
+        stopping.catch(() => { /* observed via the race or superseded by the drain signal */ });
+        return Promise.race([stopping, this.wsSocketsDrained()]);
+      })
       : Promise.resolve({ ok: true } as Outcome);
 
     await this.drainConnections();
@@ -539,6 +605,11 @@ export class EventBroker {
     const orderedConnectionFailures = [...this.connectionFailures.values()]
       .sort((left, right) => left.sequence - right.sequence);
     const failures: unknown[] = [...this.tcpRuntimeErrors];
+    if (this.droppedTcpRuntimeErrors > 0) {
+      failures.push(new Error(
+        `${this.droppedTcpRuntimeErrors} additional TCP listener runtime errors were logged at occurrence and dropped`,
+      ));
+    }
     for (const failure of orderedConnectionFailures) {
       if (failure.contextFailed) failures.push(failure.contextError);
       if (failure.timerFailed) failures.push(failure.timerError);
@@ -550,6 +621,11 @@ export class EventBroker {
     if (wsOutcome.ok === false) failures.push(wsOutcome.error);
     for (const failure of orderedConnectionFailures) {
       if (failure.serveFailed) failures.push(failure.serveError);
+    }
+    if (this.droppedConnectionFailures > 0) {
+      failures.push(new Error(
+        `${this.droppedConnectionFailures} additional connection cleanup failures were logged at occurrence and dropped`,
+      ));
     }
 
     if (failures.length === 1) throw failures[0];

--- a/packages/node-sdk/events/src/event-broker.ts
+++ b/packages/node-sdk/events/src/event-broker.ts
@@ -180,13 +180,6 @@ function createWsServer(
             // socket was manually closed first. The readable wake-up settles
             // Opifex; the Bun server retains transport ownership until stop.
           },
-          remoteAddr: {
-            // This listener is bound exclusively to 127.0.0.1, so retaining
-            // that address preserves the existing localhost-only Will policy.
-            hostname: '127.0.0.1',
-            port: 0,
-            transport: 'tcp',
-          },
         };
         serveConnection(sockConn);
       },

--- a/packages/node-sdk/events/test/event-broker-lifecycle.test.ts
+++ b/packages/node-sdk/events/test/event-broker-lifecycle.test.ts
@@ -132,10 +132,19 @@ async function connectWs(port: number): Promise<WebSocket> {
   return ws;
 }
 
+type MqttQos = 0 | 1 | 2;
+
+type MqttWill = {
+  topic: string;
+  payload: string;
+  qos: MqttQos;
+  retain: boolean;
+};
+
 function mqttConnectPacket(
   clientId: string,
   keepAlive: number,
-  will?: { topic: string; payload: string },
+  will?: MqttWill,
 ): Uint8Array {
   const encoder = new TextEncoder();
   const id = encoder.encode(clientId);
@@ -144,7 +153,7 @@ function mqttConnectPacket(
   const body = [
     0x00, 0x04, 0x4d, 0x51, 0x54, 0x54,
     0x04,
-    will ? 0x06 : 0x02,
+    will ? 0x02 | 0x04 | (will.qos << 3) | (will.retain ? 0x20 : 0) : 0x02,
     (keepAlive >> 8) & 0xff, keepAlive & 0xff,
     0x00, id.length, ...id,
     ...(will ? [0x00, topic.length, ...topic, 0x00, payload.length, ...payload] : []),
@@ -155,6 +164,25 @@ function mqttConnectPacket(
 
 function mqttDisconnectPacket(): Uint8Array {
   return new Uint8Array([0xe0, 0x00]);
+}
+
+function mqttPublishPacket(
+  topicName: string,
+  payloadText: string,
+  qos: MqttQos,
+  retain: boolean,
+): Uint8Array {
+  const encoder = new TextEncoder();
+  const topic = encoder.encode(topicName);
+  const payload = encoder.encode(payloadText);
+  const packetId = qos === 0 ? [] : [0x00, 0x01];
+  const body = [0x00, topic.length, ...topic, ...packetId, ...payload];
+  if (body.length >= 128) throw new Error("test PUBLISH packet is unexpectedly large");
+  return new Uint8Array([0x30 | (qos << 1) | (retain ? 0x01 : 0), body.length, ...body]);
+}
+
+function mqttPingRequestPacket(): Uint8Array {
+  return new Uint8Array([0xc0, 0x00]);
 }
 
 type PublishedPacket = {
@@ -185,7 +213,7 @@ async function connectMqttTcp(
   port: number,
   clientId: string,
   keepAlive: number,
-  will?: { topic: string; payload: string },
+  will?: MqttWill,
 ): Promise<Socket> {
   const socket = await connectTcp(port);
   const response = new Promise<Uint8Array>((resolve, reject) => {
@@ -203,7 +231,7 @@ async function connectMqttWs(
   port: number,
   clientId: string,
   keepAlive: number,
-  will?: { topic: string; payload: string },
+  will?: MqttWill,
 ): Promise<WebSocket> {
   const ws = await connectWs(port);
   const response = new Promise<Uint8Array>((resolve, reject) => {
@@ -357,8 +385,12 @@ test("real TCP and WebSocket keepalive timers clear before shutdown settles and 
       return realPublish(topic, packet);
     };
     await Promise.all([
-      connectMqttTcp(tcpPort, "lifecycle-tcp", keepAlive, { topic: "lifecycle/will", payload: "tcp" }),
-      connectMqttWs(wsPort, "lifecycle-ws", keepAlive, { topic: "lifecycle/will", payload: "ws" }),
+      connectMqttTcp(tcpPort, "lifecycle-tcp", keepAlive, {
+        topic: "lifecycle/will", payload: "tcp", qos: 0, retain: false,
+      }),
+      connectMqttWs(wsPort, "lifecycle-ws", keepAlive, {
+        topic: "lifecycle/will", payload: "ws", qos: 0, retain: false,
+      }),
     ]);
     await waitUntil(() => probe.captured.size === 2);
     const stopping = internals.shutdown();
@@ -413,7 +445,92 @@ test("raw Opifex transport close and serve-task drain alone do not clear keepali
   }
 });
 
-test("abrupt TCP and WebSocket peers preserve exact-once Will and system routing while clearing timers", async () => {
+test("exact-base routing preserves TCP Will policy and rejects WebSocket publishes and Wills", async () => {
+  const [tcpPort, wsPort] = brokerPorts("effectstream-engine");
+  const broker = makeBroker();
+  await broker.start();
+  const published = capturePublishedPackets(broker);
+  const deniedRemoteAddresses: string[] = [];
+  const originalConsoleError = console.error;
+  console.error = (...args: unknown[]) => {
+    if (args[0] === "Filtering MQTT publish from non-localhost:") {
+      deniedRemoteAddresses.push(String(args[1]));
+      return;
+    }
+    originalConsoleError(...args);
+  };
+  try {
+    const tcpClientId = "routing-tcp-client";
+    const wsClientId = "routing-ws-client";
+    const [socket, ws] = await Promise.all([
+      connectMqttTcp(tcpPort, tcpClientId, 1, {
+        topic: "lifecycle/routing/will/tcp-qos2-retained",
+        payload: "tcp-qos2-retained-payload",
+        qos: 2,
+        retain: true,
+      }),
+      connectMqttWs(wsPort, wsClientId, 1, {
+        topic: "lifecycle/routing/will/ws-qos1-retained",
+        payload: "ws-qos1-retained-payload",
+        qos: 1,
+        retain: true,
+      }),
+    ]);
+
+    const pingResponse = new Promise<Uint8Array>((resolve, reject) => {
+      ws.onmessage = (event) => resolve(new Uint8Array(event.data as ArrayBuffer));
+      ws.onerror = () => reject(new Error("WebSocket routing barrier failed"));
+    });
+    ws.send(mqttPublishPacket(
+      "lifecycle/routing/application/ws-retained",
+      "must-not-route-from-unknown-ws",
+      0,
+      true,
+    ));
+    ws.send(mqttPingRequestPacket());
+    expect(Array.from(await withDeadline(pingResponse))).toEqual([0xd0, 0x00]);
+
+    socket.destroy();
+    ws.close();
+    await waitUntil(() => {
+      const disconnected = published.filter((packet) =>
+        packet.topic === "$SYS/disconnect/clients" &&
+        (packet.payload === tcpClientId || packet.payload === wsClientId)
+      );
+      return disconnected.length === 2;
+    }, 3_000);
+
+    const application = published.filter((packet) =>
+      packet.topic === "lifecycle/routing/application/ws-retained"
+    );
+    const wills = published.filter((packet) =>
+      packet.topic.startsWith("lifecycle/routing/will/")
+    );
+    const disconnects = published.filter((packet) =>
+      packet.topic === "$SYS/disconnect/clients" &&
+      (packet.payload === tcpClientId || packet.payload === wsClientId)
+    ).sort((left, right) => left.payload.localeCompare(right.payload));
+
+    expect({ application, wills, disconnects, deniedRemoteAddresses }).toEqual({
+      application: [],
+      wills: [{
+        topic: "lifecycle/routing/will/tcp-qos2-retained",
+        payload: "tcp-qos2-retained-payload",
+        qos: 2,
+        retain: true,
+      }],
+      disconnects: [
+        { topic: "$SYS/disconnect/clients", payload: tcpClientId, qos: 0, retain: false },
+        { topic: "$SYS/disconnect/clients", payload: wsClientId, qos: 0, retain: false },
+      ],
+      deniedRemoteAddresses: ["unknown", "unknown"],
+    });
+  } finally {
+    console.error = originalConsoleError;
+  }
+});
+
+test("abrupt TCP and WebSocket peers preserve exact-base Will and system routing while clearing timers", async () => {
   const keepAlive = 181;
   const probe = instrumentKeepalive(keepAlive);
   try {
@@ -425,10 +542,14 @@ test("abrupt TCP and WebSocket peers preserve exact-once Will and system routing
       connectMqttTcp(tcpPort, "abrupt-tcp-client", keepAlive, {
         topic: "lifecycle/will/tcp",
         payload: "abrupt-tcp-payload",
+        qos: 2,
+        retain: true,
       }),
       connectMqttWs(wsPort, "abrupt-ws-client", keepAlive, {
         topic: "lifecycle/will/ws",
         payload: "abrupt-ws-payload",
+        qos: 1,
+        retain: true,
       }),
     ]);
     const internals = broker as any;
@@ -438,7 +559,7 @@ test("abrupt TCP and WebSocket peers preserve exact-once Will and system routing
       probe.cleared.size === probe.captured.size &&
       probe.cleared.size === 2 &&
       internals.connections.size === 0 &&
-      published.filter((packet) => packet.topic.startsWith("lifecycle/will/")).length === 2
+      published.filter((packet) => packet.topic === "$SYS/disconnect/clients").length === 2
     );
     expect(
       published.filter((packet) => packet.topic === "$SYS/disconnect/clients"),
@@ -449,8 +570,7 @@ test("abrupt TCP and WebSocket peers preserve exact-once Will and system routing
     expect(
       published.filter((packet) => packet.topic.startsWith("lifecycle/will/")),
     ).toEqual([
-      { topic: "lifecycle/will/tcp", payload: "abrupt-tcp-payload", qos: 0, retain: false },
-      { topic: "lifecycle/will/ws", payload: "abrupt-ws-payload", qos: 0, retain: false },
+      { topic: "lifecycle/will/tcp", payload: "abrupt-tcp-payload", qos: 2, retain: true },
     ]);
     const probeSocket = await connectTcp(tcpPort);
     const probeWs = await connectWs(wsPort);
@@ -474,10 +594,14 @@ test("graceful TCP and WebSocket DISCONNECT quiesces rearmed timers without Will
       connectMqttTcp(tcpPort, "graceful-tcp-client", keepAlive, {
         topic: "lifecycle/will/graceful-tcp",
         payload: "must-not-publish-tcp",
+        qos: 0,
+        retain: false,
       }),
       connectMqttWs(wsPort, "graceful-ws-client", keepAlive, {
         topic: "lifecycle/will/graceful-ws",
         payload: "must-not-publish-ws",
+        qos: 0,
+        retain: false,
       }),
     ]);
     const wsClosed = new Promise<void>((resolve) => {
@@ -509,7 +633,7 @@ test("graceful TCP and WebSocket DISCONNECT quiesces rearmed timers without Will
   }
 });
 
-test("timed-out WebSocket MQTT context quiesces while Bun retains transport ownership until shutdown", async () => {
+test("timed-out WebSocket MQTT context preserves exact-base no-Will routing while Bun owns transport", async () => {
   const keepAlive = 1;
   const probe = instrumentKeepalive(keepAlive);
   try {
@@ -520,6 +644,8 @@ test("timed-out WebSocket MQTT context quiesces while Bun retains transport owne
     const ws = await connectMqttWs(wsPort, "timeout-ws-client", keepAlive, {
       topic: "lifecycle/will/timeout-ws",
       payload: "timeout-ws-payload",
+      qos: 0,
+      retain: false,
     });
     const wsClosed = new Promise<void>((resolve) => {
       ws.addEventListener("close", () => resolve(), { once: true });
@@ -529,7 +655,7 @@ test("timed-out WebSocket MQTT context quiesces while Bun retains transport owne
       internals.connections.size === 0 &&
       probe.captured.size === 1 &&
       probe.cleared.size === 1 &&
-      published.some((packet) => packet.topic === "lifecycle/will/timeout-ws")
+      published.some((packet) => packet.topic === "$SYS/disconnect/clients")
     , 2_500);
     expect(
       published.filter((packet) => packet.topic === "$SYS/disconnect/clients"),
@@ -538,9 +664,7 @@ test("timed-out WebSocket MQTT context quiesces while Bun retains transport owne
     ]);
     expect(
       published.filter((packet) => packet.topic === "lifecycle/will/timeout-ws"),
-    ).toEqual([
-      { topic: "lifecycle/will/timeout-ws", payload: "timeout-ws-payload", qos: 0, retain: false },
-    ]);
+    ).toEqual([]);
     expect(ws.readyState).toBe(WebSocket.OPEN);
     await withDeadline(internals.shutdown());
     await withDeadline(wsClosed);
@@ -563,6 +687,8 @@ test("shutdown synchronously claims close(false) and clears a timer rearmed by a
     const socket = await connectMqttTcp(tcpPort, "in-flight-client", keepAlive, {
       topic: "lifecycle/will/in-flight",
       payload: "must-not-publish",
+      qos: 0,
+      retain: false,
     });
     const internals = broker as any;
     await waitUntil(() => [...internals.connections.values()].some((entry: any) => entry.context));

--- a/packages/node-sdk/events/test/event-broker-lifecycle.test.ts
+++ b/packages/node-sdk/events/test/event-broker-lifecycle.test.ts
@@ -622,18 +622,17 @@ test("graceful TCP and WebSocket DISCONNECT quiesces rearmed timers without Will
       { topic: "$SYS/disconnect/clients", payload: "graceful-ws-client", qos: 0, retain: false },
     ]);
     expect(published.filter((packet) => packet.topic.startsWith("lifecycle/will/"))).toEqual([]);
-    // Bun owns an upgraded socket until Server.stop(true). Closing it from the
-    // MQTT SockConn first can strand Bun 1.3.10's stop Promise.
-    expect(ws.readyState).toBe(WebSocket.OPEN);
-    await withDeadline(internals.shutdown());
+    // A gracefully disconnected WebSocket peer is released immediately; only
+    // sockets still open when shutdown begins are left to Server.stop(true).
     await withDeadline(wsClosed);
+    await withDeadline(internals.shutdown());
     await expectWsReusable(wsPort);
   } finally {
     probe.restore();
   }
 });
 
-test("timed-out WebSocket MQTT context preserves exact-base no-Will routing while Bun owns transport", async () => {
+test("timed-out WebSocket MQTT context preserves exact-base no-Will routing and closes the evicted socket", async () => {
   const keepAlive = 1;
   const probe = instrumentKeepalive(keepAlive);
   try {
@@ -665,13 +664,40 @@ test("timed-out WebSocket MQTT context preserves exact-base no-Will routing whil
     expect(
       published.filter((packet) => packet.topic === "lifecycle/will/timeout-ws"),
     ).toEqual([]);
-    expect(ws.readyState).toBe(WebSocket.OPEN);
-    await withDeadline(internals.shutdown());
     await withDeadline(wsClosed);
+    await withDeadline(internals.shutdown());
     await expectWsReusable(wsPort);
   } finally {
     probe.restore();
   }
+});
+
+test("the authentication hook refuses CONNECTs once shutdown has begun", async () => {
+  const broker = makeBroker();
+  const internals = broker as any;
+  const stopping = internals.shutdown();
+  const result = internals.mqttServer.handlers.isAuthenticated({} as Context);
+  expect(result).toBe(AuthenticationResult.serverUnavailable);
+  await stopping;
+});
+
+test("a CONNECT racing shutdown never registers a session", async () => {
+  const [tcpPort] = brokerPorts("effectstream-engine");
+  const broker = makeBroker();
+  await broker.start();
+  const published = capturePublishedPackets(broker);
+  const socket = await connectTcp(tcpPort);
+  const internals = broker as any;
+  await waitUntil(() => internals.connections.size === 1);
+  const stopping = internals.shutdown();
+  socket.write(mqttConnectPacket("shutdown-race-client", 7));
+  await withDeadline(stopping);
+  expect(
+    published.filter((packet) =>
+      packet.topic === "$SYS/connect/clients" && packet.payload === "shutdown-race-client"
+    ),
+  ).toEqual([]);
+  expect(internals.connections.size).toBe(0);
 });
 
 test("shutdown synchronously claims close(false) and clears a timer rearmed by an in-flight handler", async () => {
@@ -748,7 +774,7 @@ test("shutdown before start is safe; repeated shutdown shares success", async ()
   expect(second).toBe(first);
   await first;
   expect((broker as any).shutdown()).toBe(first);
-  await expect(broker.start()).rejects.toThrow(/cannot start from state STOPPED/);
+  await expect(broker.start()).rejects.toThrow(/cannot start after shutdown/);
 });
 
 test("shutdown racing startup rejects start and prevents late WebSocket acquisition", async () => {
@@ -879,7 +905,7 @@ test("TCP bind conflict rejects before deadline and failed instances cannot rest
   const result = await withDeadline(captureRejection(broker.start()), 500);
   expect(result.rejected).toBe(true);
   expect((result.reason as NodeJS.ErrnoException).code).toBe("EADDRINUSE");
-  await expect(broker.start()).rejects.toThrow(/cannot start from state STOPPED/);
+  await expect(broker.start()).rejects.toThrow(/cannot start after shutdown/);
   await expectWsReusable(wsPort);
 });
 
@@ -946,11 +972,9 @@ test.each(rejectionReasons)(
     const first = internals.shutdown();
     const result = await captureRejection(first);
     expect(result.rejected).toBe(true);
-    expect(result.reason).toBeInstanceOf(AggregateError);
-    const failures = (result.reason as AggregateError).errors;
-    expect(failures).toHaveLength(2);
-    expect(Object.is(failures[0], value)).toBe(true);
-    expect(Object.is(failures[1], value)).toBe(true);
+    // The Context close is attempted exactly once (memoized), so the single
+    // failure replays by identity rather than wrapped in an AggregateError.
+    expect(Object.is(result.reason, value)).toBe(true);
     expect(internals.shutdown()).toBe(first);
     brokers.delete(broker);
   },
@@ -1080,7 +1104,6 @@ test("context, TCP, and WebSocket cleanup failures aggregate in shutdown order",
     contextError,
     tcpError,
     wsError,
-    contextError,
   ]);
   tcpServer.close = realTcpClose as typeof tcpServer.close;
   wsServer.stop = realWsStop as typeof wsServer.stop;

--- a/packages/node-sdk/events/test/event-broker-lifecycle.test.ts
+++ b/packages/node-sdk/events/test/event-broker-lifecycle.test.ts
@@ -153,6 +153,34 @@ function mqttConnectPacket(
   return new Uint8Array([0x10, body.length, ...body]);
 }
 
+function mqttDisconnectPacket(): Uint8Array {
+  return new Uint8Array([0xe0, 0x00]);
+}
+
+type PublishedPacket = {
+  topic: string;
+  payload: string;
+  qos: number;
+  retain: boolean;
+};
+
+function capturePublishedPackets(broker: EventBroker): PublishedPacket[] {
+  const internals = broker as any;
+  const published: PublishedPacket[] = [];
+  const persistence = internals.mqttServer.persistence;
+  const realPublish = persistence.publish.bind(persistence);
+  persistence.publish = (topic: string, packet: any) => {
+    published.push({
+      topic,
+      payload: new TextDecoder().decode(packet.payload ?? new Uint8Array()),
+      qos: packet.qos ?? 0,
+      retain: packet.retain ?? false,
+    });
+    return realPublish(topic, packet);
+  };
+  return published;
+}
+
 async function connectMqttTcp(
   port: number,
   clientId: string,
@@ -337,7 +365,7 @@ test("real TCP and WebSocket keepalive timers clear before shutdown settles and 
     await withDeadline(stopping);
     probe.markShutdownSettled();
     expect(probe.cleared.size).toBe(2);
-    expect(probe.clearEvents).toHaveLength(2);
+    expect(probe.clearEvents.length).toBeGreaterThanOrEqual(2);
     expect(probe.clearEvents.every((event) => event.shutdownSettled === false)).toBe(true);
     expect(published).toEqual([]);
     expect(internals.connections.size).toBe(0);
@@ -385,42 +413,194 @@ test("raw Opifex transport close and serve-task drain alone do not clear keepali
   }
 });
 
-test("abrupt TCP and WebSocket disconnects finalize tracked contexts while broker stays running", async () => {
+test("abrupt TCP and WebSocket peers preserve exact-once Will and system routing while clearing timers", async () => {
   const keepAlive = 181;
   const probe = instrumentKeepalive(keepAlive);
   try {
     const [tcpPort, wsPort] = brokerPorts("effectstream-engine");
     const broker = makeBroker();
     await broker.start();
+    const published = capturePublishedPackets(broker);
     const [socket, ws] = await Promise.all([
       connectMqttTcp(tcpPort, "abrupt-tcp-client", keepAlive, {
-        topic: "lifecycle/will",
-        payload: "must-not-publish-tcp",
+        topic: "lifecycle/will/tcp",
+        payload: "abrupt-tcp-payload",
       }),
       connectMqttWs(wsPort, "abrupt-ws-client", keepAlive, {
-        topic: "lifecycle/will",
-        payload: "must-not-publish-ws",
+        topic: "lifecycle/will/ws",
+        payload: "abrupt-ws-payload",
       }),
     ]);
     const internals = broker as any;
-    const published: string[] = [];
-    const persistence = internals.mqttServer.persistence;
-    const realPublish = persistence.publish.bind(persistence);
-    persistence.publish = (topic: string, packet: unknown) => {
-      if (topic === "lifecycle/will") published.push(topic);
-      return realPublish(topic, packet);
-    };
     socket.destroy();
     ws.close();
-    await waitUntil(() => probe.cleared.size === 2 && internals.connections.size === 0);
-    expect(probe.cleared.size).toBe(2);
-    expect(published).toEqual([]);
+    await waitUntil(() =>
+      probe.cleared.size === probe.captured.size &&
+      probe.cleared.size === 2 &&
+      internals.connections.size === 0 &&
+      published.filter((packet) => packet.topic.startsWith("lifecycle/will/")).length === 2
+    );
+    expect(
+      published.filter((packet) => packet.topic === "$SYS/disconnect/clients"),
+    ).toEqual([
+      { topic: "$SYS/disconnect/clients", payload: "abrupt-tcp-client", qos: 0, retain: false },
+      { topic: "$SYS/disconnect/clients", payload: "abrupt-ws-client", qos: 0, retain: false },
+    ]);
+    expect(
+      published.filter((packet) => packet.topic.startsWith("lifecycle/will/")),
+    ).toEqual([
+      { topic: "lifecycle/will/tcp", payload: "abrupt-tcp-payload", qos: 0, retain: false },
+      { topic: "lifecycle/will/ws", payload: "abrupt-ws-payload", qos: 0, retain: false },
+    ]);
     const probeSocket = await connectTcp(tcpPort);
     const probeWs = await connectWs(wsPort);
     probeSocket.destroy();
     probeWs.close();
     await internals.shutdown();
   } finally {
+    probe.restore();
+  }
+});
+
+test("graceful TCP and WebSocket DISCONNECT quiesces rearmed timers without Will or duplicate system routing", async () => {
+  const keepAlive = 183;
+  const probe = instrumentKeepalive(keepAlive);
+  try {
+    const [tcpPort, wsPort] = brokerPorts("effectstream-engine");
+    const broker = makeBroker();
+    await broker.start();
+    const published = capturePublishedPackets(broker);
+    const [socket, ws] = await Promise.all([
+      connectMqttTcp(tcpPort, "graceful-tcp-client", keepAlive, {
+        topic: "lifecycle/will/graceful-tcp",
+        payload: "must-not-publish-tcp",
+      }),
+      connectMqttWs(wsPort, "graceful-ws-client", keepAlive, {
+        topic: "lifecycle/will/graceful-ws",
+        payload: "must-not-publish-ws",
+      }),
+    ]);
+    const wsClosed = new Promise<void>((resolve) => {
+      ws.addEventListener("close", () => resolve(), { once: true });
+    });
+    socket.write(mqttDisconnectPacket());
+    ws.send(mqttDisconnectPacket());
+    const internals = broker as any;
+    await waitUntil(() =>
+      probe.captured.size === 4 &&
+      probe.cleared.size === probe.captured.size &&
+      internals.connections.size === 0
+    );
+    expect(
+      published.filter((packet) => packet.topic === "$SYS/disconnect/clients"),
+    ).toEqual([
+      { topic: "$SYS/disconnect/clients", payload: "graceful-tcp-client", qos: 0, retain: false },
+      { topic: "$SYS/disconnect/clients", payload: "graceful-ws-client", qos: 0, retain: false },
+    ]);
+    expect(published.filter((packet) => packet.topic.startsWith("lifecycle/will/"))).toEqual([]);
+    // Bun owns an upgraded socket until Server.stop(true). Closing it from the
+    // MQTT SockConn first can strand Bun 1.3.10's stop Promise.
+    expect(ws.readyState).toBe(WebSocket.OPEN);
+    await withDeadline(internals.shutdown());
+    await withDeadline(wsClosed);
+    await expectWsReusable(wsPort);
+  } finally {
+    probe.restore();
+  }
+});
+
+test("timed-out WebSocket MQTT context quiesces while Bun retains transport ownership until shutdown", async () => {
+  const keepAlive = 1;
+  const probe = instrumentKeepalive(keepAlive);
+  try {
+    const [, wsPort] = brokerPorts("effectstream-engine");
+    const broker = makeBroker();
+    await broker.start();
+    const published = capturePublishedPackets(broker);
+    const ws = await connectMqttWs(wsPort, "timeout-ws-client", keepAlive, {
+      topic: "lifecycle/will/timeout-ws",
+      payload: "timeout-ws-payload",
+    });
+    const wsClosed = new Promise<void>((resolve) => {
+      ws.addEventListener("close", () => resolve(), { once: true });
+    });
+    const internals = broker as any;
+    await waitUntil(() =>
+      internals.connections.size === 0 &&
+      probe.captured.size === 1 &&
+      probe.cleared.size === 1 &&
+      published.some((packet) => packet.topic === "lifecycle/will/timeout-ws")
+    , 2_500);
+    expect(
+      published.filter((packet) => packet.topic === "$SYS/disconnect/clients"),
+    ).toEqual([
+      { topic: "$SYS/disconnect/clients", payload: "timeout-ws-client", qos: 0, retain: false },
+    ]);
+    expect(
+      published.filter((packet) => packet.topic === "lifecycle/will/timeout-ws"),
+    ).toEqual([
+      { topic: "lifecycle/will/timeout-ws", payload: "timeout-ws-payload", qos: 0, retain: false },
+    ]);
+    expect(ws.readyState).toBe(WebSocket.OPEN);
+    await withDeadline(internals.shutdown());
+    await withDeadline(wsClosed);
+    await expectWsReusable(wsPort);
+  } finally {
+    probe.restore();
+  }
+});
+
+test("shutdown synchronously claims close(false) and clears a timer rearmed by an in-flight handler", async () => {
+  const keepAlive = 191;
+  const probe = instrumentKeepalive(keepAlive);
+  let releaseHandler!: () => void;
+  const handlerGate = new Promise<void>((resolve) => { releaseHandler = resolve; });
+  try {
+    const [tcpPort] = brokerPorts("effectstream-engine");
+    const broker = makeBroker();
+    await broker.start();
+    const published = capturePublishedPackets(broker);
+    const socket = await connectMqttTcp(tcpPort, "in-flight-client", keepAlive, {
+      topic: "lifecycle/will/in-flight",
+      payload: "must-not-publish",
+    });
+    const internals = broker as any;
+    await waitUntil(() => [...internals.connections.values()].some((entry: any) => entry.context));
+    const entry = [...internals.connections.values()].find((candidate: any) => candidate.context) as any;
+    const context = entry.context as any;
+    const closeModes: boolean[] = [];
+    const realClose = context.close.bind(context);
+    context.close = (executeWill = true) => {
+      closeModes.push(executeWill);
+      return realClose(executeWill);
+    };
+    let handlerEnteredResolve!: () => void;
+    const handlerEntered = new Promise<void>((resolve) => { handlerEnteredResolve = resolve; });
+    context.send = async () => {
+      handlerEnteredResolve();
+      await handlerGate;
+    };
+    socket.write(new Uint8Array([0xc0, 0x00]));
+    await withDeadline(handlerEntered);
+    const stopping = internals.shutdown();
+    const modesBeforeFirstAwait = [...closeModes];
+    const clearsBeforeRelease = probe.cleared.size;
+    releaseHandler();
+    await withDeadline(stopping);
+    expect(modesBeforeFirstAwait).toEqual([false]);
+    expect(clearsBeforeRelease).toBe(1);
+    expect(closeModes).toEqual([false]);
+    expect(probe.captured.size).toBe(2);
+    expect(probe.cleared.size).toBe(probe.captured.size);
+    expect(
+      published.filter((packet) => packet.topic === "$SYS/disconnect/clients"),
+    ).toEqual([
+      { topic: "$SYS/disconnect/clients", payload: "in-flight-client", qos: 0, retain: false },
+    ]);
+    expect(published.filter((packet) => packet.topic === "lifecycle/will/in-flight")).toEqual([]);
+    expect(internals.connections.size).toBe(0);
+  } finally {
+    releaseHandler?.();
     probe.restore();
   }
 });
@@ -454,6 +634,116 @@ test("shutdown racing startup rejects start and prevents late WebSocket acquisit
   await withDeadline(stopping);
   await expectTcpReusable(tcpPort);
   await expectWsReusable(wsPort);
+});
+
+test("every post-readiness TCP error stays broker-owned and replays in emission order", async () => {
+  const broker = makeBroker();
+  await broker.start();
+  const internals = broker as any;
+  const firstRuntimeError = new Error("first post-ready TCP runtime failure");
+  const secondRuntimeError = new Error("second post-ready TCP runtime failure");
+  const uncaught: unknown[] = [];
+  const onUncaught = (error: unknown) => { uncaught.push(error); };
+  process.on("uncaughtException", onUncaught);
+  try {
+    for (const runtimeError of [firstRuntimeError, secondRuntimeError]) {
+      await new Promise<void>((resolve) => {
+        setTimeout(() => {
+          try { internals.tcpServer.emit("error", runtimeError); }
+          finally { resolve(); }
+        }, 0);
+      });
+    }
+    await Bun.sleep(0);
+  } finally {
+    process.removeListener("uncaughtException", onUncaught);
+  }
+  expect(uncaught).toEqual([]);
+  const first = internals.shutdown();
+  const second = internals.shutdown();
+  expect(second).toBe(first);
+  const result = await captureRejection(first);
+  expect(result.rejected).toBe(true);
+  expect(result.reason).toBeInstanceOf(AggregateError);
+  expect((result.reason as AggregateError).errors).toEqual([
+    firstRuntimeError,
+    secondRuntimeError,
+  ]);
+  expect(internals.shutdown()).toBe(first);
+});
+
+test("a real queued TCP accept released after STOPPING is rejected and cannot strand shutdown", async () => {
+  const [tcpPort] = brokerPorts("effectstream-engine");
+  const broker = makeBroker();
+  await broker.start();
+  const internals = broker as any;
+  const tcpServer = internals.tcpServer as Server;
+  const realEmit = tcpServer.emit;
+  let heldSocket: Socket | undefined;
+  tcpServer.emit = ((event: string | symbol, ...args: any[]) => {
+    if (event === "connection" && heldSocket === undefined) {
+      heldSocket = args[0] as Socket;
+      return true;
+    }
+    return realEmit.call(tcpServer, event, ...args);
+  }) as typeof tcpServer.emit;
+  const client = await connectTcp(tcpPort);
+  await waitUntil(() => heldSocket !== undefined);
+  const stopping = internals.shutdown();
+  await Promise.resolve();
+  realEmit.call(tcpServer, "connection", heldSocket!);
+  const result = await captureRejection(withDeadline(stopping, 500));
+  heldSocket?.destroy();
+  client.destroy();
+  expect(result.rejected).toBe(false);
+  expect(heldSocket?.destroyed).toBe(true);
+  expect(internals.tcpSockets.size).toBe(0);
+  expect(internals.connections.size).toBe(0);
+});
+
+test("a WebSocket open callback observed after STOPPING closes without starting serve work", async () => {
+  const [, wsPort] = brokerPorts("effectstream-engine");
+  const realServe = Bun.serve.bind(Bun);
+  let releaseOpen: ((ws: any) => void) | undefined;
+  let heldWs: any;
+  (Bun as any).serve = (options: any) => {
+    const realOpen = options.websocket?.open;
+    if (!realOpen) return realServe(options);
+    releaseOpen = realOpen;
+    return realServe({
+      ...options,
+      websocket: {
+        ...options.websocket,
+        open(ws: any) { heldWs = ws; },
+      },
+    });
+  };
+  const broker = makeBroker();
+  try {
+    await broker.start();
+    await connectWs(wsPort);
+    await waitUntil(() => heldWs !== undefined && releaseOpen !== undefined);
+  } finally {
+    (Bun as any).serve = realServe;
+  }
+  const internals = broker as any;
+  const realMqttServe = internals.mqttServer.serve.bind(internals.mqttServer);
+  let serveCalls = 0;
+  internals.mqttServer.serve = (conn: SockConn) => {
+    serveCalls++;
+    return realMqttServe(conn);
+  };
+  const stopping = internals.shutdown();
+  await Promise.resolve();
+  releaseOpen!(heldWs);
+  const result = await captureRejection(withDeadline(stopping, 500));
+  await Bun.sleep(0);
+  const retained = internals.connections.size;
+  try { heldWs.data?.controller?.error(new Error("late-open test cleanup")); } catch {}
+  try { heldWs.close(); } catch {}
+  expect(result.rejected).toBe(false);
+  expect(retained).toBe(0);
+  expect(serveCalls).toBe(0);
 });
 
 test("TCP bind conflict rejects before deadline and failed instances cannot restart", async () => {
@@ -530,9 +820,94 @@ test.each(rejectionReasons)(
     const first = internals.shutdown();
     const result = await captureRejection(first);
     expect(result.rejected).toBe(true);
-    expect(Object.is(result.reason, value)).toBe(true);
+    expect(result.reason).toBeInstanceOf(AggregateError);
+    const failures = (result.reason as AggregateError).errors;
+    expect(failures).toHaveLength(2);
+    expect(Object.is(failures[0], value)).toBe(true);
+    expect(Object.is(failures[1], value)).toBe(true);
     expect(internals.shutdown()).toBe(first);
     brokers.delete(broker);
+  },
+);
+
+test.each(rejectionReasons)(
+  "independent Context and serve stages preserve two ordered same-identity failures: $label",
+  async ({ value }) => {
+    const [tcpPort] = brokerPorts("effectstream-engine");
+    const broker = makeBroker();
+    const internals = broker as any;
+    let contextCloseCalls = 0;
+    let serveCalls = 0;
+    internals.mqttServer.serve = (conn: SockConn) => {
+      serveCalls++;
+      internals.registerContext({
+        conn,
+        close: () => {
+          contextCloseCalls++;
+          throw value;
+        },
+      });
+      return Promise.reject(value);
+    };
+    await broker.start();
+    await connectTcp(tcpPort);
+    await waitUntil(() => internals.connectionFailures.size === 1);
+    const first = internals.shutdown();
+    const result = await captureRejection(first);
+    expect(result.rejected).toBe(true);
+    expect(result.reason).toBeInstanceOf(AggregateError);
+    const failures = (result.reason as AggregateError).errors;
+    expect(failures).toHaveLength(2);
+    expect(Object.is(failures[0], value)).toBe(true);
+    expect(Object.is(failures[1], value)).toBe(true);
+    expect(contextCloseCalls).toBe(1);
+    expect(serveCalls).toBe(1);
+    expect(internals.shutdown()).toBe(first);
+  },
+);
+
+test.each(rejectionReasons)(
+  "independent Context, timer, and serve stages preserve every same-identity failure: $label",
+  async ({ value }) => {
+    const [tcpPort] = brokerPorts("effectstream-engine");
+    const broker = makeBroker();
+    const internals = broker as any;
+    let contextCloseCalls = 0;
+    let timerClearCalls = 0;
+    let serveCalls = 0;
+    internals.mqttServer.serve = (conn: SockConn) => {
+      serveCalls++;
+      internals.registerContext({
+        conn,
+        close: () => {
+          contextCloseCalls++;
+          throw value;
+        },
+        timer: {
+          clear: () => {
+            timerClearCalls++;
+            throw value;
+          },
+        },
+      });
+      return Promise.reject(value);
+    };
+    await broker.start();
+    await connectTcp(tcpPort);
+    await waitUntil(() => internals.connectionFailures.size === 1);
+    const first = internals.shutdown();
+    const result = await captureRejection(first);
+    expect(result.rejected).toBe(true);
+    expect(result.reason).toBeInstanceOf(AggregateError);
+    const failures = (result.reason as AggregateError).errors;
+    expect(failures).toHaveLength(3);
+    expect(Object.is(failures[0], value)).toBe(true);
+    expect(Object.is(failures[1], value)).toBe(true);
+    expect(Object.is(failures[2], value)).toBe(true);
+    expect(contextCloseCalls).toBe(1);
+    expect(timerClearCalls).toBe(1);
+    expect(serveCalls).toBe(1);
+    expect(internals.shutdown()).toBe(first);
   },
 );
 
@@ -575,7 +950,12 @@ test("context, TCP, and WebSocket cleanup failures aggregate in shutdown order",
   const result = await captureRejection(internals.shutdown());
   expect(result.rejected).toBe(true);
   expect(result.reason).toBeInstanceOf(AggregateError);
-  expect((result.reason as AggregateError).errors).toEqual([contextError, tcpError, wsError]);
+  expect((result.reason as AggregateError).errors).toEqual([
+    contextError,
+    tcpError,
+    wsError,
+    contextError,
+  ]);
   tcpServer.close = realTcpClose as typeof tcpServer.close;
   wsServer.stop = realWsStop as typeof wsServer.stop;
   await new Promise<void>((resolve) => realTcpClose(() => resolve()));

--- a/packages/node-sdk/events/test/event-broker-lifecycle.test.ts
+++ b/packages/node-sdk/events/test/event-broker-lifecycle.test.ts
@@ -1,0 +1,609 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import {
+  createConnection,
+  createServer,
+  Server,
+  type AddressInfo,
+  type Socket,
+} from "node:net";
+import { AuthenticationResult, MqttServer } from "@seriousme/opifex/server";
+import type { Context, SockConn } from "@seriousme/opifex/server";
+import { EventBroker } from "../src/event-broker.ts";
+
+const envKeys = [
+  "MQTT_BROKER",
+  "MQTT_ENGINE_BROKER_PORT",
+  "MQTT_ENGINE_BROKER_WS_PORT",
+  "MQTT_BATCHER_BROKER_PORT",
+  "MQTT_BATCHER_BROKER_WS_PORT",
+] as const;
+
+const rejectionReasons: Array<{ label: string; value: unknown }> = [
+  { label: "undefined", value: undefined },
+  { label: "null", value: null },
+  { label: "false", value: false },
+  { label: "zero", value: 0 },
+  { label: "empty string", value: "" },
+  { label: "Error", value: new Error("ordinary rejection") },
+];
+
+let savedEnv: Record<(typeof envKeys)[number], string | undefined>;
+const brokers = new Set<EventBroker>();
+const tcpClients = new Set<Socket>();
+const webSockets = new Set<WebSocket>();
+const occupiedTcp = new Set<Server>();
+const occupiedWs = new Set<ReturnType<typeof Bun.serve>>();
+
+async function captureRejection(promise: PromiseLike<unknown>): Promise<{
+  rejected: boolean;
+  reason: unknown;
+}> {
+  return Promise.resolve(promise).then(
+    () => ({ rejected: false, reason: undefined }),
+    (reason) => ({ rejected: true, reason }),
+  );
+}
+
+async function withDeadline<T>(promise: PromiseLike<T>, ms = 2_000): Promise<T> {
+  return Promise.race([
+    Promise.resolve(promise),
+    Bun.sleep(ms).then(() => {
+      throw new Error(`deadline exceeded after ${ms}ms`);
+    }),
+  ]);
+}
+
+async function waitUntil(check: () => boolean, ms = 2_000): Promise<void> {
+  const end = Date.now() + ms;
+  while (!check()) {
+    if (Date.now() >= end) throw new Error(`condition not met within ${ms}ms`);
+    await Bun.sleep(5);
+  }
+}
+
+async function closeTcp(server?: Server): Promise<void> {
+  if (!server?.listening) return;
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+}
+
+async function freeTcpPort(): Promise<number> {
+  for (let attempt = 0; attempt < 40; attempt++) {
+    const server = createServer();
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", resolve);
+    });
+    const port = (server.address() as AddressInfo).port;
+    await closeTcp(server);
+    if (port > 10_000) return port;
+  }
+  throw new Error("Unable to acquire an OS-selected port above 10000");
+}
+
+async function freeDistinctPorts(count: number): Promise<number[]> {
+  const ports = new Set<number>();
+  while (ports.size < count) ports.add(await freeTcpPort());
+  return [...ports];
+}
+
+async function listenTcp(port: number): Promise<Server> {
+  const server = createServer();
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(port, "127.0.0.1", resolve);
+  });
+  occupiedTcp.add(server);
+  return server;
+}
+
+async function expectTcpReusable(port: number): Promise<void> {
+  const server = await listenTcp(port);
+  occupiedTcp.delete(server);
+  await closeTcp(server);
+}
+
+async function expectWsReusable(port: number): Promise<void> {
+  const server = Bun.serve({
+    hostname: "127.0.0.1",
+    port,
+    fetch: () => new Response("ok"),
+  });
+  await server.stop(true);
+}
+
+async function connectTcp(port: number): Promise<Socket> {
+  const socket = createConnection({ port, host: "127.0.0.1" });
+  tcpClients.add(socket);
+  await new Promise<void>((resolve, reject) => {
+    socket.once("connect", resolve);
+    socket.once("error", reject);
+  });
+  return socket;
+}
+
+async function connectWs(port: number): Promise<WebSocket> {
+  const ws = new WebSocket(`ws://127.0.0.1:${port}`, "mqtt");
+  ws.binaryType = "arraybuffer";
+  webSockets.add(ws);
+  await new Promise<void>((resolve, reject) => {
+    ws.onopen = () => resolve();
+    ws.onerror = () => reject(new Error("WebSocket did not open"));
+  });
+  return ws;
+}
+
+function mqttConnectPacket(
+  clientId: string,
+  keepAlive: number,
+  will?: { topic: string; payload: string },
+): Uint8Array {
+  const encoder = new TextEncoder();
+  const id = encoder.encode(clientId);
+  const topic = will ? encoder.encode(will.topic) : new Uint8Array();
+  const payload = will ? encoder.encode(will.payload) : new Uint8Array();
+  const body = [
+    0x00, 0x04, 0x4d, 0x51, 0x54, 0x54,
+    0x04,
+    will ? 0x06 : 0x02,
+    (keepAlive >> 8) & 0xff, keepAlive & 0xff,
+    0x00, id.length, ...id,
+    ...(will ? [0x00, topic.length, ...topic, 0x00, payload.length, ...payload] : []),
+  ];
+  if (body.length >= 128) throw new Error("test CONNECT packet is unexpectedly large");
+  return new Uint8Array([0x10, body.length, ...body]);
+}
+
+async function connectMqttTcp(
+  port: number,
+  clientId: string,
+  keepAlive: number,
+  will?: { topic: string; payload: string },
+): Promise<Socket> {
+  const socket = await connectTcp(port);
+  const response = new Promise<Uint8Array>((resolve, reject) => {
+    socket.once("data", (data) => {
+      resolve(typeof data === "string" ? new TextEncoder().encode(data) : Uint8Array.from(data));
+    });
+    socket.once("error", reject);
+  });
+  socket.write(mqttConnectPacket(clientId, keepAlive, will));
+  expect(Array.from(await withDeadline(response))).toEqual([0x20, 0x02, 0x00, 0x00]);
+  return socket;
+}
+
+async function connectMqttWs(
+  port: number,
+  clientId: string,
+  keepAlive: number,
+  will?: { topic: string; payload: string },
+): Promise<WebSocket> {
+  const ws = await connectWs(port);
+  const response = new Promise<Uint8Array>((resolve, reject) => {
+    ws.onmessage = (event) => resolve(new Uint8Array(event.data as ArrayBuffer));
+    ws.onerror = () => reject(new Error("WebSocket MQTT handshake failed"));
+  });
+  ws.send(mqttConnectPacket(clientId, keepAlive, will));
+  expect(Array.from(await withDeadline(response))).toEqual([0x20, 0x02, 0x00, 0x00]);
+  return ws;
+}
+
+function brokerPorts(kind: "effectstream-engine" | "Batcher"): [number, number] {
+  return kind === "effectstream-engine"
+    ? [Number(process.env.MQTT_ENGINE_BROKER_PORT), Number(process.env.MQTT_ENGINE_BROKER_WS_PORT)]
+    : [Number(process.env.MQTT_BATCHER_BROKER_PORT), Number(process.env.MQTT_BATCHER_BROKER_WS_PORT)];
+}
+
+function makeBroker(kind: "effectstream-engine" | "Batcher" = "effectstream-engine") {
+  const broker = new EventBroker(kind);
+  brokers.add(broker);
+  return broker;
+}
+
+async function forceCleanupBroker(broker: EventBroker): Promise<void> {
+  const internals = broker as any;
+  if (typeof internals.shutdown === "function") {
+    await withDeadline(internals.shutdown(), 1_000).catch(() => {});
+  }
+  for (const socket of internals.tcpSockets ?? []) socket.destroy();
+  const tcpServer = internals.tcpServer as Server | undefined;
+  if (tcpServer?.listening) await closeTcp(tcpServer);
+  const wsServer = internals.wsServer as ReturnType<typeof Bun.serve> | undefined;
+  if (wsServer) await Promise.resolve(wsServer.stop(true)).catch(() => {});
+}
+
+function instrumentKeepalive(keepAlive: number) {
+  const expectedDelay = keepAlive * 1_500;
+  const originalSetTimeout = globalThis.setTimeout;
+  const originalClearTimeout = globalThis.clearTimeout;
+  const captured = new Set<ReturnType<typeof setTimeout>>();
+  const cleared = new Set<ReturnType<typeof setTimeout>>();
+  const clearEvents: Array<{ handle: ReturnType<typeof setTimeout>; shutdownSettled: boolean }> = [];
+  let shutdownSettled = false;
+
+  globalThis.setTimeout = ((handler: TimerHandler, timeout?: number, ...args: unknown[]) => {
+    const handle = originalSetTimeout(handler, timeout, ...args) as unknown as ReturnType<typeof setTimeout>;
+    if (timeout === expectedDelay) captured.add(handle);
+    return handle;
+  }) as typeof setTimeout;
+  globalThis.clearTimeout = ((handle?: ReturnType<typeof setTimeout>) => {
+    if (handle !== undefined && captured.has(handle)) {
+      cleared.add(handle);
+      clearEvents.push({ handle, shutdownSettled });
+    }
+    return originalClearTimeout(handle);
+  }) as typeof clearTimeout;
+
+  return {
+    captured,
+    cleared,
+    clearEvents,
+    markShutdownSettled: () => { shutdownSettled = true; },
+    restore: () => {
+      for (const handle of captured) originalClearTimeout(handle);
+      globalThis.setTimeout = originalSetTimeout;
+      globalThis.clearTimeout = originalClearTimeout;
+    },
+  };
+}
+
+beforeEach(async () => {
+  savedEnv = Object.fromEntries(envKeys.map((key) => [key, process.env[key]])) as typeof savedEnv;
+  const [engineTcp, engineWs, batcherTcp, batcherWs] = await freeDistinctPorts(4);
+  process.env.MQTT_BROKER = "true";
+  process.env.MQTT_ENGINE_BROKER_PORT = String(engineTcp);
+  process.env.MQTT_ENGINE_BROKER_WS_PORT = String(engineWs);
+  process.env.MQTT_BATCHER_BROKER_PORT = String(batcherTcp);
+  process.env.MQTT_BATCHER_BROKER_WS_PORT = String(batcherWs);
+});
+
+afterEach(async () => {
+  for (const socket of tcpClients) socket.destroy();
+  tcpClients.clear();
+  for (const ws of webSockets) {
+    try { ws.close(); } catch { /* already closed */ }
+  }
+  webSockets.clear();
+  for (const broker of brokers) await forceCleanupBroker(broker);
+  brokers.clear();
+  for (const server of occupiedTcp) await closeTcp(server);
+  occupiedTcp.clear();
+  for (const server of occupiedWs) await Promise.resolve(server.stop(true)).catch(() => {});
+  occupiedWs.clear();
+  for (const key of envKeys) {
+    const value = savedEnv[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
+
+test("start resolves only after TCP and WebSocket readiness; shutdown releases both", async () => {
+  const [tcpPort, wsPort] = brokerPorts("effectstream-engine");
+  const broker = makeBroker();
+  await withDeadline(broker.start());
+  const tcp = await connectTcp(tcpPort);
+  const ws = await connectWs(wsPort);
+  const tcpClosed = new Promise<void>((resolve) => tcp.once("close", resolve));
+  const wsClosed = new Promise<void>((resolve) => ws.addEventListener("close", () => resolve(), { once: true }));
+  await withDeadline((broker as any).shutdown());
+  await withDeadline(Promise.all([tcpClosed, wsClosed]));
+  expect((broker as any).connections?.size ?? 0).toBe(0);
+  await expectTcpReusable(tcpPort);
+  await expectWsReusable(wsPort);
+});
+
+test("engine and batcher coexist and fresh replacements reuse all four ports", async () => {
+  const enginePorts = brokerPorts("effectstream-engine");
+  const batcherPorts = brokerPorts("Batcher");
+  const engine = makeBroker();
+  const batcher = makeBroker("Batcher");
+  await withDeadline(Promise.all([engine.start(), batcher.start()]));
+  await Promise.all([
+    connectTcp(enginePorts[0]), connectWs(enginePorts[1]),
+    connectTcp(batcherPorts[0]), connectWs(batcherPorts[1]),
+  ]);
+  await withDeadline(Promise.all([(engine as any).shutdown(), (batcher as any).shutdown()]));
+  const replacementEngine = makeBroker();
+  const replacementBatcher = makeBroker("Batcher");
+  await withDeadline(Promise.all([replacementEngine.start(), replacementBatcher.start()]));
+  await withDeadline(Promise.all([
+    (replacementEngine as any).shutdown(),
+    (replacementBatcher as any).shutdown(),
+  ]));
+  for (const port of [enginePorts[0], batcherPorts[0]]) await expectTcpReusable(port);
+  for (const port of [enginePorts[1], batcherPorts[1]]) await expectWsReusable(port);
+});
+
+test("real TCP and WebSocket keepalive timers clear before shutdown settles and no Will is emitted", async () => {
+  const keepAlive = 173;
+  const probe = instrumentKeepalive(keepAlive);
+  try {
+    const [tcpPort, wsPort] = brokerPorts("effectstream-engine");
+    const broker = makeBroker();
+    await broker.start();
+    const internals = broker as any;
+    const published: string[] = [];
+    const persistence = internals.mqttServer.persistence;
+    const realPublish = persistence.publish.bind(persistence);
+    persistence.publish = (topic: string, packet: unknown) => {
+      if (topic === "lifecycle/will") published.push(topic);
+      return realPublish(topic, packet);
+    };
+    await Promise.all([
+      connectMqttTcp(tcpPort, "lifecycle-tcp", keepAlive, { topic: "lifecycle/will", payload: "tcp" }),
+      connectMqttWs(wsPort, "lifecycle-ws", keepAlive, { topic: "lifecycle/will", payload: "ws" }),
+    ]);
+    await waitUntil(() => probe.captured.size === 2);
+    const stopping = internals.shutdown();
+    await withDeadline(stopping);
+    probe.markShutdownSettled();
+    expect(probe.cleared.size).toBe(2);
+    expect(probe.clearEvents).toHaveLength(2);
+    expect(probe.clearEvents.every((event) => event.shutdownSettled === false)).toBe(true);
+    expect(published).toEqual([]);
+    expect(internals.connections.size).toBe(0);
+  } finally {
+    probe.restore();
+  }
+});
+
+test("raw Opifex transport close and serve-task drain alone do not clear keepalive", async () => {
+  const keepAlive = 179;
+  const probe = instrumentKeepalive(keepAlive);
+  let context: Context | undefined;
+  try {
+    const readable = new ReadableStream<Uint8Array>({
+      type: "bytes",
+      start(controller) {
+        controller.enqueue(Uint8Array.from(mqttConnectPacket("raw-gap", keepAlive)));
+        controller.close();
+      },
+    });
+    const writable = new WritableStream<Uint8Array>({ write() {} });
+    const conn: SockConn = {
+      readable,
+      writable,
+      close: () => {},
+      remoteAddr: { hostname: "127.0.0.1", port: 12_345, transport: "tcp" },
+    };
+    const mqttServer = new MqttServer({
+      handlers: {
+        isAuthenticated: (ctx) => {
+          context = ctx;
+          return AuthenticationResult.ok;
+        },
+      },
+    });
+    const serving = mqttServer.serve(conn);
+    await waitUntil(() => context !== undefined && probe.captured.size === 1);
+    await withDeadline(serving);
+    expect(probe.cleared.size).toBe(0);
+    context!.close(false);
+    expect(probe.cleared.size).toBe(1);
+  } finally {
+    context?.close(false);
+    probe.restore();
+  }
+});
+
+test("abrupt TCP and WebSocket disconnects finalize tracked contexts while broker stays running", async () => {
+  const keepAlive = 181;
+  const probe = instrumentKeepalive(keepAlive);
+  try {
+    const [tcpPort, wsPort] = brokerPorts("effectstream-engine");
+    const broker = makeBroker();
+    await broker.start();
+    const [socket, ws] = await Promise.all([
+      connectMqttTcp(tcpPort, "abrupt-tcp-client", keepAlive, {
+        topic: "lifecycle/will",
+        payload: "must-not-publish-tcp",
+      }),
+      connectMqttWs(wsPort, "abrupt-ws-client", keepAlive, {
+        topic: "lifecycle/will",
+        payload: "must-not-publish-ws",
+      }),
+    ]);
+    const internals = broker as any;
+    const published: string[] = [];
+    const persistence = internals.mqttServer.persistence;
+    const realPublish = persistence.publish.bind(persistence);
+    persistence.publish = (topic: string, packet: unknown) => {
+      if (topic === "lifecycle/will") published.push(topic);
+      return realPublish(topic, packet);
+    };
+    socket.destroy();
+    ws.close();
+    await waitUntil(() => probe.cleared.size === 2 && internals.connections.size === 0);
+    expect(probe.cleared.size).toBe(2);
+    expect(published).toEqual([]);
+    const probeSocket = await connectTcp(tcpPort);
+    const probeWs = await connectWs(wsPort);
+    probeSocket.destroy();
+    probeWs.close();
+    await internals.shutdown();
+  } finally {
+    probe.restore();
+  }
+});
+
+test("concurrent and settled starts share identity", async () => {
+  const broker = makeBroker();
+  const first = broker.start();
+  const second = broker.start();
+  expect(second).toBe(first);
+  await first;
+  expect(broker.start()).toBe(first);
+  await (broker as any).shutdown();
+});
+
+test("shutdown before start is safe; repeated shutdown shares success", async () => {
+  const broker = makeBroker();
+  const first = (broker as any).shutdown();
+  const second = (broker as any).shutdown();
+  expect(second).toBe(first);
+  await first;
+  expect((broker as any).shutdown()).toBe(first);
+  await expect(broker.start()).rejects.toThrow(/cannot start from state STOPPED/);
+});
+
+test("shutdown racing startup rejects start and prevents late WebSocket acquisition", async () => {
+  const [tcpPort, wsPort] = brokerPorts("effectstream-engine");
+  const broker = makeBroker();
+  const starting = broker.start();
+  const stopping = (broker as any).shutdown();
+  await expect(withDeadline(starting)).rejects.toThrow(/cancelled by shutdown/);
+  await withDeadline(stopping);
+  await expectTcpReusable(tcpPort);
+  await expectWsReusable(wsPort);
+});
+
+test("TCP bind conflict rejects before deadline and failed instances cannot restart", async () => {
+  const [tcpPort, wsPort] = brokerPorts("effectstream-engine");
+  await listenTcp(tcpPort);
+  const broker = makeBroker();
+  const result = await withDeadline(captureRejection(broker.start()), 500);
+  expect(result.rejected).toBe(true);
+  expect((result.reason as NodeJS.ErrnoException).code).toBe("EADDRINUSE");
+  await expect(broker.start()).rejects.toThrow(/cannot start from state STOPPED/);
+  await expectWsReusable(wsPort);
+});
+
+test("WebSocket bind conflict cleans the already-ready TCP listener", async () => {
+  const [tcpPort, wsPort] = brokerPorts("effectstream-engine");
+  const occupied = Bun.serve({ hostname: "127.0.0.1", port: wsPort, fetch: () => new Response() });
+  occupiedWs.add(occupied);
+  const broker = makeBroker();
+  const result = await withDeadline(captureRejection(broker.start()));
+  expect(result.rejected).toBe(true);
+  expect((result.reason as NodeJS.ErrnoException).code).toBe("EADDRINUSE");
+  await expectTcpReusable(tcpPort);
+});
+
+test.each(rejectionReasons)(
+  "start retains primary error before falsey partial-cleanup rejection: $label",
+  async ({ value }) => {
+    const [tcpPort] = brokerPorts("effectstream-engine");
+    await listenTcp(tcpPort);
+    const broker = makeBroker();
+    (broker as any).beginShutdown = () => Promise.reject(value);
+    const result = await withDeadline(captureRejection(broker.start()));
+    expect(result.rejected).toBe(true);
+    expect(result.reason).toBeInstanceOf(AggregateError);
+    const failures = (result.reason as AggregateError).errors;
+    expect((failures[0] as NodeJS.ErrnoException).code).toBe("EADDRINUSE");
+    expect(Object.is(failures[1], value)).toBe(true);
+    brokers.delete(broker);
+  },
+);
+
+test.each(rejectionReasons)(
+  "shutdown retains and replays falsey WebSocket failure: $label",
+  async ({ value }) => {
+    const broker = makeBroker();
+    await broker.start();
+    const internals = broker as any;
+    const realStop = internals.wsServer.stop.bind(internals.wsServer);
+    internals.wsServer.stop = () => { throw value; };
+    const first = internals.shutdown();
+    const second = internals.shutdown();
+    expect(second).toBe(first);
+    const result = await captureRejection(first);
+    expect(result.rejected).toBe(true);
+    expect(Object.is(result.reason, value)).toBe(true);
+    expect(internals.shutdown()).toBe(first);
+    internals.wsServer.stop = realStop;
+    await realStop(true);
+    brokers.delete(broker);
+  },
+);
+
+test.each(rejectionReasons)(
+  "tracked Context.close failure retains falsey identity: $label",
+  async ({ value }) => {
+    const [tcpPort] = brokerPorts("effectstream-engine");
+    const broker = makeBroker();
+    await broker.start();
+    await connectMqttTcp(tcpPort, `context-${String(value)}`, 0);
+    const internals = broker as any;
+    await waitUntil(() => [...internals.connections.values()].some((entry: any) => entry.context));
+    const entry = [...internals.connections.values()].find((candidate: any) => candidate.context);
+    entry.context.close = () => { throw value; };
+    const first = internals.shutdown();
+    const result = await captureRejection(first);
+    expect(result.rejected).toBe(true);
+    expect(Object.is(result.reason, value)).toBe(true);
+    expect(internals.shutdown()).toBe(first);
+    brokers.delete(broker);
+  },
+);
+
+test("serve-task rejection is observed immediately and retained for shutdown", async () => {
+  const [tcpPort] = brokerPorts("effectstream-engine");
+  const broker = makeBroker();
+  const internals = broker as any;
+  const serveError = new Error("serve finalizer failed");
+  internals.mqttServer.serve = () => Promise.reject(serveError);
+  await broker.start();
+  await connectTcp(tcpPort);
+  await waitUntil(() => internals.connectionFailures?.size === 1);
+  const result = await captureRejection(internals.shutdown());
+  expect(result.rejected).toBe(true);
+  expect(result.reason).toBe(serveError);
+  brokers.delete(broker);
+});
+
+test("context, TCP, and WebSocket cleanup failures aggregate in shutdown order", async () => {
+  const [tcpPort, wsPort] = brokerPorts("effectstream-engine");
+  const broker = makeBroker();
+  await broker.start();
+  await connectMqttTcp(tcpPort, "ordered-errors", 0);
+  const internals = broker as any;
+  await waitUntil(() => [...internals.connections.values()].some((entry: any) => entry.context));
+  const entry = [...internals.connections.values()].find((candidate: any) => candidate.context);
+  const contextError = new Error("context close failed");
+  const tcpError = new Error("tcp close failed");
+  const wsError = new Error("ws stop failed");
+  entry.context.close = () => { throw contextError; };
+  const tcpServer = internals.tcpServer as Server;
+  const wsServer = internals.wsServer as ReturnType<typeof Bun.serve>;
+  const realTcpClose = tcpServer.close.bind(tcpServer);
+  const realWsStop = wsServer.stop.bind(wsServer);
+  tcpServer.close = ((callback?: (error?: Error) => void) => {
+    callback?.(tcpError);
+    return tcpServer;
+  }) as typeof tcpServer.close;
+  wsServer.stop = (() => { throw wsError; }) as typeof wsServer.stop;
+  const result = await captureRejection(internals.shutdown());
+  expect(result.rejected).toBe(true);
+  expect(result.reason).toBeInstanceOf(AggregateError);
+  expect((result.reason as AggregateError).errors).toEqual([contextError, tcpError, wsError]);
+  tcpServer.close = realTcpClose as typeof tcpServer.close;
+  wsServer.stop = realWsStop as typeof wsServer.stop;
+  await new Promise<void>((resolve) => realTcpClose(() => resolve()));
+  await realWsStop(true);
+  brokers.delete(broker);
+  await expectTcpReusable(tcpPort);
+  await expectWsReusable(wsPort);
+});
+
+test("legacy createServer/stop remain void and observe failures", async () => {
+  const [tcpPort] = brokerPorts("effectstream-engine");
+  await listenTcp(tcpPort);
+  const broker = makeBroker();
+  const unhandled: unknown[] = [];
+  const logged: unknown[][] = [];
+  const listener = (reason: unknown) => unhandled.push(reason);
+  const originalError = console.error;
+  process.on("unhandledRejection", listener);
+  console.error = (...args: unknown[]) => { logged.push(args); };
+  try {
+    expect(broker.createServer()).toBeUndefined();
+    await Bun.sleep(40);
+    expect((broker as any).stop()).toBeUndefined();
+    await Bun.sleep(20);
+  } finally {
+    console.error = originalError;
+    process.removeListener("unhandledRejection", listener);
+  }
+  expect(unhandled).toEqual([]);
+  expect(logged.some((args) => String(args[0]).includes("failed to start"))).toBe(true);
+});

--- a/packages/node-sdk/events/test/examples.test.ts
+++ b/packages/node-sdk/events/test/examples.test.ts
@@ -7,6 +7,9 @@ import { EventBroker } from "../src/mod.ts";
 test("README: EventBroker class is exported and constructible", () => {
   const engine = new EventBroker("effectstream-engine");
   expect(typeof engine.createServer).toBe("function");
+  expect(typeof engine.start).toBe("function");
+  expect(typeof engine.shutdown).toBe("function");
+  expect(typeof engine.stop).toBe("function");
 });
 
 test("README: separate engine vs batcher brokers", () => {

--- a/packages/node-sdk/runtime/src/main.ts
+++ b/packages/node-sdk/runtime/src/main.ts
@@ -90,9 +90,16 @@ export function* start(config: StartConfig): Operation<void> {
     yield* startSync(syncProtocol);
   }
 
-  // Create MQTT Broker
+  // Create MQTT Broker. Startup must fail fast on a bind conflict (e.g. a
+  // stale engine still holding the port) instead of running without a broker.
   if (ENV.MQTT_BROKER) {
-    new EventBroker("effectstream-engine").createServer();
+    const eventBroker = new EventBroker("effectstream-engine");
+    yield* call(() => eventBroker.start());
+    yield* ensure(function* () {
+      yield* call(() => eventBroker.shutdown().catch((error) => {
+        console.error("MQTT broker shutdown failed:", error);
+      }));
+    });
   }
 
   // 20× main clock block time (NTP if present, else protocol 0).


### PR DESCRIPTION
## Summary

Gives each `EventBroker` instance an awaitable acquisition/finalization boundary while preserving all MQTT payload, topic, authorization, and routing behavior byte-for-byte:

- `start()` now resolves only when both the TCP and WebSocket transports are ready, normalizes synchronous and asynchronous bind failures, and cleans up partial acquisitions before rejecting. Concurrent/repeated starts share one cached Promise.
- New `shutdown(): Promise<void>` stops ingress, explicitly finalizes every tracked Opifex `Context` (broker-owned `close(false)`, so no Will is published), destroys remaining sockets, awaits Node listener release and Bun `Server.stop(true)`, and drains every tracked serve task and keepalive timer before settling. Idempotent: repeated/concurrent shutdowns replay one cached result.
- Peer-driven disconnects claim `close(true)`, preserving exact-base Will and `$SYS/disconnect/clients` routing, including the base's transport-specific WebSocket `unknown`-identity publish rejection.
- Cleanup is all-attempt with deterministic aggregation (`AggregateError`), preserving falsey rejection reasons and per-stage provenance. Post-readiness TCP `Server` errors are retained for shutdown aggregation instead of escaping as unhandled.
- Legacy `createServer()`/`stop()` remain `void` compatibility shims that observe and log rejection.

Scope is exactly five paths: the broker, a new lifecycle test matrix, additive example assertions, the event-server README, and its script-generated docs mirror.

## Verification

All gates ran in pinned no-network Bun 1.3.10 Docker images over exact base `8f8705b9`:

- Focused event lifecycle/example suites: 57 pass / 0 fail (286 assertions); event-client suite unchanged green.
- Unchanged standalone MQTT oracle: 9/0/0 (TCP connect, binary WS roundtrip, pub/sub, wildcards, QoS 2, event topics, multi-subscriber) plus proven 18883/19883 port reuse.
- Stress: 3 × 20 fresh-process groups (replacement/dual-transport shutdown, queued-TCP/late-WS/graceful DISCONNECT, abrupt-disconnect routing) — 120/120 green, no flake, leak, or retained container.
- Full `bun test ./packages`: no failure/error/skip owned by this change (nonzeros reproduce identically on an exact-base overlay of the same dependency image).
- TypeScript no-emit: zero diagnostics in the changed event paths; removes 5 pre-existing event-broker diagnostics; all other diagnostics byte-identical to base.

Independently audited over three delivery cycles; the final pin passed with zero findings. Merges cleanly onto current `v-next` (post-`8f8705b9` drift is release/CI-only and touches none of these paths).