### PR TITLE
feat(runtime): protocol-owned start policy with latest resolution

### DIFF
--- a/docs/site/docs/home/500-packages/520-node/node-sdk.md
+++ b/docs/site/docs/home/500-packages/520-node/node-sdk.md
@@ -64,10 +64,15 @@ await runNode({
 
 `runNode` uses the normal Effectstream sync, primitive, STM, migration, and
 configuration-snapshot paths. It owns PGlite and runtime cleanup in the same
-process; it does not launch another script. A fresh `"latest"` source begins at
-the current indexed block. When `pglite({ dataDir: "..." })` is persistent, a
-restart reads the saved numeric start height and resumes the stored checkpoint
-instead of jumping to a new tip.
+process; it does not launch another script. The declared `startBlockHeight` -
+a number or `"latest"` - is passed to the runtime untouched: the runtime asks
+that protocol's own start policy to resolve `"latest"` exactly once, commits the
+resulting numeric boundary together with its `latest`/`explicit` provenance
+before any sync state exists, and reuses the committed value afterwards. So a
+fresh `"latest"` source begins at the current indexed block, and when
+`pglite({ dataDir: "..." })` is persistent a restart performs no tip query at
+all: it resumes from the committed boundary and the saved clock mapping instead
+of jumping to a new tip.
 
 The subpaths are thin re-exports - semantics are identical to importing
 from the underlying packages.

--- a/packages/effectstream-sdk/config/src/config/parts/primitive.ts
+++ b/packages/effectstream-sdk/config/src/config/parts/primitive.ts
@@ -79,7 +79,12 @@ export class PrimitiveBuilder<
     const NewPrimitive extends {
       name: string;
       type: string;
-      startBlockHeight: number;
+      /**
+       * Optional: a primitive that omits its start inherits the owning sync
+       * protocol's committed numeric start (`@effectstream/runtime`). An
+       * explicit value always wins.
+       */
+      startBlockHeight?: number;
     }, // TODO This is the format from Primitive.getConfig()
   >(
     genSyncProtocol: (syncProtocol: SyncProtocols) => SyncProtocol,

--- a/packages/effectstream-sdk/config/src/schema/common.ts
+++ b/packages/effectstream-sdk/config/src/schema/common.ts
@@ -1,4 +1,4 @@
-import { TypeboxHelpers } from "@effectstream/utils";
+import { type BlockNumber, TypeboxHelpers } from "@effectstream/utils";
 import { Type } from "@sinclair/typebox";
 import { ConfigSchema } from "./utils.ts";
 
@@ -52,6 +52,39 @@ export const pollingSyncProtocolWithDefault = <const Interval extends number>(
 export const StartStopBlockheight = new ConfigSchema({
   required: Type.Object({
     startBlockHeight: TypeboxHelpers.BlockNumber(),
+  }),
+  optional: Type.Object({
+    stopBlockHeight: TypeboxHelpers.Nullable(TypeboxHelpers.BlockNumber(), {
+      default: null,
+    }),
+  }),
+});
+
+/**
+ * Start/stop pair for protocols that can discover their own first boundary.
+ *
+ * ONLY the NTP main and Midnight parallel schemas use this (FR-005); every
+ * other protocol keeps the numeric `StartStopBlockheight` above, byte for byte.
+ *
+ * The widening is two-sided on purpose. `Static` yields exactly one type per
+ * schema node, so a single `Type.Unsafe` override cannot make the builder input
+ * and the runtime-facing type differ. Instead:
+ *  1. here, the validator AND the builder-input static both widen to
+ *     `BlockNumber | "latest"`, so `.addMain`/`.addParallel` callbacks compile
+ *     with the sentinel;
+ *  2. `schema/sync-protocols/types.ts` re-narrows the `startBlockHeight` member
+ *     back to a number inside the `SyncProtocolWithNetwork` mapped type.
+ *
+ * That is truthful rather than a convenience: reconciliation
+ * (`@effectstream/runtime` `config-snapshot.ts`, the sentinel's only consumer)
+ * replaces `"latest"` with a committed numeric boundary before any sync state
+ * or primitive is constructed.
+ */
+export const StartStopBlockheightWithLatest = new ConfigSchema({
+  required: Type.Object({
+    startBlockHeight: Type.Unsafe<BlockNumber | "latest">(
+      Type.Union([Type.Number(), Type.Literal("latest")]),
+    ),
   }),
   optional: Type.Object({
     stopBlockHeight: TypeboxHelpers.Nullable(TypeboxHelpers.BlockNumber(), {

--- a/packages/effectstream-sdk/config/src/schema/sync-protocols/midnight/graphql.ts
+++ b/packages/effectstream-sdk/config/src/schema/sync-protocols/midnight/graphql.ts
@@ -4,7 +4,7 @@ import { ConfigSyncProtocolType } from "../types.ts";
 import {
   NameField,
   pollingSyncProtocolWithDefault,
-  StartStopBlockheight,
+  StartStopBlockheightWithLatest,
 } from "../../common.ts";
 import {
   CommonResponseParallelSyncProtocol,
@@ -24,7 +24,7 @@ import {
 
 export const ConfigSyncProtocolSchemaMidnightBase = NameField.cloneMerge(
   pollingSyncProtocolWithDefault(6_000),
-).cloneMerge(StartStopBlockheight).cloneMerge({
+).cloneMerge(StartStopBlockheightWithLatest).cloneMerge({
   required: Type.Object({
     indexer: Type.String(),
     // note: node URL and proof server are not needed for read-only use

--- a/packages/effectstream-sdk/config/src/schema/sync-protocols/ntp/rpc.ts
+++ b/packages/effectstream-sdk/config/src/schema/sync-protocols/ntp/rpc.ts
@@ -4,7 +4,7 @@ import { ConfigSyncProtocolType } from "../types.ts";
 import {
   NameField,
   pollingSyncProtocolWithDefault,
-  StartStopBlockheight,
+  StartStopBlockheightWithLatest,
 } from "../../common.ts";
 import { type MergeIntersects, TypeboxHelpers } from "@effectstream/utils";
 import {
@@ -18,7 +18,7 @@ import {
 
 export const ConfigSyncProtocolSchemaNtpBase = NameField.cloneMerge(
   pollingSyncProtocolWithDefault(1_000),
-).cloneMerge(StartStopBlockheight).cloneMerge({
+).cloneMerge(StartStopBlockheightWithLatest).cloneMerge({
   required: Type.Object({}),
   optional: Type.Object({
     stepSize: Type.Number({ default: 1000 }),

--- a/packages/effectstream-sdk/config/src/schema/sync-protocols/types.ts
+++ b/packages/effectstream-sdk/config/src/schema/sync-protocols/types.ts
@@ -52,7 +52,12 @@ export type SyncProtocolFromNetwork<T extends ConfigNetworkType> =
 type BasePrimitive = {
   name: string;
   type: `${string}:${string}`;
-  startBlockHeight: number;
+  /**
+   * Omit it to inherit the owning sync protocol's committed numeric start
+   * (`@effectstream/runtime` fills it in before the primitive class is
+   * constructed). An explicit value always wins.
+   */
+  startBlockHeight?: number;
   /**
    * Grammar prefix used to route this primitive's payload into the state
    * machine. Omit it and the primitive still writes accounting rows, but
@@ -267,11 +272,27 @@ export type NetworkFromSyncProtocol<
   ? Extract<NetworkConfig, { type: NetworkTypeFromSyncProtocol<T> }>
   : undefined;
 
+/**
+ * Re-narrows the `"latest"` sentinel out of the runtime-facing protocol shape.
+ *
+ * NTP main and Midnight parallel accept `startBlockHeight: "latest"` on the
+ * builder-input side (`schema/common.ts` `StartStopBlockheightWithLatest`), but
+ * `@effectstream/runtime` reconciles that to a committed numeric boundary
+ * before any sync state or primitive exists. Applying the narrowing here — the
+ * single place every runtime and sync consumer types through — keeps
+ * `startBlockHeight - 1` and friends compiling in every per-chain sync state
+ * without touching those files.
+ */
+type NumericStartBlockHeight<T> = {
+  [Field in keyof T]: Field extends "startBlockHeight" ? Extract<T[Field], number>
+    : T[Field];
+};
+
 export type SyncProtocolWithNetwork = {
   [K in keyof typeof SyncProtocolToNetwork]: {
     networkType: NetworkFromSyncProtocol<K>["type"];
     syncProtocolType: ConfigSyncProtocolMapping[K]["type"];
-    syncProtocol: ConfigSyncProtocolMapping[K];
+    syncProtocol: NumericStartBlockHeight<ConfigSyncProtocolMapping[K]>;
     network: NetworkFromSyncProtocol<K>;
     primitives: Extract<
       PrimitiveEntry,

--- a/packages/effectstream-sdk/config/test/builder-semantics.typecheck.ts
+++ b/packages/effectstream-sdk/config/test/builder-semantics.typecheck.ts
@@ -552,6 +552,120 @@ new ConfigBuilder()
       )
   );
 
+// ───────────────────────────────────────────────────────────────────────────
+// Protocol-owned start policy (00034): the builder input accepts `"latest"`
+// for exactly NTP main and Midnight parallel, while the runtime-facing
+// `SyncProtocolWithNetwork` member stays numeric so sync states keep doing
+// arithmetic on it. A primitive may omit its start and inherit the protocol's.
+// ───────────────────────────────────────────────────────────────────────────
+
+const latestStarts = new ConfigBuilder()
+  .buildNetworks((builder) =>
+    builder
+      .addNetwork({ type: ConfigNetworkType.NTP })
+      .addNetwork({
+        type: ConfigNetworkType.MIDNIGHT,
+        networkId: "stagenet",
+      })
+  )
+  .buildSyncProtocols((builder) =>
+    builder
+      .addMain(
+        (networks) => networks.ntp,
+        () => ({
+          name: "ntp",
+          type: ConfigSyncProtocolType.NTP_MAIN,
+          startBlockHeight: "latest",
+        }),
+      )
+      .addParallel(
+        (networks) => networks.midnight,
+        () => ({
+          name: "midnight",
+          type: ConfigSyncProtocolType.MIDNIGHT_PARALLEL,
+          indexer: "https://indexer.example/graphql",
+          startBlockHeight: "latest",
+        }),
+      )
+  )
+  .buildPrimitives((builder) =>
+    builder.addPrimitive(
+      (protocols) => protocols.midnight,
+      () => ({
+        // No startBlockHeight: it is inherited from the owning protocol's
+        // committed numeric start (FR-007).
+        name: "round",
+        type: "Midnight:Generic",
+      }),
+    )
+  )
+  .build();
+
+type RuntimeNtp = Extract<
+  SyncProtocolWithNetwork,
+  { syncProtocolType: ConfigSyncProtocolType.NTP_MAIN }
+>;
+type RuntimeMidnight = Extract<
+  SyncProtocolWithNetwork,
+  { syncProtocolType: ConfigSyncProtocolType.MIDNIGHT_PARALLEL }
+>;
+type _RuntimeNtpStartIsNumeric = Assert<
+  RuntimeNtp["syncProtocol"]["startBlockHeight"] extends number ? true : false
+>;
+type _RuntimeMidnightStartIsNumeric = Assert<
+  RuntimeMidnight["syncProtocol"]["startBlockHeight"] extends number ? true
+    : false
+>;
+type _RuntimeNtpStartDropsSentinel = Assert<
+  IsExact<Extract<RuntimeNtp["syncProtocol"]["startBlockHeight"], string>, never>
+>;
+type _RuntimeMidnightStartDropsSentinel = Assert<
+  IsExact<
+    Extract<RuntimeMidnight["syncProtocol"]["startBlockHeight"], string>,
+    never
+  >
+>;
+// Sibling members are untouched by the re-narrowing.
+const _RuntimeMidnightIndexer: RuntimeMidnight["syncProtocol"]["indexer"] =
+  "https://indexer.example/graphql";
+
+// Every other protocol keeps a numeric-only start (FR-005).
+new ConfigBuilder()
+  .buildNetworks((builder) =>
+    builder
+      .addNetwork({ type: ConfigNetworkType.NTP })
+      .addNetwork({
+        name: "evm",
+        type: ConfigNetworkType.EVM,
+        chainId: 31_337,
+        nativeCurrency: { name: "Ether", symbol: "ETH", decimals: 18 },
+        rpcUrls: { default: { http: ["http://127.0.0.1:8545"] } },
+      })
+  )
+  .buildSyncProtocols((builder) =>
+    builder
+      .addMain(
+        (networks) => networks.ntp,
+        () => ({
+          name: "ntp",
+          type: ConfigSyncProtocolType.NTP_MAIN,
+          startBlockHeight: 1,
+        }),
+      )
+      .addParallel(
+        (networks) => networks.evm,
+        () => ({
+          name: "evm",
+          type: ConfigSyncProtocolType.EVM_RPC_PARALLEL,
+          // @ts-expect-error "latest" stays out of every other protocol's schema.
+          startBlockHeight: "latest",
+          chainUri: "http://127.0.0.1:8545",
+          confirmationDepth: 1,
+          pollingInterval: 1_000,
+        }),
+      )
+  );
+
 void minimal;
 void explicitEmpty;
 void nonempty;
@@ -559,3 +673,5 @@ void explicitLegacy;
 void maybeNtpFullChain;
 void optionalNtpNetworks;
 void maybeMidnightProtocol;
+void latestStarts;
+void _RuntimeMidnightIndexer;

--- a/packages/effectstream-sdk/config/test/start-block-height-latest.test.ts
+++ b/packages/effectstream-sdk/config/test/start-block-height-latest.test.ts
@@ -1,0 +1,217 @@
+// Schema oracle for project 00034 (spec FR-005 / FR-007).
+//
+// `"latest"` must reach exactly two protocol schemas — NTP main and Midnight
+// parallel — and no other. A primitive must be able to omit `startBlockHeight`
+// so it can inherit its owning protocol's committed numeric start.
+//
+// The compile-time half of this oracle (builder input accepts `"latest"`, the
+// runtime-facing `SyncProtocolWithNetwork` member stays numeric) lives in
+// `builder-semantics.typecheck.ts`, which `bun run typecheck` enforces.
+
+import { describe, expect, test } from "bun:test";
+import { Value } from "@sinclair/typebox/value";
+import type { TSchema } from "@sinclair/typebox";
+import {
+  ConfigBuilder,
+  ConfigNetworkType,
+  ConfigSyncProtocolType,
+} from "../src/mod.ts";
+import {
+  mainSyncProtocolTypes,
+  parallelSyncProtocolTypes,
+} from "../src/schema/sync-protocols/all.ts";
+
+const LATEST_PROTOCOLS: ConfigSyncProtocolType[] = [
+  ConfigSyncProtocolType.NTP_MAIN,
+  ConfigSyncProtocolType.MIDNIGHT_PARALLEL,
+];
+
+const allSchemas = {
+  ...mainSyncProtocolTypes,
+  ...parallelSyncProtocolTypes,
+} as Record<string, { config: { required: { properties: Record<string, TSchema> } } }>;
+
+function startSchemaFor(type: string): TSchema | undefined {
+  return allSchemas[type]?.config.required.properties["startBlockHeight"];
+}
+
+describe('"latest" reaches exactly the NTP main and Midnight parallel schemas', () => {
+  test.each(LATEST_PROTOCOLS)('%s accepts "latest"', (type) => {
+    const schema = startSchemaFor(type);
+    expect(schema, `${type} must declare startBlockHeight`).toBeDefined();
+    expect(Value.Check(schema!, "latest")).toBe(true);
+  });
+
+  test.each(LATEST_PROTOCOLS)("%s still accepts a plain number", (type) => {
+    expect(Value.Check(startSchemaFor(type)!, 42)).toBe(true);
+  });
+
+  test('every other protocol keeps a numeric-only start', () => {
+    const leaked: string[] = [];
+    for (const type of Object.keys(allSchemas)) {
+      if (LATEST_PROTOCOLS.includes(type as ConfigSyncProtocolType)) continue;
+      const schema = startSchemaFor(type);
+      // Cardano protocols start from a slot / chain point and declare no
+      // startBlockHeight at all — they cannot leak the sentinel either.
+      if (schema === undefined) continue;
+      if (Value.Check(schema, "latest")) leaked.push(type);
+      expect(Value.Check(schema, 7), type).toBe(true);
+    }
+    expect(leaked).toEqual([]);
+  });
+
+  test("the shared numeric start schema is untouched for slot/chain-point protocols", () => {
+    expect(
+      startSchemaFor(ConfigSyncProtocolType.CARDANO_CARP_PARALLEL),
+    ).toBeUndefined();
+    expect(
+      startSchemaFor(ConfigSyncProtocolType.CARDANO_UTXORPC_PARALLEL),
+    ).toBeUndefined();
+  });
+});
+
+describe("composed protocol schemas validate a latest start end to end", () => {
+  test("NTP main", () => {
+    const schema = mainSyncProtocolTypes[ConfigSyncProtocolType.NTP_MAIN]
+      .allProperties(true);
+    expect(Value.Check(schema, {
+      name: "ntp",
+      type: ConfigSyncProtocolType.NTP_MAIN,
+      startBlockHeight: "latest",
+      stopBlockHeight: null,
+      pollingInterval: 1_000,
+      requestTimeoutMs: 15_000,
+      stepSize: 1_000,
+      maxBufferedPages: 10,
+    })).toBe(true);
+  });
+
+  test("Midnight parallel", () => {
+    const schema =
+      parallelSyncProtocolTypes[ConfigSyncProtocolType.MIDNIGHT_PARALLEL]
+        .allProperties(true);
+    expect(Value.Check(schema, {
+      name: "midnight",
+      type: ConfigSyncProtocolType.MIDNIGHT_PARALLEL,
+      indexer: "https://indexer.example/graphql",
+      startBlockHeight: "latest",
+      stopBlockHeight: null,
+      pollingInterval: 6_000,
+      requestTimeoutMs: 15_000,
+      stepSize: 10,
+      paginationLimit: 50,
+      confirmationDepth: 3,
+      delayMs: 20_000,
+      maxBufferedPages: 10,
+    })).toBe(true);
+  });
+});
+
+describe("the builder carries a latest start through materialization", () => {
+  test('"latest" survives untouched — the runtime resolves it, not the builder', () => {
+    const built = new ConfigBuilder()
+      .buildNetworks((builder) =>
+        builder
+          .addNetwork({ type: ConfigNetworkType.NTP })
+          .addNetwork({
+            type: ConfigNetworkType.MIDNIGHT,
+            networkId: "stagenet",
+          })
+      )
+      .buildSyncProtocols((builder) =>
+        builder
+          .addMain(
+            (networks) => networks.ntp,
+            () => ({
+              name: "ntp",
+              type: ConfigSyncProtocolType.NTP_MAIN,
+              startBlockHeight: "latest",
+            }),
+          )
+          .addParallel(
+            (networks) => networks.midnight,
+            () => ({
+              name: "midnight",
+              type: ConfigSyncProtocolType.MIDNIGHT_PARALLEL,
+              indexer: "https://indexer.example/graphql",
+              startBlockHeight: "latest",
+            }),
+          )
+      )
+      .build();
+
+    expect(built.syncProtocols.main.syncProtocol.startBlockHeight).toBe("latest");
+    expect(
+      built.syncProtocols.parallel.midnight.syncProtocol.startBlockHeight,
+    ).toBe("latest");
+  });
+});
+
+describe("primitive start inheritance (FR-007)", () => {
+  const buildWithPrimitive = (
+    primitive: Record<string, unknown>,
+  ) =>
+    new ConfigBuilder()
+      .buildNetworks((builder) =>
+        builder
+          .addNetwork({ type: ConfigNetworkType.NTP })
+          .addNetwork({
+            type: ConfigNetworkType.MIDNIGHT,
+            networkId: "stagenet",
+          })
+      )
+      .buildSyncProtocols((builder) =>
+        builder
+          .addMain(
+            (networks) => networks.ntp,
+            () => ({
+              name: "ntp",
+              type: ConfigSyncProtocolType.NTP_MAIN,
+              startBlockHeight: "latest",
+            }),
+          )
+          .addParallel(
+            (networks) => networks.midnight,
+            () => ({
+              name: "midnight",
+              type: ConfigSyncProtocolType.MIDNIGHT_PARALLEL,
+              indexer: "https://indexer.example/graphql",
+              startBlockHeight: "latest",
+            }),
+          )
+      )
+      .buildPrimitives((builder) =>
+        builder.addPrimitive(
+          (protocols) => protocols.midnight,
+          () => primitive as { name: string; type: string },
+        )
+      )
+      .build();
+
+  test("a primitive may omit its start height entirely", () => {
+    const built = buildWithPrimitive({
+      name: "round",
+      type: "Midnight:Generic",
+      contractAddress: `0x${"a".repeat(64)}`,
+    });
+    const primitive = built.primitives["round"]!.primitive as Record<
+      string,
+      unknown
+    >;
+    expect("startBlockHeight" in primitive).toBe(false);
+  });
+
+  test("an explicit primitive start is preserved verbatim", () => {
+    const built = buildWithPrimitive({
+      name: "round",
+      type: "Midnight:Generic",
+      contractAddress: `0x${"a".repeat(64)}`,
+      startBlockHeight: 17,
+    });
+    const primitive = built.primitives["round"]!.primitive as Record<
+      string,
+      unknown
+    >;
+    expect(primitive["startBlockHeight"]).toBe(17);
+  });
+});

--- a/packages/node-sdk/db/src/sql/system.queries.ts
+++ b/packages/node-sdk/db/src/sql/system.queries.ts
@@ -354,3 +354,31 @@ const getSyncProtocolConfigSnapshotIR: any = {"usedParamSet":{"protocolName":tru
 export const getSyncProtocolConfigSnapshot = new PreparedQuery<IGetSyncProtocolConfigSnapshotParams,IGetSyncProtocolConfigSnapshotResult>(getSyncProtocolConfigSnapshotIR);
 
 
+/** 'UpdateSyncProtocolConfigSnapshot' parameters type */
+export interface IUpdateSyncProtocolConfigSnapshotParams {
+  immutableConfig: Json;
+  protocolName: string;
+}
+
+/** 'UpdateSyncProtocolConfigSnapshot' return type */
+export type IUpdateSyncProtocolConfigSnapshotResult = void;
+
+/** 'UpdateSyncProtocolConfigSnapshot' query type */
+export interface IUpdateSyncProtocolConfigSnapshotQuery {
+  params: IUpdateSyncProtocolConfigSnapshotParams;
+  result: IUpdateSyncProtocolConfigSnapshotResult;
+}
+
+const updateSyncProtocolConfigSnapshotIR: any = {"usedParamSet":{"immutableConfig":true,"protocolName":true},"params":[{"name":"immutableConfig","required":true,"transform":{"type":"scalar"},"locs":[{"a":73,"b":89}]},{"name":"protocolName","required":true,"transform":{"type":"scalar"},"locs":[{"a":113,"b":126}]}],"statement":"UPDATE effectstream.sync_protocol_config_snapshot\nSET immutable_config = :immutableConfig!\nWHERE protocol_name = :protocolName!"};
+
+/**
+ * Query generated from SQL:
+ * ```
+ * UPDATE effectstream.sync_protocol_config_snapshot
+ * SET immutable_config = :immutableConfig!
+ * WHERE protocol_name = :protocolName!
+ * ```
+ */
+export const updateSyncProtocolConfigSnapshot = new PreparedQuery<IUpdateSyncProtocolConfigSnapshotParams,IUpdateSyncProtocolConfigSnapshotResult>(updateSyncProtocolConfigSnapshotIR);
+
+

--- a/packages/node-sdk/db/src/sql/system.sql
+++ b/packages/node-sdk/db/src/sql/system.sql
@@ -73,3 +73,9 @@ SELECT protocol_name, network_type, immutable_config
 FROM effectstream.sync_protocol_config_snapshot
 WHERE protocol_name = :protocolName!
 ;
+
+/* @name updateSyncProtocolConfigSnapshot */
+UPDATE effectstream.sync_protocol_config_snapshot
+SET immutable_config = :immutableConfig!
+WHERE protocol_name = :protocolName!
+;

--- a/packages/node-sdk/node/README.md
+++ b/packages/node-sdk/node/README.md
@@ -56,10 +56,15 @@ await runNode({
 
 `runNode` uses the normal Effectstream sync, primitive, STM, migration, and
 configuration-snapshot paths. It owns PGlite and runtime cleanup in the same
-process; it does not launch another script. A fresh `"latest"` source begins at
-the current indexed block. When `pglite({ dataDir: "..." })` is persistent, a
-restart reads the saved numeric start height and resumes the stored checkpoint
-instead of jumping to a new tip.
+process; it does not launch another script. The declared `startBlockHeight` -
+a number or `"latest"` - is passed to the runtime untouched: the runtime asks
+that protocol's own start policy to resolve `"latest"` exactly once, commits the
+resulting numeric boundary together with its `latest`/`explicit` provenance
+before any sync state exists, and reuses the committed value afterwards. So a
+fresh `"latest"` source begins at the current indexed block, and when
+`pglite({ dataDir: "..." })` is persistent a restart performs no tip query at
+all: it resumes from the committed boundary and the saved clock mapping instead
+of jumping to a new tip.
 
 The subpaths are thin re-exports - semantics are identical to importing
 from the underlying packages.

--- a/packages/node-sdk/node/src/single-file.ts
+++ b/packages/node-sdk/node/src/single-file.ts
@@ -182,9 +182,6 @@ export async function runNode<
     process.env.DB_PORT = String(database.port);
     await database.db.waitReady;
 
-    const clockSnapshot = await readConfigSnapshot(database, "clock");
-    const clockStartTime = numberFromSnapshot(clockSnapshot, "startTime") ?? Date.now();
-    const resolvedSources = await resolveStartHeights(database, sourceEntries);
     const grammar = Object.fromEntries(
       sourceEntries.map(([name]) => [name, builtinGrammars.midnightGeneric]),
     );
@@ -209,7 +206,7 @@ export async function runNode<
     ): SyncStateUpdateStream<void> {
       yield* stm.processInput(input);
     };
-    const syncInfo = makeSyncInfo(clockStartTime, resolvedSources);
+    const syncInfo = makeSyncInfo(sourceEntries);
     const staticConfig = {
       securityNamespace: options.appName,
       allNetworks: { viemNetworks: {} },
@@ -257,89 +254,22 @@ export async function runNode<
   }
 }
 
-type ResolvedSource = {
-  name: string;
-  source: AnyMidnightSource;
-  startBlockHeight: number;
-};
-
-async function resolveStartHeights(
-  database: PgliteHandle,
-  sources: [string, AnyMidnightSource][],
-): Promise<ResolvedSource[]> {
-  const latestByIndexer = new Map<string, Promise<number>>();
-  return await Promise.all(sources.map(async ([name, source]) => {
-    const protocolName = protocolNameFor(name);
-    const snapshot = await readConfigSnapshot(database, protocolName);
-    const savedHeight = numberFromSnapshot(snapshot, "startBlockHeight");
-    if (savedHeight !== undefined) {
-      return { name, source, startBlockHeight: savedHeight };
-    }
-    if (source.startBlockHeight !== "latest") {
-      return { name, source, startBlockHeight: source.startBlockHeight };
-    }
-
-    let latest = latestByIndexer.get(source.indexer);
-    if (!latest) {
-      latest = fetchLatestHeight(source.indexer, source.network);
-      latestByIndexer.set(source.indexer, latest);
-    }
-    return { name, source, startBlockHeight: await latest };
-  }));
-}
-
-async function fetchLatestHeight(
-  indexer: string,
-  network: MidnightNetwork,
-): Promise<number> {
-  const response = await fetch(indexer, {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({ query: "query { block { height } }" }),
-    signal: AbortSignal.timeout(15_000),
-  });
-  if (!response.ok) {
-    throw new Error(
-      `Unable to read the Midnight ${network} tip: ${response.status} ${response.statusText}.`,
-    );
-  }
-  const body = await response.json() as {
-    data?: { block?: { height?: unknown } };
-    errors?: unknown;
-  };
-  const height = body.data?.block?.height;
-  if (!Number.isSafeInteger(height) || (height as number) < 0) {
-    throw new Error(
-      `The Midnight ${network} indexer returned an invalid latest block height.`,
-    );
-  }
-  return height as number;
-}
-
-async function readConfigSnapshot(
-  database: PgliteHandle,
-  protocolName: string,
-): Promise<Record<string, unknown> | undefined> {
-  try {
-    const result = await database.db.query<{ immutable_config: unknown }>(
-      `SELECT immutable_config
-       FROM effectstream.sync_protocol_config_snapshot
-       WHERE protocol_name = $1`,
-      [protocolName],
-    );
-    const value = result.rows[0]?.immutable_config;
-    if (typeof value === "string") return JSON.parse(value);
-    if (value && typeof value === "object") return value as Record<string, unknown>;
-    return undefined;
-  } catch (error) {
-    if ((error as { code?: string }).code === "42P01") return undefined;
-    throw error;
-  }
-}
-
+/**
+ * Build the runtime's sync configuration.
+ *
+ * Start boundaries are NOT resolved here. Every declared start — a number or
+ * the `"latest"` sentinel — is passed through verbatim, and the generic runtime
+ * (`@effectstream/runtime` `config-snapshot.ts`) resolves `"latest"` once via
+ * the protocol's own start policy, commits the numeric boundary plus its
+ * provenance, and reuses the committed value on every restart.
+ *
+ * The clock's `startTime` is likewise sampled fresh on every boot: the NTP
+ * start policy restores the saved value from the config snapshot, so the
+ * time→block mapping of an existing database is preserved without this facade
+ * pre-reading the database itself.
+ */
 function makeSyncInfo(
-  clockStartTime: number,
-  sources: ResolvedSource[],
+  sources: [string, AnyMidnightSource][],
 ): SyncProtocolWithNetwork[] {
   const clock = {
     networkType: ConfigNetworkType.NTP,
@@ -347,7 +277,7 @@ function makeSyncInfo(
     network: {
       name: "clock",
       type: ConfigNetworkType.NTP,
-      startTime: clockStartTime,
+      startTime: Date.now(),
       blockTimeMS: 1_000,
     },
     syncProtocol: {
@@ -362,7 +292,7 @@ function makeSyncInfo(
     primitives: [],
   };
 
-  return [clock, ...sources.map(({ name, source, startBlockHeight }) => {
+  return [clock, ...sources.map(([name, source]) => {
     const protocolName = protocolNameFor(name);
     return {
       networkType: ConfigNetworkType.MIDNIGHT,
@@ -376,7 +306,7 @@ function makeSyncInfo(
         name: protocolName,
         type: ConfigSyncProtocolType.MIDNIGHT_PARALLEL,
         indexer: source.indexer,
-        startBlockHeight,
+        startBlockHeight: source.startBlockHeight,
         stopBlockHeight: null,
         pollingInterval: 1_000,
         requestTimeoutMs: 15_000,
@@ -385,13 +315,14 @@ function makeSyncInfo(
         confirmationDepth: 3,
         delayMs: 20_000,
       },
+      // The primitive declares no start of its own: it inherits the protocol's
+      // committed numeric boundary in the runtime (FR-007).
       primitives: [{
         id: name,
         syncProtocol: protocolName,
         primitive: {
           name,
           type: PrimitiveTypeMidnightGeneric,
-          startBlockHeight,
           contractAddress: source.address,
           stateMachinePrefix: name,
           ledgerSchema: source.ledger,
@@ -408,14 +339,6 @@ function midnightIndexer(network: MidnightNetwork): string {
 
 function protocolNameFor(sourceName: string): string {
   return `midnight-${sourceName}`;
-}
-
-function numberFromSnapshot(
-  snapshot: Record<string, unknown> | undefined,
-  field: string,
-): number | undefined {
-  const value = snapshot?.[field];
-  return typeof value === "number" && Number.isSafeInteger(value) ? value : undefined;
 }
 
 function validateName(value: string, label: string): void {

--- a/packages/node-sdk/node/test/single-file-start-policy.test.ts
+++ b/packages/node-sdk/node/test/single-file-start-policy.test.ts
@@ -1,0 +1,74 @@
+// Facade guard for project 00034 (spec SC-003 + the single-file goal).
+//
+// The generic runtime now owns resolution, persistence and reuse, so the
+// single-file facade must no longer hand-roll a Midnight tip query, read the
+// snapshot table with raw SQL, or pre-read the NTP clock before building the
+// config. It just declares `"latest"` and lets the runtime reconcile.
+
+import { describe, expect, test } from "bun:test";
+
+const facade = await Bun.file(
+  new URL("../src/single-file.ts", import.meta.url),
+).text();
+
+describe("single-file facade delegates start resolution to the runtime", () => {
+  test.each([
+    ["resolveStartHeights", /resolveStartHeights/],
+    ["fetchLatestHeight", /fetchLatestHeight/],
+    ["readConfigSnapshot", /readConfigSnapshot/],
+    ["numberFromSnapshot", /numberFromSnapshot/],
+    ["ResolvedSource", /ResolvedSource/],
+  ])("no longer defines or calls %s", (_name, pattern) => {
+    expect(facade).not.toMatch(pattern as RegExp);
+  });
+
+  test("no longer issues a hand-rolled tip GraphQL query", () => {
+    expect(facade).not.toMatch(/block\s*\{\s*height\s*\}/);
+  });
+
+  test("no longer reads the snapshot table with raw SQL", () => {
+    expect(facade).not.toMatch(/sync_protocol_config_snapshot/);
+    expect(facade).not.toMatch(/42P01/);
+  });
+
+  test('passes the declared start (including "latest") straight through', () => {
+    expect(facade).toMatch(/startBlockHeight:\s*source\.startBlockHeight/);
+  });
+
+  test("stops copying a resolved height into the primitive", () => {
+    // The primitive inherits the protocol's committed numeric start (FR-007),
+    // so the primitive literal must not repeat a start height.
+    const start = facade.indexOf("primitive: {");
+    expect(start).toBeGreaterThan(-1);
+    const primitiveBlock = facade.slice(start, facade.indexOf("}", start));
+    expect(primitiveBlock).not.toMatch(/startBlockHeight/);
+  });
+});
+
+describe("the facade surface is unchanged", () => {
+  test('midnightContract still accepts "latest" and numeric starts', async () => {
+    const { midnightContract } = await import("../src/single-file.ts");
+    expect(
+      midnightContract({
+        network: "preview",
+        address: "a".repeat(64),
+        startBlockHeight: "latest",
+        ledger: { round: "uint128" },
+      }).startBlockHeight,
+    ).toBe("latest");
+    expect(
+      midnightContract({
+        network: "preview",
+        address: "a".repeat(64),
+        startBlockHeight: 12,
+        ledger: { round: "uint128" },
+      }).startBlockHeight,
+    ).toBe(12);
+  });
+
+  test("runNode and pglite are still exported", async () => {
+    const facadeModule = await import("../src/single-file.ts");
+    expect(typeof facadeModule.runNode).toBe("function");
+    expect(typeof facadeModule.pglite).toBe("function");
+  });
+});

--- a/packages/node-sdk/runtime/src/config-snapshot.ts
+++ b/packages/node-sdk/runtime/src/config-snapshot.ts
@@ -1,81 +1,118 @@
-import type { Client } from "pg";
+import type { Client, PoolClient } from "pg";
 import type { Operation } from "effection";
-import { until } from "effection";
+import { call, until } from "effection";
 import {
   getSyncProtocolConfigSnapshot,
+  updateSyncProtocolConfigSnapshot,
   upsertSyncProtocolConfigSnapshot,
 } from "@effectstream/db";
-import { ConfigNetworkType, ConfigSyncProtocolType } from "@effectstream/config";
+import {
+  START_BLOCK_HEIGHT_PROVENANCE,
+  startPolicyRegistry,
+} from "@effectstream/sync";
+import type {
+  StartPolicySnapshotFields,
+  SyncProtocolStartPolicy,
+} from "@effectstream/sync";
 import type { SyncProtocolWithNetwork } from "@effectstream/config";
-import { log, ComponentNames, SeverityNumber } from "@effectstream/log";
+import { ComponentNames, log, SeverityNumber } from "@effectstream/log";
 import { getEnv } from "@effectstream/utils/runtime";
 
 /**
- * Fields that must not change between restarts for each protocol type.
- * Changing these would cause the node to sync from a different point in time/block,
- * leading to inconsistent state.
+ * Generic, protocol-agnostic reconciliation of every sync protocol's immutable
+ * start configuration.
  *
- * Field names by protocol:
- *   NTP                        → network.startTime, network.blockTimeMS
- *   Cardano CARP               → syncProtocol.startSlot
- *   Cardano UTXOrpc            → syncProtocol.startChainPoint
- *   EVM, Mina, Avail, Midnight,
- *   Bitcoin, Celestia, NEAR, Solana → syncProtocol.startBlockHeight
+ * This module knows NOTHING about NTP, Midnight, Cardano or any other chain
+ * (FR-001). It selects one opaque `SyncProtocolStartPolicy` per entry by
+ * `syncProtocolType` and drives three protocol-owned operations:
+ *
+ *  - `resolveLatest`   — only on a first run whose configured start is
+ *                        `"latest"`; it is the ONLY place a live tip is read.
+ *  - `projectImmutable`— what this protocol persists, split into the
+ *                        mismatch-checked (`validated`) and always-adopted
+ *                        (`restored`) groups.
+ *  - `applySnapshot`   — write a committed snapshot back onto the live config.
+ *
+ * The durable boundary plus its `latest | explicit` provenance is committed
+ * before this function returns, and therefore before primitives and sync states
+ * are constructed (FR-006 — see the startup ordering in `main.ts`).
  */
-function extractImmutableConfig(protocol: SyncProtocolWithNetwork): Record<string, unknown> {
-  // NTP and the synthetic TEST chain both derive blocks arithmetically from
-  // network.startTime + network.blockTimeMS, so those are the immutable fields.
-  if (
-    protocol.networkType === ConfigNetworkType.NTP ||
-    protocol.networkType === ConfigNetworkType.TEST
-  ) {
-    const arithmeticNetwork = protocol.network as {
-      startTime: number;
-      blockTimeMS: number;
-    };
-    return {
-      startTime: arithmeticNetwork.startTime,
-      blockTimeMS: arithmeticNetwork.blockTimeMS,
-    };
-  }
 
-  if (protocol.syncProtocolType === ConfigSyncProtocolType.CARDANO_CARP_PARALLEL) {
-    const sp = protocol.syncProtocol as { startSlot: number };
-    return { startSlot: sp.startSlot };
-  }
+/** How a protocol's committed numeric boundary was obtained. */
+type Provenance = "latest" | "explicit";
 
-  if (protocol.syncProtocolType === ConfigSyncProtocolType.CARDANO_UTXORPC_PARALLEL) {
-    const sp = protocol.syncProtocol as { startChainPoint: unknown };
-    return { startChainPoint: sp.startChainPoint };
-  }
+/** Test seam (FR-004): a generic registry override, never per-chain hooks. */
+export type ConfigSnapshotSeams = {
+  startPolicies?: Record<string, SyncProtocolStartPolicy>;
+};
 
-  // EVM, Mina, Avail, Midnight, Bitcoin, Celestia, NEAR, Solana
-  const knownBlockHeightProtocols: string[] = [
-    ConfigSyncProtocolType.EVM_RPC_PARALLEL,
-    ConfigSyncProtocolType.MINA_PARALLEL,
-    ConfigSyncProtocolType.AVAIL_PARALLEL,
-    ConfigSyncProtocolType.MIDNIGHT_PARALLEL,
-    ConfigSyncProtocolType.BITCOIN_RPC_PARALLEL,
-    ConfigSyncProtocolType.CELESTIA_PARALLEL,
-    ConfigSyncProtocolType.NEAR_RPC_PARALLEL,
-    ConfigSyncProtocolType.SOLANA_RPC_PARALLEL,
-  ];
-  if (!knownBlockHeightProtocols.includes(protocol.syncProtocolType)) {
-    throw new Error(
-      `[config-snapshot] Unhandled sync protocol type "${protocol.syncProtocolType}". ` +
-      `extractImmutableConfig must be updated to support this protocol.`,
-    );
-  }
+/**
+ * A connection this reconciliation owns exclusively for one protocol.
+ *
+ * `main.ts` hands us a `pg.Pool` (typed as `Client`), and statements issued on
+ * a pool may each land on a different pooled connection — so `BEGIN`/`COMMIT`
+ * on the pool would NOT be one transaction. Every statement of one protocol's
+ * reconciliation therefore runs on a single checked-out `PoolClient`, released
+ * in a `finally` exactly like `processFinalizedBlockWithRetry`
+ * (`process-blocks.ts`). When the caller already handed us a dedicated client
+ * there is nothing to check out and `release` is a no-op.
+ *
+ * Every statement goes through `<query>.run(params, client)` / `client.query()`
+ * directly and never through `runPreparedQuery`, which would try to re-acquire
+ * the PGlite startup mutex already held by `startup()` and deadlock.
+ */
+type DedicatedConnection = {
+  client: Client;
+  release: (error?: unknown) => void;
+};
 
-  const sp = protocol.syncProtocol as { startBlockHeight: number };
-  return { startBlockHeight: sp.startBlockHeight };
+type PoolLike = {
+  connect: () => Promise<PoolClient>;
+  totalCount: number;
+};
+
+/**
+ * `totalCount` is what distinguishes a `pg.Pool` from a `pg.Client`: both
+ * expose `connect`, only the pool reports how many connections it owns.
+ */
+function isPool(dbConn: unknown): dbConn is PoolLike {
+  if (dbConn === null || typeof dbConn !== "object") return false;
+  const candidate = dbConn as Partial<PoolLike>;
+  return typeof candidate.connect === "function" &&
+    typeof candidate.totalCount === "number";
+}
+
+function* checkoutConnection(dbConn: Client): Operation<DedicatedConnection> {
+  if (!isPool(dbConn)) {
+    return { client: dbConn, release: () => {} };
+  }
+  const client = yield* until(dbConn.connect());
+  let released = false;
+  return {
+    client: client as unknown as Client,
+    release: (error?: unknown) => {
+      if (released) return;
+      released = true;
+      try {
+        // Passing an error destroys the client instead of recycling it, so a
+        // connection left in an unknown transaction state is never handed out.
+        client.release(error as Error | undefined);
+      } catch {
+        /* already released/destroyed */
+      }
+    },
+  };
+}
+
+function* execute(client: Client, sql: string): Operation<void> {
+  yield* until(client.query(sql));
 }
 
 /**
  * Compares a saved snapshot value against the current in-memory value.
  * Falls back to structural JSON comparison for nested objects (which are
  * always freshly constructed plain objects with stable key-insertion order
- * from `extractImmutableConfig`), and to reference/identity comparison for
+ * from `projectImmutable`), and to reference/identity comparison for
  * everything else.
  */
 function valuesDiffer(saved: unknown, current: unknown): boolean {
@@ -89,77 +126,225 @@ function valuesDiffer(saved: unknown, current: unknown): boolean {
 }
 
 /**
- * Checks the saved config snapshot for each sync protocol against the current config.
+ * A projected value this boot deliberately cannot know.
  *
- * On the first run (no snapshot in DB), the current config is persisted as the canonical snapshot.
+ * On the restart path the projection exists only to learn the CURRENT values of
+ * each field; a protocol configured with `"latest"` has no current numeric
+ * start (that is the whole point of the sentinel), so `NaN` is passed in and
+ * the resulting key is excluded from difference reporting instead of being
+ * reported as an eternal difference.
  *
- * On subsequent runs, if an immutable field has changed:
- *  - If the `USE_DB_STARTHEIGHT` environment variable is set, the DB value is used and a warning is logged.
- *  - Otherwise, an error is thrown to prevent the node from starting with an inconsistent config.
+ * Only `NaN` qualifies. A field that is genuinely `undefined` in the current
+ * config while the snapshot holds a value is real drift and must still be
+ * reported (e.g. a saved Cardano `startChainPoint` with no counterpart today).
+ */
+function isUnresolvedProjection(value: unknown): boolean {
+  return typeof value === "number" && Number.isNaN(value);
+}
+
+/**
+ * Differences between a saved snapshot and a freshly projected group.
  *
- * The function mutates `syncInfo` in place when `USE_DB_STARTHEIGHT` overrides values.
+ * Only keys present in BOTH are compared: a key the definition projects but an
+ * older snapshot never stored is not a mismatch (that is how a protocol may
+ * start persisting a new field without breaking existing databases), and a key
+ * a snapshot stores but the definition no longer projects is ignored.
+ */
+function describeDifferences(
+  saved: Record<string, unknown>,
+  projected: StartPolicySnapshotFields,
+): string[] {
+  const differences: string[] = [];
+  for (const [key, currentValue] of Object.entries(projected)) {
+    if (!(key in saved)) continue;
+    if (isUnresolvedProjection(currentValue)) continue;
+    if (!valuesDiffer(saved[key], currentValue)) continue;
+    differences.push(
+      `  ${key}: saved=${JSON.stringify(saved[key])}, current=${
+        JSON.stringify(currentValue)
+      }`,
+    );
+  }
+  return differences;
+}
+
+type BlockHeightCarrier = { startBlockHeight?: number | "latest" };
+
+function configuredStart(
+  protocol: SyncProtocolWithNetwork,
+): number | "latest" | undefined {
+  return (protocol.syncProtocol as unknown as BlockHeightCarrier)
+    .startBlockHeight;
+}
+
+/**
+ * Checks the saved config snapshot for each sync protocol against the current
+ * config, resolving a `"latest"` start exactly once and committing the numeric
+ * boundary plus its provenance before returning.
+ *
+ * On the first run (no snapshot row) the boundary is resolved — from the
+ * protocol's own `resolveLatest` for `"latest"`, otherwise straight from the
+ * explicit numeric value — inserted with `ON CONFLICT DO NOTHING`, re-read
+ * inside the same transaction and adopted. If a concurrent process won the
+ * insert, the committed row wins and this process discards its own
+ * observation. (The re-read relies on the PostgreSQL default READ COMMITTED
+ * isolation, under which each statement sees a fresh snapshot and therefore
+ * observes a concurrently committed winner.)
+ *
+ * On later runs NO live tip query happens. A legacy row without provenance is
+ * backfilled to `"explicit"` in the same transaction, `validated` fields keep
+ * the historical contract (a difference throws unless `USE_DB_STARTHEIGHT` is
+ * set, which downgrades to a warning and lets the saved value win) and
+ * `restored` fields are always adopted from the snapshot, warning when they
+ * differ from the freshly configured ones.
+ *
+ * The function mutates `syncInfo` in place — after it returns, every protocol
+ * that declares a `startBlockHeight` carries the committed numeric boundary.
+ * That postcondition is enforced, not merely intended: a restart that cannot
+ * produce a number (a legacy snapshot with no saved boundary under a configured
+ * `"latest"`) throws rather than letting the sentinel escape.
  */
 export function* validateAndSnapshotConfig(
   syncInfo: SyncProtocolWithNetwork[],
   dbConn: Client,
+  seams?: ConfigSnapshotSeams,
 ): Operation<void> {
   const useDbStartHeight = getEnv("USE_DB_STARTHEIGHT") !== undefined;
+  const policies: Record<string, SyncProtocolStartPolicy> =
+    seams?.startPolicies ?? startPolicyRegistry;
 
   for (const protocol of syncInfo) {
-    const protocolName: string = (protocol.syncProtocol as { name: string }).name;
-    const currentImmutable = extractImmutableConfig(protocol);
+    const protocolName: string =
+      (protocol.syncProtocol as { name: string }).name;
+    const definition = policies[protocol.syncProtocolType as string];
+    if (definition === undefined) {
+      throw new Error(
+        `[config-snapshot] Unknown start policy for sync protocol type ` +
+          `"${String(protocol.syncProtocolType)}" (protocol "${protocolName}"). ` +
+          `Register a start policy beside that protocol's sync implementation.`,
+      );
+    }
 
-    const rows = yield* until(
-      getSyncProtocolConfigSnapshot.run({ protocolName }, dbConn),
+    const connection = yield* checkoutConnection(dbConn);
+    // `finally` (not `catch`) so a halted startup releases the connection too;
+    // the recorded failure is passed on so a client left mid-transaction is
+    // destroyed rather than recycled, exactly like `process-blocks.ts`.
+    let failure: unknown;
+    try {
+      yield* reconcileProtocol(
+        protocol,
+        protocolName,
+        definition,
+        connection.client,
+        useDbStartHeight,
+      );
+    } catch (error) {
+      failure = error;
+      throw error;
+    } finally {
+      connection.release(failure);
+    }
+  }
+}
+
+function* reconcileProtocol(
+  protocol: SyncProtocolWithNetwork,
+  protocolName: string,
+  definition: SyncProtocolStartPolicy,
+  client: Client,
+  useDbStartHeight: boolean,
+): Operation<void> {
+  const rows = yield* until(
+    getSyncProtocolConfigSnapshot.run({ protocolName }, client),
+  );
+
+  if (rows.length > 0) {
+    yield* reconcileExistingSnapshot(
+      protocol,
+      protocolName,
+      definition,
+      client,
+      useDbStartHeight,
+      rows[0].immutable_config as Record<string, unknown>,
     );
+    return;
+  }
 
-    if (rows.length === 0) {
-      // First run: persist the snapshot.
+  yield* resolveAndCommitFirstBoundary(
+    protocol,
+    protocolName,
+    definition,
+    client,
+  );
+}
+
+/** Restart path. No live tip query ever happens here. */
+function* reconcileExistingSnapshot(
+  protocol: SyncProtocolWithNetwork,
+  protocolName: string,
+  definition: SyncProtocolStartPolicy,
+  client: Client,
+  useDbStartHeight: boolean,
+  savedRow: Record<string, unknown>,
+): Operation<void> {
+  let saved = savedRow;
+
+  // A snapshot written before provenance existed can only have come from an
+  // explicit numeric start — `"latest"` did not exist then. Backfill it
+  // atomically so later boots take the ordinary path.
+  if (
+    !(START_BLOCK_HEIGHT_PROVENANCE in saved) &&
+    typeof saved["startBlockHeight"] === "number"
+  ) {
+    const backfilled = {
+      ...saved,
+      [START_BLOCK_HEIGHT_PROVENANCE]: "explicit" satisfies Provenance,
+    };
+    yield* inTransaction(client, function* () {
       yield* until(
-        upsertSyncProtocolConfigSnapshot.run(
-          {
-            protocolName,
-            networkType: protocol.networkType,
-            immutableConfig: JSON.stringify(currentImmutable),
-          },
-          dbConn,
+        updateSyncProtocolConfigSnapshot.run(
+          { protocolName, immutableConfig: JSON.stringify(backfilled) },
+          client,
         ),
       );
-      log.remote(
-        ComponentNames.EFFECTSTREAM_RUNTIME,
-        [],
-        SeverityNumber.INFO,
-        (l) => l(`[config-snapshot] Saved initial config snapshot for protocol "${protocolName}"`),
-      );
-      continue;
-    }
+    });
+    saved = backfilled;
+    log.remote(
+      ComponentNames.EFFECTSTREAM_RUNTIME,
+      [],
+      SeverityNumber.INFO,
+      (l) =>
+        l(
+          `[config-snapshot] Backfilled start-height provenance "explicit" for ` +
+            `protocol "${protocolName}".`,
+        ),
+    );
+  }
 
-    const saved = rows[0].immutable_config as Record<string, unknown>;
-    const mismatches: string[] = [];
-    for (const [key, savedValue] of Object.entries(saved)) {
-      if (valuesDiffer(savedValue, currentImmutable[key])) {
-        mismatches.push(`  ${key}: saved=${JSON.stringify(savedValue)}, current=${JSON.stringify(currentImmutable[key])}`);
-      }
-    }
+  // The projection is built purely to learn what THIS boot configured. A
+  // configured `"latest"` has no current numeric start, so the definition is
+  // handed NaN and puts it in the restored group, where it is not compared.
+  const configured = configuredStart(protocol);
+  const projected = definition.projectImmutable(protocol, {
+    startBlockHeight: typeof configured === "number"
+      ? configured
+      : Number.NaN,
+    provenance: configured === "latest" ? "latest" : "explicit",
+  });
 
-    if (mismatches.length === 0) {
-      continue;
-    }
-
+  const mismatches = describeDifferences(saved, projected.validated);
+  if (mismatches.length > 0) {
     const mismatchDetails = mismatches.join("\n");
-
     if (!useDbStartHeight) {
       throw new Error(
         `[config-snapshot] CRITICAL: Immutable config fields have changed for protocol "${protocolName}".\n` +
-        `${mismatchDetails}\n\n` +
-        `If this is intentional (e.g. you want to resume from the original start height/time stored in the DB), ` +
-        `set the USE_DB_STARTHEIGHT environment variable and restart the service.\n` +
-        `WARNING: Only set USE_DB_STARTHEIGHT if you understand the implications — mismatched start values ` +
-        `can cause the node to skip blocks or produce inconsistent state.`,
+          `${mismatchDetails}\n\n` +
+          `If this is intentional (e.g. you want to resume from the original start height/time stored in the DB), ` +
+          `set the USE_DB_STARTHEIGHT environment variable and restart the service.\n` +
+          `WARNING: Only set USE_DB_STARTHEIGHT if you understand the implications — mismatched start values ` +
+          `can cause the node to skip blocks or produce inconsistent state.`,
       );
     }
-
-    // USE_DB_STARTHEIGHT is set — apply the DB values and warn.
     log.remote(
       ComponentNames.EFFECTSTREAM_RUNTIME,
       [],
@@ -167,40 +352,133 @@ export function* validateAndSnapshotConfig(
       (l) =>
         l(
           `[config-snapshot] WARNING: Immutable config mismatch for protocol "${protocolName}". ` +
-          `USE_DB_STARTHEIGHT is set; overriding in-memory config with DB snapshot values.\n${mismatchDetails}`,
+            `USE_DB_STARTHEIGHT is set; overriding in-memory config with DB snapshot values.\n${mismatchDetails}`,
         ),
     );
+  }
 
-    applySnapshotOverrides(protocol, saved);
+  const restoredDifferences = describeDifferences(saved, projected.restored);
+  if (restoredDifferences.length > 0) {
+    log.remote(
+      ComponentNames.EFFECTSTREAM_RUNTIME,
+      [],
+      SeverityNumber.WARN,
+      (l) =>
+        l(
+          `[config-snapshot] Restored saved start configuration for protocol "${protocolName}"; ` +
+            `the freshly configured values differ and are ignored.\n${
+              restoredDifferences.join("\n")
+            }`,
+        ),
+    );
+  }
+
+  definition.applySnapshot(protocol, saved);
+
+  // A snapshot written before this feature can lack `startBlockHeight` entirely
+  // (a pre-00034 NTP row held only {startTime, blockTimeMS}). Nothing on this
+  // path can supply it — the provenance backfill needs a numeric saved start,
+  // `resolveLatest` is deliberately unreachable here, and `applySnapshot` has
+  // no key to write — so a configured `"latest"` would otherwise survive as a
+  // string and break this module's numeric postcondition silently. Fail loud.
+  if (configured !== undefined && typeof configuredStart(protocol) !== "number") {
+    throw new Error(
+      `[config-snapshot] CRITICAL: protocol "${protocolName}" would start with a ` +
+        `non-numeric startBlockHeight (${JSON.stringify(configuredStart(protocol))}).\n` +
+        `Its saved config snapshot has no "startBlockHeight" key, so there is nothing to ` +
+        `restore, and the restart path never queries a live tip — a boundary resolved now ` +
+        `would silently differ from the one this database was synced with.\n\n` +
+        `Fix it once, either way:\n` +
+        `  - configure an explicit numeric startBlockHeight for this protocol, or\n` +
+        `  - delete its row from effectstream.sync_protocol_config_snapshot to resolve ` +
+        `"latest" again from scratch (this re-syncs from the new boundary).`,
+    );
   }
 }
 
-/**
- * Applies the saved immutable values from `snapshot` onto the in-memory protocol config.
- * This mutates the protocol objects so the rest of the startup uses the corrected values.
- */
-function applySnapshotOverrides(
+/** First-run path: resolve at most once, commit, then adopt what committed. */
+function* resolveAndCommitFirstBoundary(
   protocol: SyncProtocolWithNetwork,
-  snapshot: Record<string, unknown>,
-): void {
-  if (protocol.networkType === ConfigNetworkType.NTP) {
-    const ntpNetwork = protocol.network as Record<string, unknown>;
-    if ("startTime" in snapshot) ntpNetwork["startTime"] = snapshot["startTime"];
-    if ("blockTimeMS" in snapshot) ntpNetwork["blockTimeMS"] = snapshot["blockTimeMS"];
-    return;
+  protocolName: string,
+  definition: SyncProtocolStartPolicy,
+  client: Client,
+): Operation<void> {
+  const configured = configuredStart(protocol);
+  const provenance: Provenance = configured === "latest"
+    ? "latest"
+    : "explicit";
+  // Resolved OUTSIDE the transaction: a network round trip must never hold a
+  // database transaction open, and a crash here has persisted nothing.
+  const startBlockHeight = configured === "latest"
+    ? yield* call(() => definition.resolveLatest(protocol))
+    : (configured as number);
+
+  const projected = definition.projectImmutable(protocol, {
+    startBlockHeight,
+    provenance,
+  });
+  const immutableConfig: StartPolicySnapshotFields = {
+    ...projected.validated,
+    ...projected.restored,
+  };
+
+  let committed = immutableConfig;
+  yield* inTransaction(client, function* () {
+    yield* until(
+      upsertSyncProtocolConfigSnapshot.run(
+        {
+          protocolName,
+          networkType: protocol.networkType as unknown as string,
+          immutableConfig: JSON.stringify(immutableConfig),
+        },
+        client,
+      ),
+    );
+    // Re-read inside the transaction: if a concurrent process won the insert
+    // (ON CONFLICT DO NOTHING silently kept its row), the committed row is
+    // authoritative and this process discards its own observation.
+    const committedRows = yield* until(
+      getSyncProtocolConfigSnapshot.run({ protocolName }, client),
+    );
+    if (committedRows.length > 0) {
+      committed = committedRows[0].immutable_config as StartPolicySnapshotFields;
+    }
+  });
+
+  definition.applySnapshot(protocol, committed);
+
+  log.remote(
+    ComponentNames.EFFECTSTREAM_RUNTIME,
+    [],
+    SeverityNumber.INFO,
+    (l) =>
+      l(
+        `[config-snapshot] Saved initial config snapshot for protocol "${protocolName}"`,
+      ),
+  );
+}
+
+/**
+ * BEGIN/COMMIT (ROLLBACK on failure) on ONE dedicated connection, imitating
+ * `process-blocks.ts`. A crash before COMMIT persists nothing, so the next boot
+ * simply resolves again; a crash after COMMIT takes the restart path.
+ */
+function* inTransaction(
+  client: Client,
+  body: () => Operation<void>,
+): Operation<void> {
+  yield* execute(client, "BEGIN");
+  try {
+    yield* body();
+  } catch (error) {
+    // A failing ROLLBACK must not mask what actually went wrong; the caller
+    // destroys the connection on the way out either way.
+    try {
+      yield* execute(client, "ROLLBACK");
+    } catch {
+      /* connection is unusable; the original error is the useful one */
+    }
+    throw error;
   }
-
-  const sp = protocol.syncProtocol as Record<string, unknown>;
-
-  if (protocol.syncProtocolType === ConfigSyncProtocolType.CARDANO_CARP_PARALLEL) {
-    if ("startSlot" in snapshot) sp["startSlot"] = snapshot["startSlot"];
-    return;
-  }
-
-  if (protocol.syncProtocolType === ConfigSyncProtocolType.CARDANO_UTXORPC_PARALLEL) {
-    if ("startChainPoint" in snapshot) sp["startChainPoint"] = snapshot["startChainPoint"];
-    return;
-  }
-
-  if ("startBlockHeight" in snapshot) sp["startBlockHeight"] = snapshot["startBlockHeight"];
+  yield* execute(client, "COMMIT");
 }

--- a/packages/node-sdk/runtime/src/main.ts
+++ b/packages/node-sdk/runtime/src/main.ts
@@ -321,17 +321,6 @@ function* startup(
   // Pull the security namespace from the static config so primitives that
   // re-verify batched signatures can access it synchronously.
   const staticConfig = yield* usePaimaStaticConfig();
-  // Create Runtime Primitives Instances
-  syncInfo.forEach((syncProtocol) => {
-    syncProtocol.primitives.forEach((primitive, primitiveIndex) => {
-      processPrimitives(
-        syncProtocol.primitives,
-        primitiveIndex,
-        staticConfig.securityNamespace,
-        config.userDefinedPrimitives
-      );
-    });
-  });
 
   yield* acquireDBMutex(`startup-node`);
   // `finally` releases the mutex on error/cancellation too; a throw in any step
@@ -352,10 +341,28 @@ function* startup(
       config.migrations,
     );
 
-    // Validate that immutable config fields (e.g. NTP startTime, startBlockHeight)
-    // have not changed since the last run. Persists a snapshot on first start.
-    // Must run after system migrations so the snapshot table exists.
+    // Reconcile every protocol's immutable start configuration: resolve a
+    // `"latest"` start exactly once, commit the numeric boundary plus its
+    // provenance, and reuse the committed value on every later boot. Must run
+    // after system migrations so the snapshot table exists.
     yield* validateAndSnapshotConfig(syncInfo, dbConn);
+
+    // Create Runtime Primitives Instances.
+    // Deliberately AFTER reconciliation (FR-006): every protocol now carries a
+    // committed numeric `startBlockHeight`, so a primitive that omits its own
+    // start can inherit it (FR-007) and no primitive can ever be constructed
+    // from an unresolved `"latest"` sentinel.
+    inheritPrimitiveStartHeights(syncInfo);
+    syncInfo.forEach((syncProtocol) => {
+      syncProtocol.primitives.forEach((primitive, primitiveIndex) => {
+        processPrimitives(
+          syncProtocol.primitives,
+          primitiveIndex,
+          staticConfig.securityNamespace,
+          config.userDefinedPrimitives
+        );
+      });
+    });
 
     const syncProtocols = yield* genSyncProtocols(dbConn as any, // Client,
       syncInfo);
@@ -377,6 +384,53 @@ function* startup(
     return syncProtocols;
   } finally {
     releaseDBMutex(`startup-node`);
+  }
+}
+
+/**
+ * FR-007: a primitive that omits `startBlockHeight` inherits its owning sync
+ * protocol's committed numeric start; an explicit primitive value always wins
+ * (including an explicit `0`).
+ *
+ * This is generic — it works for every protocol precisely because
+ * `validateAndSnapshotConfig` has already committed a numeric boundary by the
+ * time it runs. Protocols that start from something other than a block height
+ * (Cardano's slot / chain point) simply have nothing to hand down, so their
+ * primitives must still declare their own start.
+ *
+ * Exported for the runtime's unit oracle; `startup()` is the only caller.
+ */
+export function inheritPrimitiveStartHeights(
+  syncInfo: SyncProtocolWithNetwork[],
+): void {
+  for (const protocol of syncInfo) {
+    const protocolStart =
+      (protocol.syncProtocol as unknown as { startBlockHeight?: unknown })
+        .startBlockHeight;
+    const inheritable = typeof protocolStart === "number"
+      ? protocolStart
+      : undefined;
+    const protocolName = (protocol.syncProtocol as unknown as { name?: string })
+      .name ?? String(protocol.syncProtocolType);
+
+    for (
+      const entry of protocol.primitives as unknown as {
+        id: string;
+        primitive: { name?: string; startBlockHeight?: number };
+      }[]
+    ) {
+      if (entry.primitive.startBlockHeight !== undefined) continue;
+      const primitiveName = entry.primitive.name ?? entry.id;
+      if (inheritable === undefined) {
+        throw new Error(
+          `[runtime] Cannot inherit startBlockHeight for primitive ` +
+            `"${primitiveName}": sync protocol "${protocolName}" has no ` +
+            `numeric start to inherit from, so the primitive must declare its ` +
+            `own startBlockHeight.`,
+        );
+      }
+      entry.primitive.startBlockHeight = inheritable;
+    }
   }
 }
 

--- a/packages/node-sdk/runtime/test/config-snapshot.unit.test.ts
+++ b/packages/node-sdk/runtime/test/config-snapshot.unit.test.ts
@@ -1,34 +1,116 @@
-import { expect, test, mock, beforeEach, afterEach } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { run } from "effection";
+import type { Operation } from "effection";
 import type { Client } from "pg";
 import { ConfigNetworkType, ConfigSyncProtocolType } from "@effectstream/config";
 import type { SyncProtocolWithNetwork } from "@effectstream/config";
 
 /**
  * In-memory backing store for the mocked `@effectstream/db` query objects.
- * `validateAndSnapshotConfig` only touches two queries — `get…Snapshot`
- * (returns rows) and `upsert…Snapshot` (writes) — so stubbing those two is
- * sufficient to exercise the comparison loop end-to-end without a real DB.
+ *
+ * `validateAndSnapshotConfig` touches three queries — `get…Snapshot`,
+ * `upsert…Snapshot` (INSERT … ON CONFLICT DO NOTHING) and `update…Snapshot`
+ * (the provenance backfill) — and drives BEGIN/COMMIT/ROLLBACK through the
+ * connection object itself. The stub therefore models a real transaction:
+ * writes land in a per-connection pending set and only reach `committed` on
+ * COMMIT, so "a crash before COMMIT persisted nothing" is observable.
  */
 type StoredRow = { networkType: ConfigNetworkType; immutable_config: unknown };
-let store: Record<string, StoredRow | undefined> = {};
+
+let committed: Record<string, StoredRow | undefined> = {};
+let pending: Map<unknown, Record<string, StoredRow>> = new Map();
+
+/**
+ * Every statement of a reconciliation, in issue order, together with the
+ * connection it was issued on. This recording IS the "one dedicated connection
+ * per reconciliation" assertion.
+ */
+type Statement = { connection: unknown; sql: string };
+let statements: Statement[] = [];
+/** Statements interleaved with start-policy callbacks, for ordering proofs. */
+let callOrder: string[] = [];
+
+/** Injectable race/fault hooks for the transaction tests. */
+let onBeforeInsert: (() => void) | undefined;
+let failReReadWith: Error | undefined;
+
+function record(connection: unknown, sql: string): void {
+  statements.push({ connection, sql });
+  callOrder.push(sql);
+}
+
+function readRow(
+  connection: unknown,
+  protocolName: string,
+): StoredRow | undefined {
+  return pending.get(connection)?.[protocolName] ?? committed[protocolName];
+}
+
+function writeRow(
+  connection: unknown,
+  protocolName: string,
+  row: StoredRow,
+): void {
+  const buffered = pending.get(connection);
+  if (buffered) buffered[protocolName] = row;
+  else committed[protocolName] = row;
+}
 
 mock.module("@effectstream/db", () => ({
+  /**
+   * Not used by any assertion here. `config-snapshot.ts` imports the default
+   * `startPolicyRegistry` from `@effectstream/sync`, whose barrel pulls in the
+   * per-chain `state.ts` modules, and every one of those imports `getPage` from
+   * `@effectstream/db`. A wholesale module mock must therefore also carry the
+   * transitive surface or the import graph fails to resolve.
+   */
+  getPage: { run: () => Promise.resolve([]) },
   getSyncProtocolConfigSnapshot: {
-    run: ({ protocolName }: { protocolName: string }) =>
-      Promise.resolve(store[protocolName] ? [store[protocolName]] : []),
+    run: ({ protocolName }: { protocolName: string }, connection: unknown) => {
+      record(connection, "SELECT");
+      const isReRead = statements.filter((s) => s.sql === "SELECT").length > 1;
+      if (failReReadWith && isReRead) return Promise.reject(failReReadWith);
+      const row = readRow(connection, protocolName);
+      return Promise.resolve(row ? [row] : []);
+    },
   },
   upsertSyncProtocolConfigSnapshot: {
-    run: ({
-      protocolName,
-      networkType,
-      immutableConfig,
-    }: {
-      protocolName: string;
-      networkType: ConfigNetworkType;
-      immutableConfig: string;
-    }) => {
-      store[protocolName] = { networkType, immutable_config: JSON.parse(immutableConfig) };
+    run: (
+      { protocolName, networkType, immutableConfig }: {
+        protocolName: string;
+        networkType: ConfigNetworkType;
+        immutableConfig: string;
+      },
+      connection: unknown,
+    ) => {
+      record(connection, "INSERT");
+      onBeforeInsert?.();
+      // ON CONFLICT (protocol_name) DO NOTHING
+      if (readRow(connection, protocolName) === undefined) {
+        writeRow(connection, protocolName, {
+          networkType,
+          immutable_config: JSON.parse(immutableConfig),
+        });
+      }
+      return Promise.resolve([]);
+    },
+  },
+  updateSyncProtocolConfigSnapshot: {
+    run: (
+      { protocolName, immutableConfig }: {
+        protocolName: string;
+        immutableConfig: string;
+      },
+      connection: unknown,
+    ) => {
+      record(connection, "UPDATE");
+      const existing = readRow(connection, protocolName);
+      if (existing !== undefined) {
+        writeRow(connection, protocolName, {
+          ...existing,
+          immutable_config: JSON.parse(immutableConfig),
+        });
+      }
       return Promise.resolve([]);
     },
   },
@@ -36,7 +118,90 @@ mock.module("@effectstream/db", () => ({
 
 const { validateAndSnapshotConfig } = await import("../src/config-snapshot.ts");
 
-const STUB_DB = {} as Client;
+/** A checked-out connection: the only object a reconciliation may talk to. */
+class StubClient {
+  released = false;
+  releaseError: unknown;
+  constructor(readonly pool: StubPool) {}
+  query(config: string | { text: string }): Promise<{ rows: unknown[] }> {
+    const sql = typeof config === "string" ? config : config.text;
+    record(this, sql);
+    if (sql === "BEGIN") pending.set(this, {});
+    if (sql === "COMMIT") {
+      for (const [name, row] of Object.entries(pending.get(this) ?? {})) {
+        committed[name] = row;
+      }
+      pending.delete(this);
+    }
+    if (sql === "ROLLBACK") pending.delete(this);
+    return Promise.resolve({ rows: [] });
+  }
+  release(error?: unknown): void {
+    this.released = true;
+    this.releaseError = error;
+    pending.delete(this);
+  }
+}
+
+/** `totalCount` is what marks a real `pg.Pool` apart from a dedicated client. */
+class StubPool {
+  totalCount = 0;
+  readonly clients: StubClient[] = [];
+  connect(): Promise<StubClient> {
+    const client = new StubClient(this);
+    this.clients.push(client);
+    return Promise.resolve(client);
+  }
+  query(config: string | { text: string }): Promise<{ rows: unknown[] }> {
+    // Any statement landing here is a pooled statement — i.e. NOT part of the
+    // dedicated-connection transaction. Recorded so tests can forbid it.
+    const sql = typeof config === "string" ? config : config.text;
+    record(this, `POOL:${sql}`);
+    return Promise.resolve({ rows: [] });
+  }
+}
+
+let pool: StubPool;
+
+type StartPolicySeams = { startPolicies?: Record<string, unknown> };
+
+const validate = validateAndSnapshotConfig as unknown as (
+  syncInfo: SyncProtocolWithNetwork[],
+  dbConn: Client,
+  seams?: StartPolicySeams,
+) => Operation<void>;
+
+async function runValidate(
+  protocols: SyncProtocolWithNetwork[],
+  seams?: StartPolicySeams,
+): Promise<void> {
+  await run(function* () {
+    yield* validate(protocols, pool as unknown as Client, seams);
+  });
+}
+
+function sqlOrder(): string[] {
+  return statements.map((statement) => statement.sql);
+}
+
+beforeEach(() => {
+  committed = {};
+  pending = new Map();
+  statements = [];
+  callOrder = [];
+  onBeforeInsert = undefined;
+  failReReadWith = undefined;
+  pool = new StubPool();
+  delete process.env.USE_DB_STARTHEIGHT;
+});
+
+afterEach(() => {
+  delete process.env.USE_DB_STARTHEIGHT;
+});
+
+// ---------------------------------------------------------------------------
+// Legacy coverage: the DEFAULT registry must keep today's Cardano semantics.
+// ---------------------------------------------------------------------------
 
 function cardanoUtxoRpcProtocol(
   startChainPoint: unknown,
@@ -49,27 +214,10 @@ function cardanoUtxoRpcProtocol(
   } as unknown as SyncProtocolWithNetwork;
 }
 
-async function runValidate(
-  protocols: SyncProtocolWithNetwork[],
-): Promise<void> {
-  await run(function* () {
-    yield* validateAndSnapshotConfig(protocols, STUB_DB);
-  });
-}
-
-beforeEach(() => {
-  store = {};
-  delete process.env.USE_DB_STARTHEIGHT;
-});
-
-afterEach(() => {
-  delete process.env.USE_DB_STARTHEIGHT;
-});
-
 test("first run persists the snapshot and succeeds", async () => {
   const protocol = cardanoUtxoRpcProtocol({ slot: 1, hash: "0xabc" });
   await expect(runValidate([protocol])).resolves.toBeUndefined();
-  expect(store["cardano-utxorpc"]?.immutable_config).toEqual({
+  expect(committed["cardano-utxorpc"]?.immutable_config).toEqual({
     startChainPoint: { slot: 1, hash: "0xabc" },
   });
 });
@@ -96,4 +244,412 @@ test("reports a clean mismatch (no TypeError) when a saved nested object has no 
   await expect(runValidate([drifted])).rejects.toThrow(
     /\[config-snapshot\] CRITICAL/,
   );
+});
+
+// ---------------------------------------------------------------------------
+// SC-001: the generic runtime drives an opaque, injected definition. Nothing
+// below names a real chain — that is the point of the oracle.
+// ---------------------------------------------------------------------------
+
+const FAKE_TYPE = "fake-protocol" as ConfigSyncProtocolType;
+const FAKE_NETWORK = "fake-network" as ConfigNetworkType;
+
+type SnapshotFields = Record<string, unknown>;
+type ResolvedStart = {
+  startBlockHeight: number;
+  provenance: "latest" | "explicit";
+};
+
+type FakePolicy = {
+  resolveLatest(entry: SyncProtocolWithNetwork): Promise<number>;
+  projectImmutable(
+    entry: SyncProtocolWithNetwork,
+    resolved: ResolvedStart,
+  ): { validated: SnapshotFields; restored: SnapshotFields };
+  applySnapshot(entry: SyncProtocolWithNetwork, snapshot: SnapshotFields): void;
+};
+
+function startOf(entry: SyncProtocolWithNetwork): number | "latest" {
+  return (entry.syncProtocol as unknown as {
+    startBlockHeight: number | "latest";
+  }).startBlockHeight;
+}
+
+function clockOf(entry: SyncProtocolWithNetwork): number {
+  return (entry.network as unknown as { clock: number }).clock;
+}
+
+/**
+ * A protocol definition with no chain behind it. `clock` stands in for any
+ * restored network field (NTP's startTime/blockTimeMS in production).
+ */
+function makeFakePolicy(tip: number): {
+  policy: FakePolicy;
+  state: { resolveCalls: number; applied: SnapshotFields[] };
+} {
+  const state = { resolveCalls: 0, applied: [] as SnapshotFields[] };
+  const policy: FakePolicy = {
+    resolveLatest(_entry) {
+      state.resolveCalls += 1;
+      callOrder.push("resolveLatest");
+      return Promise.resolve(tip);
+    },
+    projectImmutable(entry, resolved) {
+      const validated: SnapshotFields = {};
+      const restored: SnapshotFields = {
+        clock: clockOf(entry),
+        startBlockHeightProvenance: resolved.provenance,
+      };
+      if (startOf(entry) === "latest") {
+        restored["startBlockHeight"] = resolved.startBlockHeight;
+      } else {
+        validated["startBlockHeight"] = resolved.startBlockHeight;
+      }
+      return { validated, restored };
+    },
+    applySnapshot(entry, snapshot) {
+      callOrder.push("applySnapshot");
+      state.applied.push(snapshot);
+      if ("startBlockHeight" in snapshot) {
+        (entry.syncProtocol as unknown as { startBlockHeight: unknown })
+          .startBlockHeight = snapshot["startBlockHeight"];
+      }
+      if ("clock" in snapshot) {
+        (entry.network as unknown as { clock: unknown }).clock =
+          snapshot["clock"];
+      }
+    },
+  };
+  return { policy, state };
+}
+
+function fakeProtocol(
+  startBlockHeight: number | "latest",
+  clock = 100,
+  name = "fake",
+): SyncProtocolWithNetwork {
+  return {
+    networkType: FAKE_NETWORK,
+    syncProtocolType: FAKE_TYPE,
+    syncProtocol: { name, startBlockHeight },
+    network: { clock },
+    primitives: [],
+  } as unknown as SyncProtocolWithNetwork;
+}
+
+function seams(policy: FakePolicy): StartPolicySeams {
+  return { startPolicies: { [FAKE_TYPE]: policy } };
+}
+
+function seedRow(immutableConfig: SnapshotFields, name = "fake"): void {
+  committed[name] = {
+    networkType: FAKE_NETWORK,
+    immutable_config: immutableConfig,
+  };
+}
+
+describe("generic reconciliation over an injected start-policy definition", () => {
+  test('first run with "latest" resolves once and commits value + provenance', async () => {
+    const { policy, state } = makeFakePolicy(1_234);
+    const protocol = fakeProtocol("latest");
+
+    await runValidate([protocol], seams(policy));
+
+    expect(state.resolveCalls).toBe(1);
+    expect(committed["fake"]?.immutable_config).toEqual({
+      clock: 100,
+      startBlockHeightProvenance: "latest",
+      startBlockHeight: 1_234,
+    });
+    expect(startOf(protocol)).toBe(1_234);
+  });
+
+  test("the tip resolves before the transaction, and the commit precedes adoption", async () => {
+    const { policy } = makeFakePolicy(1_234);
+
+    await runValidate([fakeProtocol("latest")], seams(policy));
+
+    expect(sqlOrder()).toEqual([
+      "SELECT",
+      "BEGIN",
+      "INSERT",
+      "SELECT",
+      "COMMIT",
+    ]);
+    expect(callOrder.indexOf("resolveLatest")).toBeLessThan(
+      callOrder.indexOf("BEGIN"),
+    );
+    expect(callOrder.indexOf("COMMIT")).toBeLessThan(
+      callOrder.lastIndexOf("applySnapshot"),
+    );
+  });
+
+  test("an explicit numeric start is committed with explicit provenance and no tip query", async () => {
+    const { policy, state } = makeFakePolicy(1_234);
+    const protocol = fakeProtocol(7);
+
+    await runValidate([protocol], seams(policy));
+
+    expect(state.resolveCalls).toBe(0);
+    expect(committed["fake"]?.immutable_config).toEqual({
+      clock: 100,
+      startBlockHeightProvenance: "explicit",
+      startBlockHeight: 7,
+    });
+    expect(startOf(protocol)).toBe(7);
+  });
+
+  test("a restart reuses the committed boundary and never queries a tip", async () => {
+    seedRow({
+      clock: 100,
+      startBlockHeight: 1_234,
+      startBlockHeightProvenance: "latest",
+    });
+    const { policy, state } = makeFakePolicy(9_999);
+    // A rebuilt config re-samples its network field and still asks for "latest".
+    const protocol = fakeProtocol("latest", 999);
+
+    await runValidate([protocol], seams(policy));
+
+    expect(state.resolveCalls).toBe(0);
+    expect(startOf(protocol)).toBe(1_234);
+    expect(clockOf(protocol)).toBe(100);
+    // No writes: nothing to backfill, nothing to insert.
+    expect(sqlOrder()).toEqual(["SELECT"]);
+  });
+
+  test("a legacy row without provenance is backfilled to explicit inside one transaction", async () => {
+    seedRow({ clock: 100, startBlockHeight: 55 });
+    const { policy } = makeFakePolicy(1_234);
+    const protocol = fakeProtocol(55);
+
+    await runValidate([protocol], seams(policy));
+
+    expect(committed["fake"]?.immutable_config).toEqual({
+      clock: 100,
+      startBlockHeight: 55,
+      startBlockHeightProvenance: "explicit",
+    });
+    expect(sqlOrder()).toEqual(["SELECT", "BEGIN", "UPDATE", "COMMIT"]);
+    expect(startOf(protocol)).toBe(55);
+  });
+
+  test("a row that already carries provenance is not rewritten", async () => {
+    seedRow({
+      clock: 100,
+      startBlockHeight: 55,
+      startBlockHeightProvenance: "latest",
+    });
+    const { policy } = makeFakePolicy(1_234);
+
+    await runValidate([fakeProtocol("latest")], seams(policy));
+
+    expect(sqlOrder()).toEqual(["SELECT"]);
+  });
+
+  test("a lost first-insert race adopts the committed row, not the local observation", async () => {
+    const { policy, state } = makeFakePolicy(1_234);
+    const protocol = fakeProtocol("latest");
+    onBeforeInsert = () => {
+      // Another process committed first, between our read and our insert.
+      seedRow({
+        clock: 100,
+        startBlockHeight: 900,
+        startBlockHeightProvenance: "latest",
+      });
+    };
+
+    await runValidate([protocol], seams(policy));
+
+    expect(committed["fake"]?.immutable_config).toEqual({
+      clock: 100,
+      startBlockHeight: 900,
+      startBlockHeightProvenance: "latest",
+    });
+    expect(startOf(protocol)).toBe(900);
+    expect(state.applied.at(-1)).toEqual({
+      clock: 100,
+      startBlockHeight: 900,
+      startBlockHeightProvenance: "latest",
+    });
+  });
+
+  test("a failure before COMMIT rolls back and persists nothing", async () => {
+    const { policy } = makeFakePolicy(1_234);
+    failReReadWith = new Error("re-read exploded");
+
+    await expect(
+      runValidate([fakeProtocol("latest")], seams(policy)),
+    ).rejects.toThrow(/re-read exploded/);
+
+    expect(sqlOrder()).toEqual([
+      "SELECT",
+      "BEGIN",
+      "INSERT",
+      "SELECT",
+      "ROLLBACK",
+    ]);
+    expect(committed["fake"]).toBeUndefined();
+    expect(pool.clients[0].released).toBe(true);
+  });
+
+  test("every statement of one reconciliation runs on one checked-out client", async () => {
+    const { policy } = makeFakePolicy(1_234);
+
+    await runValidate([fakeProtocol("latest")], seams(policy));
+
+    expect(pool.clients).toHaveLength(1);
+    const client = pool.clients[0];
+    expect(statements.length).toBeGreaterThan(0);
+    for (const statement of statements) {
+      expect(statement.connection).toBe(client);
+    }
+    expect(sqlOrder().some((sql) => sql.startsWith("POOL:"))).toBe(false);
+    expect(client.released).toBe(true);
+  });
+
+  test("each protocol gets its own dedicated connection", async () => {
+    const { policy } = makeFakePolicy(1_234);
+
+    await runValidate(
+      [fakeProtocol("latest", 100, "first"), fakeProtocol(3, 100, "second")],
+      seams(policy),
+    );
+
+    expect(pool.clients).toHaveLength(2);
+    expect(pool.clients.every((client) => client.released)).toBe(true);
+    expect(committed["first"]).toBeDefined();
+    expect(committed["second"]).toBeDefined();
+  });
+
+  test("a sync protocol type with no definition is rejected", async () => {
+    const orphan = {
+      networkType: FAKE_NETWORK,
+      syncProtocolType: "unregistered-protocol",
+      syncProtocol: { name: "orphan", startBlockHeight: 1 },
+      network: {},
+      primitives: [],
+    } as unknown as SyncProtocolWithNetwork;
+
+    await expect(runValidate([orphan], { startPolicies: {} })).rejects.toThrow(
+      /Unknown start policy[\s\S]*unregistered-protocol/,
+    );
+  });
+});
+
+describe("validated versus restored fields on the restart path", () => {
+  test("a validated mismatch still aborts startup with the CRITICAL error", async () => {
+    seedRow({
+      clock: 100,
+      startBlockHeight: 5,
+      startBlockHeightProvenance: "explicit",
+    });
+    const { policy } = makeFakePolicy(1_234);
+
+    await expect(runValidate([fakeProtocol(9)], seams(policy))).rejects
+      .toThrow(/\[config-snapshot\] CRITICAL/);
+  });
+
+  test("USE_DB_STARTHEIGHT downgrades a validated mismatch to saved-wins", async () => {
+    seedRow({
+      clock: 100,
+      startBlockHeight: 5,
+      startBlockHeightProvenance: "explicit",
+    });
+    process.env.USE_DB_STARTHEIGHT = "1";
+    const { policy } = makeFakePolicy(1_234);
+    const protocol = fakeProtocol(9);
+
+    await expect(runValidate([protocol], seams(policy))).resolves
+      .toBeUndefined();
+    expect(startOf(protocol)).toBe(5);
+  });
+
+  test("a restored difference is adopted without throwing", async () => {
+    seedRow({
+      clock: 100,
+      startBlockHeight: 5,
+      startBlockHeightProvenance: "explicit",
+    });
+    const { policy } = makeFakePolicy(1_234);
+    // Same explicit start, but the restored network field was re-sampled.
+    const protocol = fakeProtocol(5, 777);
+
+    await expect(runValidate([protocol], seams(policy))).resolves
+      .toBeUndefined();
+    expect(clockOf(protocol)).toBe(100);
+    expect(startOf(protocol)).toBe(5);
+  });
+
+  test('a configured "latest" is never a mismatch against a saved numeric start', async () => {
+    seedRow({
+      clock: 100,
+      startBlockHeight: 42,
+      startBlockHeightProvenance: "latest",
+    });
+    const { policy, state } = makeFakePolicy(1_234);
+    const protocol = fakeProtocol("latest");
+
+    await expect(runValidate([protocol], seams(policy))).resolves
+      .toBeUndefined();
+    expect(startOf(protocol)).toBe(42);
+    expect(state.resolveCalls).toBe(0);
+  });
+
+  test("a saved key the definition never projects is ignored (legacy tolerance)", async () => {
+    seedRow({
+      clock: 100,
+      startBlockHeight: 5,
+      startBlockHeightProvenance: "explicit",
+      retiredField: "who-knows",
+    });
+    const { policy } = makeFakePolicy(1_234);
+
+    await expect(runValidate([fakeProtocol(5)], seams(policy))).resolves
+      .toBeUndefined();
+  });
+
+  test("reconciliation always leaves a numeric start in memory", async () => {
+    const { policy } = makeFakePolicy(2_468);
+    const protocol = fakeProtocol("latest");
+
+    await runValidate([protocol], seams(policy));
+
+    expect(typeof startOf(protocol)).toBe("number");
+  });
+
+  // Delivery-audit finding F1 (MAJOR). A snapshot written before this feature
+  // can lack `startBlockHeight` entirely — every pre-00034 NTP row held only
+  // {startTime, blockTimeMS}. On the restart path nothing can supply it: the
+  // provenance backfill is skipped (it requires a numeric saved start),
+  // `resolveLatest` is unreachable by design, the NaN projection is excluded
+  // from difference reporting, and `applySnapshot` has no key to write. The
+  // sentinel would otherwise survive into `genSyncProtocols` as a string.
+  test('a legacy row with no saved boundary plus a configured "latest" fails loud', async () => {
+    seedRow({ clock: 100 });
+    const { policy, state } = makeFakePolicy(1_234);
+    const protocol = fakeProtocol("latest");
+
+    await expect(runValidate([protocol], seams(policy))).rejects.toThrow(
+      /\[config-snapshot\] CRITICAL[\s\S]*non-numeric startBlockHeight/,
+    );
+    // It fails loud rather than quietly reaching for a live tip.
+    expect(state.resolveCalls).toBe(0);
+    expect(sqlOrder()).toEqual(["SELECT"]);
+    // …and the dedicated connection is still handed back.
+    expect(pool.clients[0].released).toBe(true);
+  });
+
+  test("the same legacy row is fine when the configured start is explicit", async () => {
+    // The guard must not over-trigger: an explicit numeric start needs nothing
+    // from the snapshot, so a row that predates the key is still usable. (This
+    // is the single-file facade's NTP clock, pinned to an explicit start.)
+    seedRow({ clock: 100 });
+    const { policy } = makeFakePolicy(1_234);
+    const protocol = fakeProtocol(6);
+
+    await expect(runValidate([protocol], seams(policy))).resolves
+      .toBeUndefined();
+    expect(startOf(protocol)).toBe(6);
+  });
 });

--- a/packages/node-sdk/runtime/test/primitive-start-inheritance.unit.test.ts
+++ b/packages/node-sdk/runtime/test/primitive-start-inheritance.unit.test.ts
@@ -1,0 +1,104 @@
+// FR-007: a primitive that omits `startBlockHeight` inherits its owning
+// protocol's committed numeric start; an explicit primitive value always wins.
+//
+// Inheritance is generic — it works for every protocol precisely because
+// `validateAndSnapshotConfig` has already committed a numeric boundary by the
+// time primitives are constructed (the startup reordering in D4).
+
+import { describe, expect, test } from "bun:test";
+import { ConfigNetworkType, ConfigSyncProtocolType } from "@effectstream/config";
+import type { SyncProtocolWithNetwork } from "@effectstream/config";
+import { inheritPrimitiveStartHeights } from "../src/main.ts";
+
+function protocolWith(
+  startBlockHeight: number | undefined,
+  primitives: Record<string, unknown>[],
+): SyncProtocolWithNetwork {
+  return {
+    networkType: ConfigNetworkType.MIDNIGHT,
+    syncProtocolType: ConfigSyncProtocolType.MIDNIGHT_PARALLEL,
+    syncProtocol: {
+      name: "midnight",
+      type: ConfigSyncProtocolType.MIDNIGHT_PARALLEL,
+      indexer: "https://indexer.example/graphql",
+      ...(startBlockHeight === undefined ? {} : { startBlockHeight }),
+    },
+    network: { name: "midnight", type: ConfigNetworkType.MIDNIGHT },
+    primitives: primitives.map((primitive, index) => ({
+      id: `primitive-${index}`,
+      syncProtocol: "midnight",
+      primitive,
+    })),
+  } as unknown as SyncProtocolWithNetwork;
+}
+
+function startsOf(protocol: SyncProtocolWithNetwork): (number | undefined)[] {
+  return (protocol.primitives as unknown as {
+    primitive: { startBlockHeight?: number };
+  }[]).map((entry) => entry.primitive.startBlockHeight);
+}
+
+describe("inheritPrimitiveStartHeights", () => {
+  test("fills an omitted primitive start from the protocol's committed value", () => {
+    const protocol = protocolWith(4_242, [
+      { name: "round", type: "Midnight:Generic" },
+    ]);
+
+    inheritPrimitiveStartHeights([protocol]);
+
+    expect(startsOf(protocol)).toEqual([4_242]);
+  });
+
+  test("an explicit primitive start always wins", () => {
+    const protocol = protocolWith(4_242, [
+      { name: "round", type: "Midnight:Generic", startBlockHeight: 17 },
+    ]);
+
+    inheritPrimitiveStartHeights([protocol]);
+
+    expect(startsOf(protocol)).toEqual([17]);
+  });
+
+  test("a primitive start of 0 is explicit, not missing", () => {
+    const protocol = protocolWith(4_242, [
+      { name: "round", type: "Midnight:Generic", startBlockHeight: 0 },
+    ]);
+
+    inheritPrimitiveStartHeights([protocol]);
+
+    expect(startsOf(protocol)).toEqual([0]);
+  });
+
+  test("mixed primitives inherit independently", () => {
+    const protocol = protocolWith(900, [
+      { name: "a", type: "Midnight:Generic" },
+      { name: "b", type: "Midnight:Generic", startBlockHeight: 5 },
+      { name: "c", type: "Midnight:Generic" },
+    ]);
+
+    inheritPrimitiveStartHeights([protocol]);
+
+    expect(startsOf(protocol)).toEqual([900, 5, 900]);
+  });
+
+  test("a protocol with no numeric start leaves an explicit primitive alone", () => {
+    // Cardano-style protocols start from a slot, not a block height.
+    const protocol = protocolWith(undefined, [
+      { name: "round", type: "Midnight:Generic", startBlockHeight: 11 },
+    ]);
+
+    inheritPrimitiveStartHeights([protocol]);
+
+    expect(startsOf(protocol)).toEqual([11]);
+  });
+
+  test("a primitive with nothing to inherit is a clear configuration error", () => {
+    const protocol = protocolWith(undefined, [
+      { name: "round", type: "Midnight:Generic" },
+    ]);
+
+    expect(() => inheritPrimitiveStartHeights([protocol])).toThrow(
+      /startBlockHeight[\s\S]*round/,
+    );
+  });
+});

--- a/packages/node-sdk/runtime/test/reproduction/harness.ts
+++ b/packages/node-sdk/runtime/test/reproduction/harness.ts
@@ -325,6 +325,15 @@ export type RunToHeightOpts = {
   /** Enable/disable empty-block coalescing. */
   coalesce?: boolean;
   /**
+   * Exit as soon as `startup()` has completed (the `dev.onStarted` callback),
+   * without waiting for any finalized height. Used by tests whose subject is
+   * startup itself — config reconciliation, snapshot persistence, primitive
+   * construction — rather than block production. `target`/`tips` are then
+   * irrelevant, but a genuine subprocess still boots the real runtime against
+   * the real database, so a "restart" is still a real restart.
+   */
+  bootOnly?: boolean;
+  /**
    * Full ConfigBuilder output, for tests that need protocols the default
    * scenario doesn't provide. When omitted the node-runner builds the standard
    * two-protocol scenario from `events`/`parallelStepSize`.
@@ -359,6 +368,7 @@ function makeRunToHeight(
       apiPort: opts.apiPort,
       waitPages: opts.waitPages,
       coalesce: opts.coalesce,
+      bootOnly: opts.bootOnly,
       // Forwarded so a caller can supply its own protocols; node-runner already
       // prefers `spec.config` over the default scenario.
       config: opts.config,

--- a/packages/node-sdk/runtime/test/reproduction/node-runner.ts
+++ b/packages/node-sdk/runtime/test/reproduction/node-runner.ts
@@ -49,6 +49,13 @@ export type RunSpec = {
    */
   waitPages?: Record<string, number>;
   coalesce?: boolean;
+  /**
+   * Exit as soon as `startup()` finished (`dev.onStarted`), skipping every
+   * height/page wait. For tests whose subject is startup itself — config
+   * reconciliation, snapshot persistence, primitive construction — where block
+   * production is beside the point but a genuine subprocess boot is not.
+   */
+  bootOnly?: boolean;
 };
 
 const noopStf: StartConfigGameStateTransitions = function* () {};
@@ -128,10 +135,12 @@ async function main() {
   }
 
   try {
-    await guard(waitForHeight(pool, spec.target));
-    await guard(waitUntilStable(pool));
-    for (const [name, page] of Object.entries(spec.waitPages ?? {})) {
-      await guard(waitForPage(pool, name, page));
+    if (!spec.bootOnly) {
+      await guard(waitForHeight(pool, spec.target));
+      await guard(waitUntilStable(pool));
+      for (const [name, page] of Object.entries(spec.waitPages ?? {})) {
+        await guard(waitForPage(pool, name, page));
+      }
     }
   } catch (e) {
     const probe = live.map((p) =>

--- a/packages/node-sdk/runtime/test/reproduction/start-policy.test.ts
+++ b/packages/node-sdk/runtime/test/reproduction/start-policy.test.ts
@@ -1,0 +1,268 @@
+/**
+ * Durable end-to-end oracle for the protocol-owned start policy (project
+ * 00034, spec SC-002 and the crash/restart edge cases).
+ *
+ * Everything below happens across GENUINE subprocess boots of the real runtime
+ * against one surviving database, which is the production restart condition:
+ * the in-memory config is rebuilt from scratch every time, only what was
+ * committed survives.
+ *
+ *  1. First boot with `startBlockHeight: "latest"` queries the indexer's tip
+ *     EXACTLY ONCE and commits the numeric boundary plus provenance `"latest"`.
+ *  2. A restart — with the fixture now reporting a completely different tip —
+ *     performs ZERO tip queries and reuses the committed boundary.
+ *  3. A legacy row seeded WITHOUT provenance (what a pre-00034 database holds)
+ *     is backfilled to `"explicit"` on the next boot, with its value untouched.
+ *
+ * The counted fixture is a real HTTP indexer: the start policy's tip request is
+ * the exact one-line `query { block { height } }` that `getMidnightTip` sends,
+ * which is byte-distinct from every query `MidnightClient` issues, so tip
+ * resolutions can be counted without counting ordinary sync traffic.
+ */
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import {
+  ConfigBuilder,
+  ConfigNetworkType,
+  ConfigSyncProtocolType,
+} from "@effectstream/config";
+import { type Harness, setupHarness } from "./harness.ts";
+import { BLOCK_TIME_MS, START_TIME } from "./scenario.ts";
+
+/** The exact request `getMidnightTip` sends — nothing else in the tree does. */
+const START_POLICY_TIP_QUERY = "query { block { height } }";
+
+const MIDNIGHT_PROTOCOL = "midnightP";
+const CLOCK_PROTOCOL = "mainClock";
+
+type Fixture = {
+  url: string;
+  /** Tip queries issued by the START POLICY (the thing under test). */
+  tipHits: number;
+  /** Everything else the node asked the indexer (ordinary sync traffic). */
+  otherHits: number;
+  /** Height the fixture currently reports as the chain tip. */
+  height: number;
+  stop: () => Promise<void>;
+};
+
+/**
+ * A counted stand-in for a Midnight indexer.
+ *
+ * The start policy's tip query gets `height`. Every OTHER query — notably
+ * `MidnightClient.fetchLatestBlock`, which the sync state calls once it starts
+ * — deliberately gets `height - 1`. That is exactly the boundary at which
+ * `MidnightSyncState.stateToInput` decides it has nothing to fetch, so the sync
+ * loop idles instead of pulling blocks this test does not care about. The
+ * asymmetry is a fixture convenience only; it cannot influence reconciliation,
+ * which runs to completion before any sync state exists.
+ */
+async function startIndexerFixture(height: number): Promise<Fixture> {
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt < 50; attempt++) {
+    try {
+      let fixture!: Fixture;
+      const server = Bun.serve({
+        hostname: "127.0.0.1",
+        port: 0,
+        async fetch(request) {
+          const body = await request.json().catch(() => ({})) as {
+            query?: unknown;
+          };
+          if (body.query === START_POLICY_TIP_QUERY) {
+            fixture.tipHits++;
+            return Response.json({ data: { block: { height: fixture.height } } });
+          }
+          fixture.otherHits++;
+          return Response.json({
+            data: { block: { height: Math.max(fixture.height - 1, 0) } },
+          });
+        },
+      });
+      // Workspace rule: fixtures bind ports above 10000 only.
+      if (server.port <= 10_000) {
+        await server.stop(true);
+        continue;
+      }
+
+      fixture = {
+        url: `http://127.0.0.1:${server.port}/api/v4/graphql`,
+        tipHits: 0,
+        otherHits: 0,
+        height,
+        stop: () => server.stop(true).then(() => undefined),
+      };
+      return fixture;
+    } catch (error) {
+      lastError = error;
+    }
+  }
+
+  throw lastError ??
+    new Error("Unable to allocate a loopback fixture port above 10000");
+}
+
+/**
+ * One TEST main clock with an EXPLICIT numeric start (the legacy-backfill
+ * subject) plus one Midnight parallel protocol asking for `"latest"` (the
+ * resolve-once subject). No primitives: this scenario is about startup
+ * reconciliation, not block production.
+ */
+function buildLatestStartConfig(indexer: string) {
+  return new ConfigBuilder()
+    .setNamespace((b) => b.setSecurityNamespace("sync-repro-start-policy"))
+    .buildNetworks((b) =>
+      b
+        .addNetwork({
+          name: "clock",
+          type: ConfigNetworkType.TEST,
+          startTime: START_TIME,
+          blockTimeMS: BLOCK_TIME_MS,
+        })
+        .addNetwork({
+          type: ConfigNetworkType.MIDNIGHT,
+          networkId: "stagenet",
+        })
+    )
+    .buildDeployments((b) => b)
+    .buildSyncProtocols((b) =>
+      b
+        .addMain(
+          (n) => n.clock,
+          () => ({
+            name: CLOCK_PROTOCOL,
+            type: ConfigSyncProtocolType.TEST_MAIN,
+            startBlockHeight: 1,
+            pollingInterval: 30,
+            stepSize: 1000,
+          }),
+        )
+        .addParallel(
+          (n) => (n as any).midnight,
+          () => ({
+            name: MIDNIGHT_PROTOCOL,
+            type: ConfigSyncProtocolType.MIDNIGHT_PARALLEL,
+            indexer,
+            startBlockHeight: "latest",
+            pollingInterval: 30,
+            delayMs: 0,
+          }),
+        )
+    )
+    .buildPrimitives((b) => b)
+    .build();
+}
+
+async function snapshotOf(
+  harness: Harness,
+  protocolName: string,
+): Promise<Record<string, unknown> | undefined> {
+  const result = await harness.pool.query<{ immutable_config: unknown }>(
+    `SELECT immutable_config
+       FROM effectstream.sync_protocol_config_snapshot
+      WHERE protocol_name = $1`,
+    [protocolName],
+  );
+  const value = result.rows[0]?.immutable_config;
+  if (typeof value === "string") return JSON.parse(value);
+  return value as Record<string, unknown> | undefined;
+}
+
+let h: Harness;
+let fixture: Fixture;
+
+beforeAll(async () => {
+  h = await setupHarness();
+  fixture = await startIndexerFixture(9_001);
+});
+
+afterAll(async () => {
+  await fixture?.stop();
+  await h?.teardown();
+});
+
+test(
+  'a "latest" start resolves once, survives a real restart, and backfills legacy rows',
+  async () => {
+    const config = buildLatestStartConfig(fixture.url);
+
+    // ── Boot 1: first run ────────────────────────────────────────────────
+    await h.runToHeight({
+      config,
+      tips: { [CLOCK_PROTOCOL]: 50 },
+      target: 0,
+      apiPort: 19171,
+      bootOnly: true,
+    });
+
+    // Resolved exactly once, and the numeric boundary + provenance are durable
+    // by the time startup() returned (spec Acceptance 1).
+    expect(fixture.tipHits).toBe(1);
+    expect(await snapshotOf(h, MIDNIGHT_PROTOCOL)).toMatchObject({
+      startBlockHeight: 9_001,
+      startBlockHeightProvenance: "latest",
+    });
+
+    // The explicit-start main clock committed its own boundary with `explicit`
+    // provenance, through the same generic path and with no tip query at all.
+    expect(await snapshotOf(h, CLOCK_PROTOCOL)).toMatchObject({
+      startBlockHeight: 1,
+      startBlockHeightProvenance: "explicit",
+      startTime: START_TIME,
+      blockTimeMS: BLOCK_TIME_MS,
+    });
+
+    // ── Boot 2: genuine restart, moving tip ──────────────────────────────
+    // The chain has moved on. A node that re-queried would start from 12345
+    // and silently skip everything in between — the bug this project removes.
+    fixture.height = 12_345;
+    const hitsBeforeRestart = fixture.tipHits;
+
+    await h.runToHeight({
+      config: buildLatestStartConfig(fixture.url),
+      tips: { [CLOCK_PROTOCOL]: 50 },
+      target: 0,
+      apiPort: 19172,
+      bootOnly: true,
+    });
+
+    // Zero tip queries on the restart path, and the committed boundary wins
+    // (spec Acceptance 2).
+    expect(fixture.tipHits).toBe(hitsBeforeRestart);
+    expect(await snapshotOf(h, MIDNIGHT_PROTOCOL)).toMatchObject({
+      startBlockHeight: 9_001,
+      startBlockHeightProvenance: "latest",
+    });
+
+    // ── Boot 3: legacy row without provenance ────────────────────────────
+    // Exactly what a pre-00034 database holds: a numeric start, no provenance.
+    await h.pool.query(
+      `UPDATE effectstream.sync_protocol_config_snapshot
+          SET immutable_config = immutable_config - 'startBlockHeightProvenance'
+        WHERE protocol_name = $1`,
+      [CLOCK_PROTOCOL],
+    );
+    const legacy = await snapshotOf(h, CLOCK_PROTOCOL);
+    expect(legacy).toBeDefined();
+    expect("startBlockHeightProvenance" in legacy!).toBe(false);
+    expect(legacy!["startBlockHeight"]).toBe(1);
+
+    await h.runToHeight({
+      config: buildLatestStartConfig(fixture.url),
+      tips: { [CLOCK_PROTOCOL]: 50 },
+      target: 0,
+      apiPort: 19173,
+      bootOnly: true,
+    });
+
+    // Backfilled to `explicit`, value untouched, and still no tip query.
+    expect(await snapshotOf(h, CLOCK_PROTOCOL)).toMatchObject({
+      startBlockHeight: 1,
+      startBlockHeightProvenance: "explicit",
+      startTime: START_TIME,
+      blockTimeMS: BLOCK_TIME_MS,
+    });
+    expect(fixture.tipHits).toBe(hitsBeforeRestart);
+  },
+  180_000,
+);

--- a/packages/node-sdk/sync/src/sync-protocols/midnight/start-policy.ts
+++ b/packages/node-sdk/sync/src/sync-protocols/midnight/start-policy.ts
@@ -1,0 +1,68 @@
+import type { SyncProtocolWithNetwork } from "@effectstream/config";
+import { getMidnightTip } from "./tip.ts";
+import type {
+  ResolvedStart,
+  StartPolicyProjection,
+  StartPolicySnapshotFields,
+  SyncProtocolStartPolicy,
+} from "../start-policy.ts";
+
+// Only types are imported from `../start-policy.ts`: that module imports this
+// one to build the registry, so a value import would close a runtime cycle.
+const PROVENANCE_KEY = "startBlockHeightProvenance";
+
+type MidnightProtocol = {
+  indexer: string;
+  startBlockHeight: number | "latest";
+  requestTimeoutMs?: number;
+};
+
+/**
+ * Start policy for the Midnight parallel protocol.
+ *
+ * The indexer URL is already materialized on the protocol config by the config
+ * builder, so the definition uses it verbatim — it never derives an endpoint
+ * from a network id. Each protocol entry resolves its own boundary: there is
+ * deliberately no cross-entry dedupe, because every protocol persists its own
+ * durable first boundary anyway.
+ */
+export const midnightStartPolicy: SyncProtocolStartPolicy = {
+  async resolveLatest(entry: SyncProtocolWithNetwork): Promise<number> {
+    const syncProtocol = entry.syncProtocol as unknown as MidnightProtocol;
+    const { height } = await getMidnightTip({
+      indexer: syncProtocol.indexer,
+      ...(syncProtocol.requestTimeoutMs !== undefined
+        ? { requestTimeoutMs: syncProtocol.requestTimeoutMs }
+        : {}),
+    });
+    return height;
+  },
+
+  projectImmutable(
+    entry: SyncProtocolWithNetwork,
+    resolved: ResolvedStart,
+  ): StartPolicyProjection {
+    const syncProtocol = entry.syncProtocol as unknown as MidnightProtocol;
+    const validated: StartPolicySnapshotFields = {};
+    const restored: StartPolicySnapshotFields = {
+      [PROVENANCE_KEY]: resolved.provenance,
+    };
+    if (syncProtocol.startBlockHeight === "latest") {
+      restored["startBlockHeight"] = resolved.startBlockHeight;
+    } else {
+      validated["startBlockHeight"] = resolved.startBlockHeight;
+    }
+    return { validated, restored };
+  },
+
+  applySnapshot(
+    entry: SyncProtocolWithNetwork,
+    snapshot: StartPolicySnapshotFields,
+  ): void {
+    if ("startBlockHeight" in snapshot) {
+      (entry.syncProtocol as unknown as Record<string, unknown>)[
+        "startBlockHeight"
+      ] = snapshot["startBlockHeight"];
+    }
+  },
+};

--- a/packages/node-sdk/sync/src/sync-protocols/mod.ts
+++ b/packages/node-sdk/sync/src/sync-protocols/mod.ts
@@ -4,6 +4,7 @@ export * from "./evm/state.ts";
 export * from "./midnight/fetcher.ts";
 export * from "./midnight/state.ts";
 export * from "./midnight/tip.ts";
+export { midnightStartPolicy } from "./midnight/start-policy.ts";
 
 export * from "./avail/fetcher.ts";
 export * from "./avail/state.ts";
@@ -15,6 +16,23 @@ export * from "./ntp/fetcher.ts";
 export * from "./ntp/state.ts";
 export { getNtpTip, NtpTipError } from "./ntp/tip.ts";
 export type { GetNtpTipOptions, NtpTip, NtpTipErrorCode } from "./ntp/tip.ts";
+export { ntpStartPolicy } from "./ntp/start-policy.ts";
+
+// Protocol-owned start policies. The generic runtime imports exactly the
+// registry — never a per-chain hook (FR-004).
+export {
+  configuredStartIsLatest,
+  numericStartPolicy,
+  rejectLatest,
+  START_BLOCK_HEIGHT_PROVENANCE,
+  startPolicyRegistry,
+} from "./start-policy.ts";
+export type {
+  ResolvedStart,
+  StartPolicyProjection,
+  StartPolicySnapshotFields,
+  SyncProtocolStartPolicy,
+} from "./start-policy.ts";
 
 export * from "./utxorpc/fetcher.ts";
 export * from "./utxorpc/state.ts";

--- a/packages/node-sdk/sync/src/sync-protocols/ntp/start-policy.ts
+++ b/packages/node-sdk/sync/src/sync-protocols/ntp/start-policy.ts
@@ -1,0 +1,86 @@
+import type { SyncProtocolWithNetwork } from "@effectstream/config";
+import { getNtpTip } from "./tip.ts";
+import type {
+  ResolvedStart,
+  StartPolicyProjection,
+  StartPolicySnapshotFields,
+  SyncProtocolStartPolicy,
+} from "../start-policy.ts";
+
+// Only types are imported from `../start-policy.ts`: that module imports this
+// one to build the registry, so a value import would close a runtime cycle.
+const PROVENANCE_KEY = "startBlockHeightProvenance";
+
+type NtpNetwork = {
+  startTime: number;
+  blockTimeMS: number;
+  servers?: readonly string[];
+};
+
+type NtpProtocol = {
+  startBlockHeight: number | "latest";
+  requestTimeoutMs?: number;
+};
+
+/**
+ * Start policy for the NTP main protocol.
+ *
+ * NTP blocks are pure arithmetic over `network.startTime` and
+ * `network.blockTimeMS`, so those two fields are **restored** rather than
+ * mismatch-checked: `startTime` defaults to `Date.now()` sampled at
+ * `addNetwork`, so a rebuilt config differs on every single boot, and the saved
+ * mapping must win or previously synced blocks would be remapped in time.
+ * (Consequence, accepted by design: an intentionally changed explicit
+ * `startTime` is adopted with a warning instead of aborting startup.)
+ */
+export const ntpStartPolicy: SyncProtocolStartPolicy = {
+  async resolveLatest(entry: SyncProtocolWithNetwork): Promise<number> {
+    const network = entry.network as unknown as NtpNetwork;
+    const syncProtocol = entry.syncProtocol as unknown as NtpProtocol;
+    const { height } = await getNtpTip({
+      startTime: network.startTime,
+      blockTimeMS: network.blockTimeMS,
+      ...(network.servers !== undefined ? { servers: network.servers } : {}),
+      ...(syncProtocol.requestTimeoutMs !== undefined
+        ? { requestTimeoutMs: syncProtocol.requestTimeoutMs }
+        : {}),
+    });
+    return height;
+  },
+
+  projectImmutable(
+    entry: SyncProtocolWithNetwork,
+    resolved: ResolvedStart,
+  ): StartPolicyProjection {
+    const network = entry.network as unknown as NtpNetwork;
+    const syncProtocol = entry.syncProtocol as unknown as NtpProtocol;
+    const validated: StartPolicySnapshotFields = {};
+    const restored: StartPolicySnapshotFields = {
+      startTime: network.startTime,
+      blockTimeMS: network.blockTimeMS,
+      [PROVENANCE_KEY]: resolved.provenance,
+    };
+    if (syncProtocol.startBlockHeight === "latest") {
+      restored["startBlockHeight"] = resolved.startBlockHeight;
+    } else {
+      validated["startBlockHeight"] = resolved.startBlockHeight;
+    }
+    return { validated, restored };
+  },
+
+  applySnapshot(
+    entry: SyncProtocolWithNetwork,
+    snapshot: StartPolicySnapshotFields,
+  ): void {
+    const network = entry.network as unknown as Record<string, unknown>;
+    if ("startTime" in snapshot) network["startTime"] = snapshot["startTime"];
+    if ("blockTimeMS" in snapshot) {
+      network["blockTimeMS"] = snapshot["blockTimeMS"];
+    }
+    if ("startBlockHeight" in snapshot) {
+      (entry.syncProtocol as unknown as Record<string, unknown>)[
+        "startBlockHeight"
+      ] = snapshot["startBlockHeight"];
+    }
+  },
+};

--- a/packages/node-sdk/sync/src/sync-protocols/start-policy.ts
+++ b/packages/node-sdk/sync/src/sync-protocols/start-policy.ts
@@ -1,0 +1,215 @@
+import { ConfigSyncProtocolType } from "@effectstream/config";
+import type { SyncProtocolWithNetwork } from "@effectstream/config";
+import { midnightStartPolicy } from "./midnight/start-policy.ts";
+import { ntpStartPolicy } from "./ntp/start-policy.ts";
+
+/**
+ * Protocol-owned start policies.
+ *
+ * The generic runtime (`@effectstream/runtime` `config-snapshot.ts`) knows only
+ * this interface: it picks one definition by `syncProtocolType`, asks it to
+ * resolve `"latest"` at most once, persists what the definition projects, and
+ * hands a saved snapshot back to the definition on every later boot. Start
+ * behaviour therefore lives beside each sync implementation instead of inside
+ * the runtime's persistence code.
+ */
+
+/** One protocol's contribution to the durable snapshot, flattened into JSONB. */
+export type StartPolicySnapshotFields = Record<string, unknown>;
+
+/** Key the block-height protocols persist next to their numeric boundary. */
+export const START_BLOCK_HEIGHT_PROVENANCE = "startBlockHeightProvenance";
+
+/** The numeric first boundary a protocol starts from, and how it was obtained. */
+export type ResolvedStart = {
+  startBlockHeight: number;
+  provenance: "latest" | "explicit";
+};
+
+/**
+ * The two groups the runtime treats differently when a snapshot already exists:
+ *
+ * - `validated` keeps the historical contract: a saved-vs-current difference
+ *   aborts startup with the CRITICAL error unless `USE_DB_STARTHEIGHT` is set,
+ *   which downgrades it to a warning and lets the saved value win.
+ * - `restored` is always adopted from the snapshot (with a warning when the
+ *   adopted value differs from the freshly configured one). This is what makes
+ *   a re-sampled clock or a `"latest"` start survive a restart unchanged.
+ *
+ * Both groups are persisted flattened into the same JSONB document; the group
+ * membership is owned by the definition and is never stored.
+ */
+export type StartPolicyProjection = {
+  validated: StartPolicySnapshotFields;
+  restored: StartPolicySnapshotFields;
+};
+
+export type SyncProtocolStartPolicy = {
+  /**
+   * Resolve `"latest"` to an inclusive numeric first boundary. Only called on
+   * the first run of a protocol whose configured start is `"latest"`.
+   */
+  resolveLatest(entry: SyncProtocolWithNetwork): Promise<number>;
+  /** Project the immutable fields this protocol persists, split into groups. */
+  projectImmutable(
+    entry: SyncProtocolWithNetwork,
+    resolved: ResolvedStart,
+  ): StartPolicyProjection;
+  /** Apply a saved snapshot onto the in-memory config — the saved value wins. */
+  applySnapshot(
+    entry: SyncProtocolWithNetwork,
+    snapshot: StartPolicySnapshotFields,
+  ): void;
+};
+
+type BlockHeightCarrier = { startBlockHeight?: number | "latest" };
+
+/** True when this boot asked the protocol to discover its own first boundary. */
+export function configuredStartIsLatest(entry: SyncProtocolWithNetwork): boolean {
+  return (entry.syncProtocol as unknown as BlockHeightCarrier).startBlockHeight ===
+    "latest";
+}
+
+/** `resolveLatest` for protocols whose schema has no `"latest"` (FR-005). */
+export function rejectLatest(entry: SyncProtocolWithNetwork): Promise<never> {
+  return Promise.reject(
+    new Error(
+      `[start-policy] "latest" is not supported for sync protocol type ` +
+        `"${String(entry.syncProtocolType)}".`,
+    ),
+  );
+}
+
+/**
+ * The shared block-height split: an explicitly configured start stays
+ * mismatch-checked, a `"latest"` start is restored (a configured `"latest"` can
+ * never be a mismatch — that is the whole feature).
+ */
+export function projectBlockHeightStart(
+  entry: SyncProtocolWithNetwork,
+  resolved: ResolvedStart,
+): StartPolicyProjection {
+  const validated: StartPolicySnapshotFields = {};
+  const restored: StartPolicySnapshotFields = {
+    [START_BLOCK_HEIGHT_PROVENANCE]: resolved.provenance,
+  };
+  if (configuredStartIsLatest(entry)) {
+    restored["startBlockHeight"] = resolved.startBlockHeight;
+  } else {
+    validated["startBlockHeight"] = resolved.startBlockHeight;
+  }
+  return { validated, restored };
+}
+
+/** Write a saved numeric boundary back onto the live protocol config. */
+export function applyBlockHeightStart(
+  entry: SyncProtocolWithNetwork,
+  snapshot: StartPolicySnapshotFields,
+): void {
+  if ("startBlockHeight" in snapshot) {
+    (entry.syncProtocol as unknown as BlockHeightCarrier).startBlockHeight =
+      snapshot["startBlockHeight"] as number;
+  }
+}
+
+/**
+ * Passthrough definition for protocols whose start is already numeric and
+ * whose schema does not accept `"latest"`.
+ */
+export const numericStartPolicy: SyncProtocolStartPolicy = {
+  resolveLatest: rejectLatest,
+  projectImmutable: projectBlockHeightStart,
+  applySnapshot: applyBlockHeightStart,
+};
+
+/**
+ * The synthetic TEST chain derives blocks arithmetically from
+ * `network.startTime + network.blockTimeMS`, exactly like NTP — but unlike NTP
+ * those two fields stay *validated*, preserving today's mismatch-CRITICAL
+ * behaviour. Shared by TEST_MAIN and TEST_PARALLEL, because today's
+ * `extractImmutableConfig` branched on `networkType === TEST` for both.
+ */
+const testStartPolicy: SyncProtocolStartPolicy = {
+  resolveLatest: rejectLatest,
+  projectImmutable(entry, resolved) {
+    const network = entry.network as unknown as {
+      startTime: number;
+      blockTimeMS: number;
+    };
+    const start = projectBlockHeightStart(entry, resolved);
+    return {
+      validated: {
+        startTime: network.startTime,
+        blockTimeMS: network.blockTimeMS,
+        ...start.validated,
+      },
+      restored: start.restored,
+    };
+  },
+  applySnapshot(entry, snapshot) {
+    // Under USE_DB_STARTHEIGHT the saved network fields are written back too,
+    // closing the historical gap where the override skipped them for TEST.
+    const network = entry.network as unknown as Record<string, unknown>;
+    if ("startTime" in snapshot) network["startTime"] = snapshot["startTime"];
+    if ("blockTimeMS" in snapshot) {
+      network["blockTimeMS"] = snapshot["blockTimeMS"];
+    }
+    applyBlockHeightStart(entry, snapshot);
+  },
+};
+
+/** Cardano CARP starts from an absolute slot, never a block height. */
+const cardanoCarpStartPolicy: SyncProtocolStartPolicy = {
+  resolveLatest: rejectLatest,
+  projectImmutable(entry) {
+    const syncProtocol = entry.syncProtocol as unknown as { startSlot: unknown };
+    return { validated: { startSlot: syncProtocol.startSlot }, restored: {} };
+  },
+  applySnapshot(entry, snapshot) {
+    if ("startSlot" in snapshot) {
+      (entry.syncProtocol as unknown as Record<string, unknown>)["startSlot"] =
+        snapshot["startSlot"];
+    }
+  },
+};
+
+/** Cardano UTXOrpc starts from a chain point (`origin`, `tip`, or a point). */
+const cardanoUtxoRpcStartPolicy: SyncProtocolStartPolicy = {
+  resolveLatest: rejectLatest,
+  projectImmutable(entry) {
+    const syncProtocol = entry.syncProtocol as unknown as {
+      startChainPoint: unknown;
+    };
+    return {
+      validated: { startChainPoint: syncProtocol.startChainPoint },
+      restored: {},
+    };
+  },
+  applySnapshot(entry, snapshot) {
+    if ("startChainPoint" in snapshot) {
+      (entry.syncProtocol as unknown as Record<string, unknown>)[
+        "startChainPoint"
+      ] = snapshot["startChainPoint"];
+    }
+  },
+};
+
+/**
+ * Exhaustive by construction: adding a `ConfigSyncProtocolType` without a start
+ * definition is a compile error, and the runtime never guesses.
+ */
+export const startPolicyRegistry = {
+  [ConfigSyncProtocolType.NTP_MAIN]: ntpStartPolicy,
+  [ConfigSyncProtocolType.EVM_RPC_PARALLEL]: numericStartPolicy,
+  [ConfigSyncProtocolType.CARDANO_CARP_PARALLEL]: cardanoCarpStartPolicy,
+  [ConfigSyncProtocolType.CARDANO_UTXORPC_PARALLEL]: cardanoUtxoRpcStartPolicy,
+  [ConfigSyncProtocolType.MINA_PARALLEL]: numericStartPolicy,
+  [ConfigSyncProtocolType.AVAIL_PARALLEL]: numericStartPolicy,
+  [ConfigSyncProtocolType.MIDNIGHT_PARALLEL]: midnightStartPolicy,
+  [ConfigSyncProtocolType.BITCOIN_RPC_PARALLEL]: numericStartPolicy,
+  [ConfigSyncProtocolType.CELESTIA_PARALLEL]: numericStartPolicy,
+  [ConfigSyncProtocolType.NEAR_RPC_PARALLEL]: numericStartPolicy,
+  [ConfigSyncProtocolType.SOLANA_RPC_PARALLEL]: numericStartPolicy,
+  [ConfigSyncProtocolType.TEST_MAIN]: testStartPolicy,
+  [ConfigSyncProtocolType.TEST_PARALLEL]: testStartPolicy,
+} as const satisfies Record<ConfigSyncProtocolType, SyncProtocolStartPolicy>;

--- a/packages/node-sdk/sync/test/examples.test.ts
+++ b/packages/node-sdk/sync/test/examples.test.ts
@@ -20,3 +20,11 @@ test("README: per-chain fetchers and states are exported", () => {
   expect(typeof sync.getNtpTip).toBe("function");
   expect(typeof sync.NtpTipError).toBe("function");
 });
+
+test("README: protocol-owned start policies are exported", () => {
+  // The generic runtime imports exactly this registry — no per-chain hooks.
+  expect(typeof sync.startPolicyRegistry).toBe("object");
+  expect(typeof sync.numericStartPolicy.projectImmutable).toBe("function");
+  expect(typeof sync.ntpStartPolicy.resolveLatest).toBe("function");
+  expect(typeof sync.midnightStartPolicy.resolveLatest).toBe("function");
+});

--- a/packages/node-sdk/sync/test/midnight-start-policy.test.ts
+++ b/packages/node-sdk/sync/test/midnight-start-policy.test.ts
@@ -1,0 +1,204 @@
+// Midnight start-policy oracle (project 00034, spec SC-002 / FR-003).
+//
+// A counted `Bun.serve` fixture stands in for the indexer: the definition must
+// use the already-materialized explicit indexer URL verbatim, hit it exactly
+// once per protocol entry on the first run, and never on the restart path
+// (which only ever calls `applySnapshot`).
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { ConfigNetworkType, ConfigSyncProtocolType } from "@effectstream/config";
+import type { SyncProtocolWithNetwork } from "@effectstream/config";
+import { midnightStartPolicy } from "../src/sync-protocols/midnight/start-policy.ts";
+import { startPolicyRegistry } from "../src/sync-protocols/start-policy.ts";
+
+type TestServer = ReturnType<typeof Bun.serve>;
+
+type Fixture = {
+  server: TestServer;
+  url: string;
+  hits: number;
+  paths: string[];
+};
+
+const fixtures = new Set<Fixture>();
+
+afterEach(async () => {
+  await Promise.all([...fixtures].map((fixture) => stopFixture(fixture)));
+});
+
+async function startFixture(height: number): Promise<Fixture> {
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt < 50; attempt++) {
+    try {
+      let fixture!: Fixture;
+      const server = Bun.serve({
+        hostname: "127.0.0.1",
+        port: 0,
+        fetch(request) {
+          fixture.hits++;
+          fixture.paths.push(new URL(request.url).pathname);
+          return Response.json({ data: { block: { height } } });
+        },
+      });
+      const port = server.port;
+      // Workspace rule: fixtures bind ports above 10000 only.
+      if (port <= 10_000) {
+        await server.stop(true);
+        continue;
+      }
+
+      fixture = {
+        server,
+        url: `http://127.0.0.1:${port}/api/v4/graphql`,
+        hits: 0,
+        paths: [],
+      };
+      fixtures.add(fixture);
+      return fixture;
+    } catch (error) {
+      lastError = error;
+    }
+  }
+
+  throw lastError ?? new Error("Unable to allocate a loopback fixture port above 10000");
+}
+
+async function stopFixture(fixture: Fixture): Promise<void> {
+  fixtures.delete(fixture);
+  await fixture.server.stop(true);
+}
+
+function midnightEntry(options: {
+  startBlockHeight: number | "latest";
+  indexer: string;
+  name?: string;
+}): SyncProtocolWithNetwork {
+  return {
+    networkType: ConfigNetworkType.MIDNIGHT,
+    syncProtocolType: ConfigSyncProtocolType.MIDNIGHT_PARALLEL,
+    syncProtocol: {
+      name: options.name ?? "midnight",
+      type: ConfigSyncProtocolType.MIDNIGHT_PARALLEL,
+      indexer: options.indexer,
+      startBlockHeight: options.startBlockHeight,
+      requestTimeoutMs: 5_000,
+    },
+    network: {
+      name: options.name ?? "midnight",
+      type: ConfigNetworkType.MIDNIGHT,
+      networkId: "stagenet",
+    },
+    primitives: [],
+  } as unknown as SyncProtocolWithNetwork;
+}
+
+describe("midnightStartPolicy.resolveLatest", () => {
+  test("queries the materialized indexer URL verbatim, exactly once", async () => {
+    const fixture = await startFixture(9_001);
+
+    const height = await midnightStartPolicy.resolveLatest(
+      midnightEntry({ startBlockHeight: "latest", indexer: fixture.url }),
+    );
+
+    expect(height).toBe(9_001);
+    expect(fixture.hits).toBe(1);
+    expect(fixture.paths).toEqual(["/api/v4/graphql"]);
+  });
+
+  test("issues one hit per protocol entry on a first run (dedupe is not carried over)", async () => {
+    const fixture = await startFixture(4_100);
+
+    const heights = await Promise.all([
+      midnightStartPolicy.resolveLatest(
+        midnightEntry({
+          startBlockHeight: "latest",
+          indexer: fixture.url,
+          name: "midnight-a",
+        }),
+      ),
+      midnightStartPolicy.resolveLatest(
+        midnightEntry({
+          startBlockHeight: "latest",
+          indexer: fixture.url,
+          name: "midnight-b",
+        }),
+      ),
+    ]);
+
+    expect(heights).toEqual([4_100, 4_100]);
+    expect(fixture.hits).toBe(2);
+  });
+
+  test("is registered for MIDNIGHT_PARALLEL", () => {
+    expect(startPolicyRegistry[ConfigSyncProtocolType.MIDNIGHT_PARALLEL]).toBe(
+      midnightStartPolicy,
+    );
+  });
+});
+
+describe("midnightStartPolicy snapshot projection", () => {
+  test('projects a configured "latest" start into the restored group', () => {
+    const entry = midnightEntry({
+      startBlockHeight: "latest",
+      indexer: "http://127.0.0.1:65535/graphql",
+    });
+
+    expect(
+      midnightStartPolicy.projectImmutable(entry, {
+        startBlockHeight: 9_001,
+        provenance: "latest",
+      }),
+    ).toEqual({
+      validated: {},
+      restored: { startBlockHeight: 9_001, startBlockHeightProvenance: "latest" },
+    });
+  });
+
+  test("keeps an explicit start validated", () => {
+    const entry = midnightEntry({
+      startBlockHeight: 12,
+      indexer: "http://127.0.0.1:65535/graphql",
+    });
+
+    expect(
+      midnightStartPolicy.projectImmutable(entry, {
+        startBlockHeight: 12,
+        provenance: "explicit",
+      }),
+    ).toEqual({
+      validated: { startBlockHeight: 12 },
+      restored: { startBlockHeightProvenance: "explicit" },
+    });
+  });
+
+  test("the restart path reuses the saved boundary without a single tip query", async () => {
+    const fixture = await startFixture(9_001);
+
+    // First run: one query, boundary committed.
+    const first = midnightEntry({
+      startBlockHeight: "latest",
+      indexer: fixture.url,
+    });
+    const resolved = await midnightStartPolicy.resolveLatest(first);
+    const projected = midnightStartPolicy.projectImmutable(first, {
+      startBlockHeight: resolved,
+      provenance: "latest",
+    });
+    const persisted = { ...projected.validated, ...projected.restored };
+    expect(fixture.hits).toBe(1);
+
+    // Restart: the runtime only applies the saved snapshot.
+    const restarted = midnightEntry({
+      startBlockHeight: "latest",
+      indexer: fixture.url,
+    });
+    midnightStartPolicy.applySnapshot(restarted, persisted);
+
+    expect(
+      (restarted.syncProtocol as unknown as { startBlockHeight: number })
+        .startBlockHeight,
+    ).toBe(9_001);
+    expect(fixture.hits).toBe(1);
+  });
+});

--- a/packages/node-sdk/sync/test/ntp-start-policy.test.ts
+++ b/packages/node-sdk/sync/test/ntp-start-policy.test.ts
@@ -1,0 +1,236 @@
+// NTP start-policy oracle (project 00034, spec SC-002 / FR-003).
+//
+// Uses the same real-UDP fixture shape as `ntp-tip.test.ts`: `resolveLatest`
+// must reach a live NTP server exactly once and derive the inclusive boundary
+// with the protocol's own arithmetic. `projectImmutable`/`applySnapshot` must
+// round-trip the clock fields that make a restart reuse the saved mapping.
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { createSocket, type RemoteInfo, type Socket } from "node:dgram";
+import { ConfigNetworkType, ConfigSyncProtocolType } from "@effectstream/config";
+import type { SyncProtocolWithNetwork } from "@effectstream/config";
+import { ntpStartPolicy } from "../src/sync-protocols/ntp/start-policy.ts";
+import { startPolicyRegistry } from "../src/sync-protocols/start-policy.ts";
+
+const NTP_EPOCH_OFFSET_MS = 2_208_988_800_000;
+
+type Fixture = {
+  server: string;
+  hits: () => number;
+  close: () => Promise<void>;
+};
+
+const fixtures: Fixture[] = [];
+
+afterEach(async () => {
+  await Promise.all(fixtures.splice(0).map((fixture) => fixture.close()));
+});
+
+function writeTimestamp(buffer: Buffer, offset: number, unixMs: number): void {
+  const ntpMs = unixMs + NTP_EPOCH_OFFSET_MS;
+  buffer.writeUInt32BE(Math.floor(ntpMs / 1000) >>> 0, offset);
+  buffer.writeUInt32BE(Math.floor(((ntpMs % 1000) / 1000) * 2 ** 32) >>> 0, offset + 4);
+}
+
+function responseFor(request: Buffer, serverTimeMs: number): Buffer {
+  const response = Buffer.alloc(48);
+  response[0] = (4 << 3) | 4; // leap 0, version 4, mode server
+  response[1] = 1; // stratum
+  response[3] = 0xec; // precision, 2^-20s
+  response.write("LOCL", 12, 4, "ascii");
+  writeTimestamp(response, 16, serverTimeMs - 1_000);
+  request.copy(response, 24, 40, 48); // echo the client transmit as origin
+  writeTimestamp(response, 32, serverTimeMs);
+  writeTimestamp(response, 40, serverTimeMs);
+  return response;
+}
+
+async function startFixture(serverTimeMs: number): Promise<Fixture> {
+  const socket = createSocket("udp4");
+  await new Promise<void>((resolve, reject) => {
+    socket.once("error", reject);
+    socket.bind(0, "127.0.0.1", () => {
+      socket.removeListener("error", reject);
+      resolve();
+    });
+  });
+  let hits = 0;
+  socket.on("message", (request: Buffer, remote: RemoteInfo) => {
+    hits += 1;
+    (socket as Socket).send(
+      responseFor(request, serverTimeMs),
+      remote.port,
+      remote.address,
+    );
+  });
+  const fixture: Fixture = {
+    server: `127.0.0.1:${socket.address().port}`,
+    hits: () => hits,
+    close: () =>
+      new Promise<void>((resolve) => {
+        try {
+          socket.close(() => resolve());
+        } catch {
+          resolve();
+        }
+      }),
+  };
+  fixtures.push(fixture);
+  return fixture;
+}
+
+function ntpEntry(options: {
+  startBlockHeight: number | "latest";
+  startTime: number;
+  blockTimeMS: number;
+  servers?: string[];
+}): SyncProtocolWithNetwork {
+  return {
+    networkType: ConfigNetworkType.NTP,
+    syncProtocolType: ConfigSyncProtocolType.NTP_MAIN,
+    syncProtocol: {
+      name: "clock",
+      type: ConfigSyncProtocolType.NTP_MAIN,
+      startBlockHeight: options.startBlockHeight,
+      requestTimeoutMs: 5_000,
+    },
+    network: {
+      name: "clock",
+      type: ConfigNetworkType.NTP,
+      startTime: options.startTime,
+      blockTimeMS: options.blockTimeMS,
+      ...(options.servers ? { servers: options.servers } : {}),
+    },
+    primitives: [],
+  } as unknown as SyncProtocolWithNetwork;
+}
+
+describe("ntpStartPolicy.resolveLatest", () => {
+  test("derives the inclusive boundary from the network clock and hits the server once", async () => {
+    const startTime = 1_000_000;
+    const blockTimeMS = 600_000;
+    const serverTimeMs = startTime + blockTimeMS * 7 + 123;
+    const fixture = await startFixture(serverTimeMs);
+
+    const height = await ntpStartPolicy.resolveLatest(
+      ntpEntry({
+        startBlockHeight: "latest",
+        startTime,
+        blockTimeMS,
+        servers: [fixture.server],
+      }),
+    );
+
+    expect(height).toBe(Math.floor((serverTimeMs - startTime) / blockTimeMS));
+    expect(height).toBe(7);
+    expect(fixture.hits()).toBe(1);
+  });
+
+  test("is registered for NTP_MAIN", () => {
+    expect(startPolicyRegistry[ConfigSyncProtocolType.NTP_MAIN]).toBe(
+      ntpStartPolicy,
+    );
+  });
+});
+
+describe("ntpStartPolicy snapshot projection", () => {
+  test("keeps the clock fields restored and an explicit start validated", () => {
+    const entry = ntpEntry({
+      startBlockHeight: 5,
+      startTime: 1_700_000_000_000,
+      blockTimeMS: 1_000,
+    });
+
+    expect(
+      ntpStartPolicy.projectImmutable(entry, {
+        startBlockHeight: 5,
+        provenance: "explicit",
+      }),
+    ).toEqual({
+      validated: { startBlockHeight: 5 },
+      restored: {
+        startTime: 1_700_000_000_000,
+        blockTimeMS: 1_000,
+        startBlockHeightProvenance: "explicit",
+      },
+    });
+  });
+
+  test('moves the start into the restored group when the config says "latest"', () => {
+    const entry = ntpEntry({
+      startBlockHeight: "latest",
+      startTime: 1_700_000_000_000,
+      blockTimeMS: 1_000,
+    });
+
+    expect(
+      ntpStartPolicy.projectImmutable(entry, {
+        startBlockHeight: 4_242,
+        provenance: "latest",
+      }),
+    ).toEqual({
+      validated: {},
+      restored: {
+        startTime: 1_700_000_000_000,
+        blockTimeMS: 1_000,
+        startBlockHeight: 4_242,
+        startBlockHeightProvenance: "latest",
+      },
+    });
+  });
+
+  test("applySnapshot restores the saved clock and start onto the live config", () => {
+    // A restarted single-file node re-samples `Date.now()` for `startTime`;
+    // the saved mapping must win or the NTP time→block mapping shifts.
+    const entry = ntpEntry({
+      startBlockHeight: "latest",
+      startTime: 9_999_999_999,
+      blockTimeMS: 2_000,
+    });
+
+    ntpStartPolicy.applySnapshot(entry, {
+      startTime: 1_700_000_000_000,
+      blockTimeMS: 1_000,
+      startBlockHeight: 4_242,
+      startBlockHeightProvenance: "latest",
+    });
+
+    expect(entry.network).toMatchObject({
+      startTime: 1_700_000_000_000,
+      blockTimeMS: 1_000,
+    });
+    expect(
+      (entry.syncProtocol as unknown as { startBlockHeight: number })
+        .startBlockHeight,
+    ).toBe(4_242);
+  });
+
+  test("round-trips a first-run projection back onto a freshly built config", () => {
+    const first = ntpEntry({
+      startBlockHeight: "latest",
+      startTime: 1_700_000_000_000,
+      blockTimeMS: 1_000,
+    });
+    const projected = ntpStartPolicy.projectImmutable(first, {
+      startBlockHeight: 4_242,
+      provenance: "latest",
+    });
+    const persisted = { ...projected.validated, ...projected.restored };
+
+    const restarted = ntpEntry({
+      startBlockHeight: "latest",
+      startTime: 1_800_000_000_000,
+      blockTimeMS: 1_000,
+    });
+    ntpStartPolicy.applySnapshot(restarted, persisted);
+
+    expect(restarted.network).toMatchObject({
+      startTime: 1_700_000_000_000,
+      blockTimeMS: 1_000,
+    });
+    expect(
+      (restarted.syncProtocol as unknown as { startBlockHeight: number })
+        .startBlockHeight,
+    ).toBe(4_242);
+  });
+});

--- a/packages/node-sdk/sync/test/start-policy.test.ts
+++ b/packages/node-sdk/sync/test/start-policy.test.ts
@@ -1,0 +1,229 @@
+// Registry-level oracle for the protocol-owned start policies (project 00034).
+//
+// Covers the generic contract every definition must honour, the byte-compatible
+// Cardano/TEST projections, and the exhaustiveness of `startPolicyRegistry`.
+// The NTP and Midnight definitions get their own network-backed suites in
+// `ntp-start-policy.test.ts` / `midnight-start-policy.test.ts`.
+
+import { describe, expect, test } from "bun:test";
+import { ConfigNetworkType, ConfigSyncProtocolType } from "@effectstream/config";
+import type { SyncProtocolWithNetwork } from "@effectstream/config";
+import {
+  numericStartPolicy,
+  startPolicyRegistry,
+} from "../src/sync-protocols/start-policy.ts";
+
+function entryFor(
+  syncProtocolType: ConfigSyncProtocolType,
+  syncProtocol: Record<string, unknown>,
+  network: Record<string, unknown> = {},
+): SyncProtocolWithNetwork {
+  return {
+    networkType: network["type"] ?? ConfigNetworkType.EVM,
+    syncProtocolType,
+    syncProtocol: { name: "protocol", ...syncProtocol },
+    network,
+    primitives: [],
+  } as unknown as SyncProtocolWithNetwork;
+}
+
+describe("startPolicyRegistry", () => {
+  test("covers every sync protocol type exactly once", () => {
+    const registryKeys = Object.keys(startPolicyRegistry).sort();
+    const protocolTypes = Object.values(ConfigSyncProtocolType).sort();
+    expect(registryKeys).toEqual(protocolTypes);
+  });
+
+  test("every definition exposes the three protocol-owned operations", () => {
+    for (const [type, definition] of Object.entries(startPolicyRegistry)) {
+      expect(typeof definition.resolveLatest, type).toBe("function");
+      expect(typeof definition.projectImmutable, type).toBe("function");
+      expect(typeof definition.applySnapshot, type).toBe("function");
+    }
+  });
+
+  test("TEST_MAIN and TEST_PARALLEL share one definition", () => {
+    expect(startPolicyRegistry[ConfigSyncProtocolType.TEST_PARALLEL]).toBe(
+      startPolicyRegistry[ConfigSyncProtocolType.TEST_MAIN],
+    );
+  });
+
+  test("plain block-height protocols share the numeric definition", () => {
+    for (
+      const type of [
+        ConfigSyncProtocolType.EVM_RPC_PARALLEL,
+        ConfigSyncProtocolType.MINA_PARALLEL,
+        ConfigSyncProtocolType.AVAIL_PARALLEL,
+        ConfigSyncProtocolType.BITCOIN_RPC_PARALLEL,
+        ConfigSyncProtocolType.CELESTIA_PARALLEL,
+        ConfigSyncProtocolType.NEAR_RPC_PARALLEL,
+        ConfigSyncProtocolType.SOLANA_RPC_PARALLEL,
+      ]
+    ) {
+      expect(startPolicyRegistry[type], type).toBe(numericStartPolicy);
+    }
+  });
+});
+
+describe("numericStartPolicy", () => {
+  const entry = () =>
+    entryFor(ConfigSyncProtocolType.EVM_RPC_PARALLEL, { startBlockHeight: 12 });
+
+  test('rejects "latest" — those protocols keep numeric starts (FR-005)', async () => {
+    await expect(numericStartPolicy.resolveLatest(entry())).rejects.toThrow(
+      /latest/i,
+    );
+  });
+
+  test("projects an explicit start as a validated field plus restored provenance", () => {
+    expect(
+      numericStartPolicy.projectImmutable(entry(), {
+        startBlockHeight: 12,
+        provenance: "explicit",
+      }),
+    ).toEqual({
+      validated: { startBlockHeight: 12 },
+      restored: { startBlockHeightProvenance: "explicit" },
+    });
+  });
+
+  test('projects a configured "latest" start as a restored field', () => {
+    const configured = entryFor(ConfigSyncProtocolType.EVM_RPC_PARALLEL, {
+      startBlockHeight: "latest",
+    });
+    expect(
+      numericStartPolicy.projectImmutable(configured, {
+        startBlockHeight: 900,
+        provenance: "latest",
+      }),
+    ).toEqual({
+      validated: {},
+      restored: { startBlockHeight: 900, startBlockHeightProvenance: "latest" },
+    });
+  });
+
+  test("applySnapshot writes the saved numeric start back onto the config", () => {
+    const target = entry();
+    numericStartPolicy.applySnapshot(target, {
+      startBlockHeight: 77,
+      startBlockHeightProvenance: "latest",
+    });
+    expect(
+      (target.syncProtocol as unknown as { startBlockHeight: number })
+        .startBlockHeight,
+    ).toBe(77);
+  });
+
+  test("applySnapshot ignores a snapshot without a start", () => {
+    const target = entry();
+    numericStartPolicy.applySnapshot(target, { unrelated: 1 });
+    expect(
+      (target.syncProtocol as unknown as { startBlockHeight: number })
+        .startBlockHeight,
+    ).toBe(12);
+  });
+});
+
+describe("Cardano definitions keep today's projections byte-compatible", () => {
+  test("CARP projects and restores startSlot only", () => {
+    const definition =
+      startPolicyRegistry[ConfigSyncProtocolType.CARDANO_CARP_PARALLEL];
+    const entry = entryFor(
+      ConfigSyncProtocolType.CARDANO_CARP_PARALLEL,
+      { startSlot: 4321 },
+      { type: ConfigNetworkType.CARDANO },
+    );
+
+    expect(
+      definition.projectImmutable(entry, {
+        startBlockHeight: 0,
+        provenance: "explicit",
+      }),
+    ).toEqual({ validated: { startSlot: 4321 }, restored: {} });
+
+    definition.applySnapshot(entry, { startSlot: 11 });
+    expect((entry.syncProtocol as unknown as { startSlot: number }).startSlot)
+      .toBe(11);
+  });
+
+  test("UTXOrpc projects and restores startChainPoint only", () => {
+    const definition =
+      startPolicyRegistry[ConfigSyncProtocolType.CARDANO_UTXORPC_PARALLEL];
+    const point = { slot: 5, hash: "0xdead" };
+    const entry = entryFor(
+      ConfigSyncProtocolType.CARDANO_UTXORPC_PARALLEL,
+      { startChainPoint: point },
+      { type: ConfigNetworkType.CARDANO },
+    );
+
+    expect(
+      definition.projectImmutable(entry, {
+        startBlockHeight: 0,
+        provenance: "explicit",
+      }),
+    ).toEqual({ validated: { startChainPoint: point }, restored: {} });
+
+    definition.applySnapshot(entry, { startChainPoint: "origin" });
+    expect(
+      (entry.syncProtocol as unknown as { startChainPoint: unknown })
+        .startChainPoint,
+    ).toBe("origin");
+  });
+
+  test('neither Cardano definition resolves "latest"', async () => {
+    for (
+      const type of [
+        ConfigSyncProtocolType.CARDANO_CARP_PARALLEL,
+        ConfigSyncProtocolType.CARDANO_UTXORPC_PARALLEL,
+      ]
+    ) {
+      await expect(
+        startPolicyRegistry[type].resolveLatest(
+          entryFor(type, {}, { type: ConfigNetworkType.CARDANO }),
+        ),
+      ).rejects.toThrow(/latest/i);
+    }
+  });
+});
+
+describe("TEST definition", () => {
+  const definition = startPolicyRegistry[ConfigSyncProtocolType.TEST_MAIN];
+  const testEntry = () =>
+    entryFor(
+      ConfigSyncProtocolType.TEST_MAIN,
+      { startBlockHeight: 3 },
+      { type: ConfigNetworkType.TEST, startTime: 1_000, blockTimeMS: 10 },
+    );
+
+  test("keeps the arithmetic network fields validated alongside the start", () => {
+    expect(
+      definition.projectImmutable(testEntry(), {
+        startBlockHeight: 3,
+        provenance: "explicit",
+      }),
+    ).toEqual({
+      validated: { startTime: 1_000, blockTimeMS: 10, startBlockHeight: 3 },
+      restored: { startBlockHeightProvenance: "explicit" },
+    });
+  });
+
+  test("applySnapshot restores the saved network fields (closing the override gap)", () => {
+    const entry = testEntry();
+    definition.applySnapshot(entry, {
+      startTime: 42,
+      blockTimeMS: 250,
+      startBlockHeight: 9,
+    });
+    expect(entry.network).toMatchObject({ startTime: 42, blockTimeMS: 250 });
+    expect(
+      (entry.syncProtocol as unknown as { startBlockHeight: number })
+        .startBlockHeight,
+    ).toBe(9);
+  });
+
+  test('does not resolve "latest"', async () => {
+    await expect(definition.resolveLatest(testEntry())).rejects.toThrow(
+      /latest/i,
+    );
+  });
+});


### PR DESCRIPTION
Supports `startBlockHeight: "latest"` through protocol-owned start-policy
definitions that live beside each sync implementation, while the generic runtime
owns only durable reconciliation.

Spec: `spec/00034-protocol-owned-start-policy.md`.

## What changes

**Protocol-owned start policies (new, in `@effectstream/sync`).** A
`SyncProtocolStartPolicy` is three operations — `resolveLatest`,
`projectImmutable` (returning `{validated, restored}` field groups) and
`applySnapshot`. `startPolicyRegistry` maps every `ConfigSyncProtocolType` to one
definition and is `as const satisfies Record<ConfigSyncProtocolType, …>`, so
adding a protocol without a start definition is a compile error. NTP's definition
lives under `sync-protocols/ntp/` and calls `getNtpTip`; Midnight's lives under
`sync-protocols/midnight/` and calls `getMidnightTip` with the already
materialized indexer URL. Cardano CARP/UTXOrpc and the synthetic TEST chain keep
today's projections; every other block-height protocol shares a passthrough
`numericStartPolicy` whose `resolveLatest` rejects.

**Generic durable reconciliation (`runtime/src/config-snapshot.ts`, rewritten).**
The runtime no longer knows any chain: it selects one opaque definition by
`syncProtocolType`. On a first run it resolves `"latest"` exactly once (outside
the transaction), then on ONE dedicated `PoolClient` runs
`BEGIN → INSERT … ON CONFLICT DO NOTHING → in-transaction re-read → COMMIT`
and adopts the committed row, so a lost race takes the winner's boundary rather
than its own observation. On every later boot there is no live tip query at all —
the committed numeric boundary and its `latest | explicit` provenance win. The
two concrete-branch functions that used to be the whole feature,
`extractImmutableConfig` and `applySnapshotOverrides`, are deleted.
`grep -rn "getNtpTip\|getMidnightTip\|resolveNtp\|resolveMidnight"` over
`packages/node-sdk/runtime/src` and `packages/effectstream-sdk/config/src` now
returns nothing.

**Schema.** `"latest"` reaches exactly two schemas — NTP main and Midnight
parallel. Every other protocol keeps a numeric-only start, byte-identical. The
widening is two-sided on purpose: `common.ts` widens the validator and the
builder-input static type together, and `SyncProtocolWithNetwork` re-narrows the
`startBlockHeight` member back to `number`, so every runtime and sync consumer
keeps the numeric type it already had and compiles untouched.

**Startup order.** `processPrimitives` moves out of the pre-mutex prologue to
AFTER `validateAndSnapshotConfig`, so the order is now
mutex → optional reset → migrations → reconcile → inherit → primitives →
`genSyncProtocols`. Primitives can therefore never be constructed from an
unresolved sentinel.

**Primitive inheritance.** A primitive that omits `startBlockHeight` inherits its
owning protocol's committed numeric start; an explicit value always wins
(including an explicit `0`), and a primitive with nothing to inherit fails with a
named configuration error.

**Single-file facade.** `node/src/single-file.ts` loses `resolveStartHeights`,
`fetchLatestHeight` (a hand-rolled duplicate of `getMidnightTip`),
`readConfigSnapshot` (raw SQL that swallowed `42P01` because it ran before
migrations), `numberFromSnapshot` and the clock-startTime pre-read — about 100
lines. It now passes the declared start through verbatim and lets the runtime
reconcile. Its public surface (`runNode`, `pglite`, `midnightContract`) is
unchanged.

## Behaviour and data changes to be aware of

- **(a)** Snapshot rows gain a `startBlockHeightProvenance` key. Pre-existing
  rows are backfilled in place to `"explicit"`, atomically, with their value
  untouched. New key inside the existing JSONB column — no DDL, no migration, no
  `EFFECTSTREAM_ENGINE_VERSION` bump.
- **(b)** TEST protocol snapshots (`TEST_MAIN` / `TEST_PARALLEL`) now also carry
  `startBlockHeight`, where previously they held only
  `{startTime, blockTimeMS}`. Existing rows are NOT invalidated: the mismatch
  comparison only compares keys present on both sides.
- **(c)** A deliberately changed explicit NTP `startTime` now logs a WARN and is
  adopted from the snapshot instead of throwing CRITICAL. NTP's
  `startTime`/`blockTimeMS` are *restored* fields rather than mismatch-checked
  ones, because their default re-samples `Date.now()` on every boot — this is
  what lets the single-file facade's clock pre-read be deleted. An explicit
  `startBlockHeight` keeps its historical CRITICAL / `USE_DB_STARTHEIGHT`
  behaviour exactly.

**Fail-loud guard for legacy upgrades.** A snapshot row written before this
change can lack `startBlockHeight` entirely (every pre-existing NTP row held only
`{startTime, blockTimeMS}`). On the restart path nothing can supply it, so
configuring `"latest"` on such a database now throws a named CRITICAL error
listing both remedies — set an explicit numeric start once, or delete the
snapshot row so `"latest"` resolves from scratch — rather than silently leaving
the string sentinel in memory.

## Testing

All suites run in disposable, network-disabled Docker containers against the
committed bytes; fixtures bind loopback ports above 10000.

- Runtime unit (fake-definition oracle: resolve-once, provenance, restart
  no-requery, legacy backfill, lost-race adoption, crash ordering,
  same-connection and per-protocol-connection assertions, validated/restored
  split, unknown-type throw, fail-loud guard) — 35 pass / 0 fail across 4 files.
- `sync/test/` — 135 pass / 0 fail across 14 files, including a real-UDP NTP
  fixture (inclusive boundary arithmetic, one hit) and a counted `Bun.serve`
  Midnight fixture (materialized URL used verbatim, one hit per protocol on
  first run, zero on restart).
- `config/test/` — 35 pass / 0 fail; plus `bun run typecheck` clean, with a
  consumed `@ts-expect-error` proving `"latest"` stays out of every other
  protocol's builder input.
- `node/test/` — 19 pass / 0 fail.
- Reproduction harness (PGlite, genuine subprocess restarts) — 14 pass / 2 skip /
  0 fail across 9 files, including a new end-to-end scenario: first boot resolves
  `"latest"` once and commits value + provenance; a real restart with the fixture
  reporting a different tip performs zero tip queries and reuses the committed
  boundary; a row seeded without provenance is backfilled to `"explicit"` with
  its value untouched.
- Broad `bun test ./packages` — 608 pass / 4 skip / 6 fail / 2 errors. The 6
  failures and 2 errors are identical on the untouched base commit
  (532 / 4 / 6 / 2), i.e. pre-existing and unrelated; the delta is exactly the
  +76 tests / +7 files added here.

## Review

Two independent delivery-audit cycles against the pinned commit. Cycle 1 raised
one MAJOR (a legacy row lacking `startBlockHeight` under a configured `"latest"`
silently kept the sentinel); it was remediated with the fail-loud guard above
plus two unit tests, proved red-then-green. Cycle 2: **PASS WITH FINDINGS, zero
unresolved BLOCKER/MAJOR.** Four findings remain deferred to the owner and are
deliberately not addressed here: F2 (the intersection comparison no longer
CRITICALs when a saved key has no current counterpart, which only weakens for a
cross-type swap behind a kept `protocol_name`), F3 (under effection *halt* the
`inTransaction` ROLLBACK does not run and the client is recycled rather than
destroyed), F4 (a halt during `pool.connect()` can leak the checked-out client —
same pattern as `process-blocks.ts`), and F5 (the guard's "delete the row"
remedy understates that, for NTP, this also discards the saved clock mapping).

Out of scope by design: multi-file template adoption keeps numeric starts, and
`main.ts`'s pre-existing NTP lag-threshold lookup is untouched.

Please do not enable auto-merge.
