### PR TITLE
fix(zswap-da): show the shielded identity as a bech32m address, copyable

### DIFF
--- a/templates/zswap-da/src/screens/Faucet.tsx
+++ b/templates/zswap-da/src/screens/Faucet.tsx
@@ -7,7 +7,10 @@
 import { useMemo, useState } from 'react';
 import { Icon } from '../ui/icons';
 import { MAX_TOKEN_NAME_LENGTH } from '../constants';
+import { formatShieldedAddress } from '../state/shieldedAddress';
 import type { ZSwapApp } from '../state/useZSwapApp';
+
+const NETWORK_ID = (import.meta.env.VITE_MIDNIGHT_NETWORK_ID as string) || 'undeployed';
 
 type Kind = 'shielded' | 'unshielded';
 interface Preset { name: string; kind: Kind; glyph: string; tint: string; desc: string }
@@ -61,7 +64,12 @@ export function Faucet({ st }: { st: ZSwapApp }) {
 
   const valid = name.length > 0;
   const activePreset = PRESETS.find((p) => p.name === name && p.kind === kind);
-  const toAddr = kind === 'shielded' ? st.shieldedAddress : st.unshieldedAddress;
+  // Caption only — the mint recipient is derived inside the contract wallet
+  // from getShieldedKeys(), never from this string, so formatting it for
+  // display changes nothing about what is submitted.
+  const toAddr = kind === 'shielded'
+    ? formatShieldedAddress(st.shieldedAddress, st.shieldedEncryptionPublicKey, NETWORK_ID)
+    : st.unshieldedAddress;
 
   const selectPreset = (p: Preset) => {
     setName(p.name);

--- a/templates/zswap-da/src/state/shieldedAddress.test.ts
+++ b/templates/zswap-da/src/state/shieldedAddress.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from 'bun:test';
+import { bech32m } from '@scure/base';
+import { ShieldedAddress } from '@midnightntwrk/wallet-sdk-address-format';
+import { formatShieldedAddress } from './shieldedAddress';
+
+// 32 bytes each — the shapes @effectstream/wallets' local connector exposes as
+// `shieldedAddress` (hex coin public key) and `shieldedEncryptionPublicKey`.
+const COIN = 'ab7931b72a4f1c8d3e5b9076a1c2d4e6f80915273849506172839405060df090';
+const ENC = '5c0d1e2f3a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f9012a3b4c5d6';
+
+/**
+ * Decode a shielded address back to its two key halves.
+ *
+ * NOT `MidnightBech32m.parse`: at the pinned wallet-sdk-address-format 3.1.2
+ * (and still at 4.0.0-beta.2) `asString()` encodes with the bech32m length
+ * limit disabled while `parse()` decodes with the default 90-character cap
+ * still on — so the library cannot read back its own 124–135 character
+ * shielded addresses. `@scure/base` is a direct dependency of this template,
+ * so we drive the same codec through it with the limit off.
+ * See issues/00043 in the organizer workspace.
+ */
+function decodeShieldedAddress(encoded: string): ShieldedAddress {
+  const { bytes } = bech32m.decodeToBytes(encoded, false);
+  return ShieldedAddress.codec.dataFromBytes(Buffer.from(bytes));
+}
+
+describe('formatShieldedAddress — local wallet (hex → bech32m)', () => {
+  test('composes a canonical undeployed shielded address', () => {
+    const out = formatShieldedAddress(COIN, ENC, 'undeployed');
+    expect(out.startsWith('mn_shield-addr_undeployed1')).toBe(true);
+  });
+
+  test('round-trips: the encoded address carries both original keys (SC-002)', () => {
+    const out = formatShieldedAddress(COIN, ENC, 'undeployed');
+    const back = decodeShieldedAddress(out);
+    expect(back.coinPublicKeyString()).toBe(COIN);
+    expect(back.encryptionPublicKeyString()).toBe(ENC);
+  });
+
+  test('network prefix follows the configured network id, not a hardcode (FR-005)', () => {
+    expect(formatShieldedAddress(COIN, ENC, 'testnet').startsWith('mn_shield-addr_testnet1')).toBe(true);
+    // 'mainnet' is the one network whose segment is omitted, by library design.
+    expect(formatShieldedAddress(COIN, ENC, 'mainnet').startsWith('mn_shield-addr1')).toBe(true);
+  });
+
+  test('accepts 0x-prefixed hex', () => {
+    const out = formatShieldedAddress(`0x${COIN}`, `0x${ENC}`, 'undeployed');
+    expect(decodeShieldedAddress(out).coinPublicKeyString()).toBe(COIN);
+  });
+
+  test('is case-insensitive about the input hex', () => {
+    const out = formatShieldedAddress(COIN.toUpperCase(), ENC.toUpperCase(), 'undeployed');
+    expect(decodeShieldedAddress(out).coinPublicKeyString()).toBe(COIN);
+  });
+});
+
+describe('formatShieldedAddress — pass-through (FR-004)', () => {
+  test('an already-bech32m Lace address is returned verbatim, never re-encoded', () => {
+    const lace = formatShieldedAddress(COIN, ENC, 'undeployed');
+    expect(formatShieldedAddress(lace, ENC, 'undeployed')).toBe(lace);
+  });
+
+  test('an unshielded mn_addr_ fallback is left alone', () => {
+    const unshielded = 'mn_addr_undeployed14dunrde2fuwg60jmjpm2rsk5umuqj9f88py4qctjsw2q2psd7zgqqtsnha';
+    expect(formatShieldedAddress(unshielded, ENC, 'undeployed')).toBe(unshielded);
+  });
+
+  test('missing encryption key → the raw coin key, unchanged', () => {
+    expect(formatShieldedAddress(COIN, null, 'undeployed')).toBe(COIN);
+    expect(formatShieldedAddress(COIN, undefined, 'undeployed')).toBe(COIN);
+    expect(formatShieldedAddress(COIN, '', 'undeployed')).toBe(COIN);
+  });
+
+  test('a short encryption key does NOT produce a plausible-but-wrong address', () => {
+    // ShieldedEncryptionPublicKey has no length check of its own, so without
+    // our guard this would encode into a valid-looking mn_shield-addr_… that
+    // nobody can receive at.
+    const out = formatShieldedAddress(COIN, 'deadbeef', 'undeployed');
+    expect(out).toBe(COIN);
+    expect(out.startsWith('mn_')).toBe(false);
+  });
+
+  test('garbage input is returned unchanged and never throws', () => {
+    expect(formatShieldedAddress('not-an-address', ENC, 'undeployed')).toBe('not-an-address');
+    expect(formatShieldedAddress('zz'.repeat(32), ENC, 'undeployed')).toBe('zz'.repeat(32));
+    expect(formatShieldedAddress(COIN.slice(0, 40), ENC, 'undeployed')).toBe(COIN.slice(0, 40));
+  });
+
+  test('null/empty address (wallet still syncing) → empty string, no crash', () => {
+    expect(formatShieldedAddress(null, ENC, 'undeployed')).toBe('');
+    expect(formatShieldedAddress(undefined, null, 'undeployed')).toBe('');
+    expect(formatShieldedAddress('', '', 'undeployed')).toBe('');
+  });
+});

--- a/templates/zswap-da/src/state/shieldedAddress.ts
+++ b/templates/zswap-da/src/state/shieldedAddress.ts
@@ -1,0 +1,73 @@
+// Display-only formatting of the shielded identity.
+//
+// The two Midnight wallets hand the shielded identity over in different shapes:
+//
+//   - Lace (injected) already returns the canonical bech32m address from
+//     `getShieldedAddresses()` — `mn_shield-addr_<network>1…`.
+//   - The built-in JS wallet returns the raw hex COIN PUBLIC KEY, because that
+//     is what shielded-output builders consume: @effectstream/wallets'
+//     `midnight/local.ts` sets `shieldedAddress = address.coinPublicKeyString()`
+//     and exposes the encryption key next to it as `shieldedEncryptionPublicKey`.
+//
+// A Midnight shielded address is bech32m(coin public key ++ encryption public
+// key), so for the local wallet we recompose the two halves here. This is a
+// DISPLAY concern only — the raw hex stays untouched in wallet state, because
+// Faucet's `toAddr`, the mint/output builders and the offer-sender matching all
+// consume the current encodings.
+
+import {
+  MidnightBech32m,
+  ShieldedAddress,
+  ShieldedCoinPublicKey,
+  ShieldedEncryptionPublicKey,
+} from '@midnightntwrk/wallet-sdk-address-format';
+
+/** Both halves of a shielded address are exactly 32 bytes. */
+const HEX_32_BYTES = /^(?:0x)?[0-9a-fA-F]{64}$/;
+
+const stripHexPrefix = (h: string): string => (h.startsWith('0x') ? h.slice(2) : h);
+
+/**
+ * Canonical `mn_shield-addr_<network>1…` for display, or the input unchanged
+ * when it cannot be derived.
+ *
+ * Pass-through cases, all deliberate:
+ *  - anything already bech32m (`mn_…`) — the Lace address, and the
+ *    `mn_addr_…` unshielded fallback the menu shows when there is no shielded
+ *    address. Re-encoding either one would produce a wrong artifact.
+ *  - a coin key that is not 32 bytes of hex, or a missing/short encryption key
+ *    — the address is simply not derivable, so show what we have rather than
+ *    crash or blank the row.
+ *
+ * The encryption-key length check is load-bearing, not belt-and-braces:
+ * `ShieldedCoinPublicKey` validates its own 32-byte length, but
+ * `ShieldedEncryptionPublicKey` does NOT — handed a short or non-hex string it
+ * silently builds a truncated key, which then encodes into a plausible-looking
+ * but wrong `mn_shield-addr_…`. Showing a wrong address is worse than showing
+ * the hex.
+ */
+export function formatShieldedAddress(
+  address: string | null | undefined,
+  encryptionPublicKey: string | null | undefined,
+  networkId: string,
+): string {
+  const addr = address ?? '';
+  if (addr === '' || addr.startsWith('mn_')) return addr;
+  if (!HEX_32_BYTES.test(addr)) return addr;
+
+  const enc = encryptionPublicKey ?? '';
+  if (!HEX_32_BYTES.test(enc)) return addr;
+
+  try {
+    return MidnightBech32m.encode(
+      networkId,
+      new ShieldedAddress(
+        ShieldedCoinPublicKey.fromHexString(stripHexPrefix(addr)),
+        ShieldedEncryptionPublicKey.fromHexString(stripHexPrefix(enc)),
+      ),
+    ).toString();
+  } catch {
+    // A display formatter must never take the wallet menu down with it.
+    return addr;
+  }
+}

--- a/templates/zswap-da/src/state/useZSwapApp.ts
+++ b/templates/zswap-da/src/state/useZSwapApp.ts
@@ -134,6 +134,8 @@ export interface ZSwapApp {
   localApi: any | null;
   status: 'disconnected' | 'connecting' | 'connected';
   shieldedAddress: string | null;
+  /** Other half of the shielded address — display-side only (WalletMenu). */
+  shieldedEncryptionPublicKey: string | null;
   unshieldedAddress: string | null;
   shieldedBalances: Record<string, string> | null;
   unshieldedBalances: Record<string, string> | null;
@@ -890,6 +892,7 @@ export function useZSwapApp(): ZSwapApp {
     localApi: connected?.localApi ?? null,
     status,
     shieldedAddress: wstate?.shieldedAddress ?? null,
+    shieldedEncryptionPublicKey: wstate?.shieldedEncryptionPublicKey ?? null,
     unshieldedAddress: wstate?.unshieldedAddress ?? null,
     shieldedBalances: wstate?.shieldedBalances ?? null,
     unshieldedBalances: wstate?.unshieldedBalances ?? null,

--- a/templates/zswap-da/src/state/wallet.ts
+++ b/templates/zswap-da/src/state/wallet.ts
@@ -40,7 +40,16 @@ export interface Connected {
 }
 
 export interface WalletState {
+  /**
+   * As the wallet reports it, NEVER normalized: bech32m from Lace, but the raw
+   * hex coin public key from the local JS wallet. Faucet's `toAddr` and the
+   * shielded-output builders consume these as-is — for a canonical
+   * `mn_shield-addr_…` to show a user, run it through `formatShieldedAddress`
+   * with `shieldedEncryptionPublicKey`.
+   */
   shieldedAddress: string | null;
+  /** The other half of the shielded address. Same encoding rule as above. */
+  shieldedEncryptionPublicKey: string | null;
   unshieldedAddress: string | null;
   shieldedBalances: Record<string, string>;
   unshieldedBalances: Record<string, string>;
@@ -102,6 +111,7 @@ export async function readState(c: Connected): Promise<WalletState> {
     ]);
     return {
       shieldedAddress: sh.shieldedAddress ?? null,
+      shieldedEncryptionPublicKey: sh.shieldedEncryptionPublicKey ?? null,
       unshieldedAddress: unsh.unshieldedAddress ?? null,
       shieldedBalances: stringify(shB),
       unshieldedBalances: stringify(unshB),
@@ -121,6 +131,7 @@ export async function readState(c: Connected): Promise<WalletState> {
   } catch { /* still syncing */ }
   return {
     shieldedAddress: c.localApi?.shieldedAddress ?? null,
+    shieldedEncryptionPublicKey: c.localApi?.shieldedEncryptionPublicKey ?? null,
     unshieldedAddress: c.localApi?.unshieldedAddress ?? null,
     shieldedBalances,
     unshieldedBalances,

--- a/templates/zswap-da/src/ui/WalletMenu.tsx
+++ b/templates/zswap-da/src/ui/WalletMenu.tsx
@@ -1,9 +1,9 @@
 // Connected wallet dropdown: shielded identity, real address + balances,
 // disconnect. Adapted from app/ZSwap.html WalletMenu — wired to live wallet data.
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState, type CSSProperties } from 'react';
 import { WalletPill, type WalletInfo } from './WalletPill';
 import { Icon } from './icons';
-import { truncateAddress } from '../utils';
+import { isShieldedAddress, truncateAddress } from '../utils';
 import { fmtBalance } from '../state/format';
 import { formatShieldedAddress } from '../state/shieldedAddress';
 import { TokenChip } from './TokenChip';
@@ -13,6 +13,21 @@ const NETWORK_ID = (import.meta.env.VITE_MIDNIGHT_NETWORK_ID as string) || 'unde
 
 /** How long the "Copied" confirmation stays up. */
 const COPIED_MS = 1500;
+
+/**
+ * A shielded address renders 33 characters (`mn_shield-addr_undeployed1…qhz8fj`)
+ * against the ~213px this row leaves for text inside the 280px card. At the
+ * 12.5px used for the short unshielded/hex forms that wraps onto a second line,
+ * so shielded addresses drop a notch. Both numbers are measured, not guessed —
+ * see the plan's Phase 6.
+ */
+const ADDRESS_FONT_SIZE = { shielded: 11, other: 12.5 } as const;
+
+/** Visually hidden, still read out by screen readers. */
+const SR_ONLY: CSSProperties = {
+  position: 'absolute', width: 1, height: 1, margin: -1, padding: 0,
+  overflow: 'hidden', clip: 'rect(0 0 0 0)', whiteSpace: 'nowrap', border: 0,
+};
 
 interface WalletMenuState {
   wallet: WalletInfo | null;
@@ -114,17 +129,27 @@ export function WalletMenu({ st }: { st: WalletMenuState }) {
             }}
           >
             <Icon.shield style={{ color: 'var(--accent)', flex: '0 0 auto' }} />
-            <span className="zs-num" style={{ fontSize: 12.5, fontWeight: 600, wordBreak: 'break-all', color: 'var(--ink-2)' }}>{truncateAddress(addr)}</span>
+            <span
+              className="zs-num"
+              style={{
+                fontSize: isShieldedAddress(addr) ? ADDRESS_FONT_SIZE.shielded : ADDRESS_FONT_SIZE.other,
+                fontWeight: 600, wordBreak: 'break-all', color: 'var(--ink-2)',
+              }}
+            >{truncateAddress(addr)}</span>
             {addr && (
+              /* Glyph-only in BOTH states, so the confirmation cannot resize
+                 this box and reflow the address next to it — a spelled-out
+                 "Copied" costs 38px, more than the wider head gained. The word
+                 is still announced: it lives in the aria-live region, hidden. */
               <span
                 aria-live="polite"
                 style={{
                   marginLeft: 'auto', flex: '0 0 auto', display: 'inline-flex',
-                  alignItems: 'center', gap: 3, fontSize: 11, fontWeight: 600,
-                  color: copied ? 'var(--accent)' : 'var(--ink-3)',
+                  alignItems: 'center', color: copied ? 'var(--accent)' : 'var(--ink-3)',
                 }}
               >
-                {copied ? <><Icon.check /> Copied</> : <Icon.copy />}
+                {copied ? <Icon.check /> : <Icon.copy />}
+                {copied && <span style={SR_ONLY}>Copied</span>}
               </span>
             )}
           </button>

--- a/templates/zswap-da/src/ui/WalletMenu.tsx
+++ b/templates/zswap-da/src/ui/WalletMenu.tsx
@@ -5,12 +5,19 @@ import { WalletPill, type WalletInfo } from './WalletPill';
 import { Icon } from './icons';
 import { truncateAddress } from '../utils';
 import { fmtBalance } from '../state/format';
+import { formatShieldedAddress } from '../state/shieldedAddress';
 import { TokenChip } from './TokenChip';
 import type { KnownToken } from '../types';
+
+const NETWORK_ID = (import.meta.env.VITE_MIDNIGHT_NETWORK_ID as string) || 'undeployed';
+
+/** How long the "Copied" confirmation stays up. */
+const COPIED_MS = 1500;
 
 interface WalletMenuState {
   wallet: WalletInfo | null;
   shieldedAddress: string | null;
+  shieldedEncryptionPublicKey: string | null;
   unshieldedAddress: string | null;
   shieldedBalances: Record<string, string> | null;
   unshieldedBalances: Record<string, string> | null;
@@ -43,13 +50,41 @@ function BalRows({ title, balances, knownTokens }: { title: string; balances: Re
 
 export function WalletMenu({ st }: { st: WalletMenuState }) {
   const [open, setOpen] = useState(false);
+  const [copied, setCopied] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
+  const copyTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   useEffect(() => {
     const off = (e: PointerEvent) => { if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false); };
     document.addEventListener('pointerdown', off);
     return () => document.removeEventListener('pointerdown', off);
   }, []);
-  const addr = st.shieldedAddress ?? st.unshieldedAddress ?? '';
+  useEffect(() => () => { if (copyTimer.current) clearTimeout(copyTimer.current); }, []);
+
+  // The local JS wallet reports the shielded identity as a raw hex coin public
+  // key; Lace reports the canonical bech32m address. Normalize for display only
+  // — st.shieldedAddress itself is what the faucet and offer builders consume.
+  // The unshielded fallback (shown when there is no shielded address yet) is
+  // already bech32m and passes straight through.
+  const addr = st.shieldedAddress
+    ? formatShieldedAddress(st.shieldedAddress, st.shieldedEncryptionPublicKey, NETWORK_ID)
+    : (st.unshieldedAddress ?? '');
+
+  const copyAddress = async () => {
+    if (!addr) return;
+    // Absent on non-secure origins; rejects if the user denies permission.
+    // Either way stay silent rather than flash a "Copied" that did not happen.
+    const clipboard = typeof navigator !== 'undefined' ? navigator.clipboard : undefined;
+    if (!clipboard?.writeText) return;
+    try {
+      await clipboard.writeText(addr);
+    } catch {
+      return;
+    }
+    setCopied(true);
+    if (copyTimer.current) clearTimeout(copyTimer.current);
+    copyTimer.current = setTimeout(() => setCopied(false), COPIED_MS);
+  };
+
   if (!st.wallet) return null;
   return (
     <div ref={ref} style={{ position: 'relative' }}>
@@ -62,10 +97,37 @@ export function WalletMenu({ st }: { st: WalletMenuState }) {
               <button className="zs-btn zs-btn--ghost" style={{ padding: '2px 8px', fontSize: 11 }} disabled={st.refreshing} onClick={() => st.refreshBalances!()}>{st.refreshing ? '…' : 'Refresh'}</button>
             )}
           </div>
-          <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 12 }}>
+          {/* Clicking copies the FULL address. The dropdown stays open: the
+              only thing that closes it is a pointerdown outside `ref`, and this
+              button lives inside it. */}
+          <button
+            type="button"
+            onClick={copyAddress}
+            disabled={!addr}
+            title={addr ? 'Copy address' : undefined}
+            aria-label={addr ? `Copy address ${addr}` : undefined}
+            style={{
+              display: 'flex', alignItems: 'center', gap: 6, marginBottom: 12,
+              width: '100%', padding: 0, border: 0, background: 'none',
+              font: 'inherit', textAlign: 'left', color: 'inherit',
+              cursor: addr ? 'pointer' : 'default',
+            }}
+          >
             <Icon.shield style={{ color: 'var(--accent)', flex: '0 0 auto' }} />
             <span className="zs-num" style={{ fontSize: 12.5, fontWeight: 600, wordBreak: 'break-all', color: 'var(--ink-2)' }}>{truncateAddress(addr)}</span>
-          </div>
+            {addr && (
+              <span
+                aria-live="polite"
+                style={{
+                  marginLeft: 'auto', flex: '0 0 auto', display: 'inline-flex',
+                  alignItems: 'center', gap: 3, fontSize: 11, fontWeight: 600,
+                  color: copied ? 'var(--accent)' : 'var(--ink-3)',
+                }}
+              >
+                {copied ? <><Icon.check /> Copied</> : <Icon.copy />}
+              </span>
+            )}
+          </button>
           <BalRows title="Shielded" balances={st.shieldedBalances} knownTokens={st.knownTokens ?? []} />
           <BalRows title="Unshielded" balances={st.unshieldedBalances} knownTokens={st.knownTokens ?? []} />
           <button className="zs-btn zs-btn--block" style={{ padding: 11, fontSize: 14 }} onClick={() => { setOpen(false); st.disconnect(); }}>Disconnect</button>

--- a/templates/zswap-da/src/ui/icons.tsx
+++ b/templates/zswap-da/src/ui/icons.tsx
@@ -124,6 +124,8 @@ export const Icon = {
   wallet: (p: SvgProps) => (<svg viewBox="0 0 16 16" fill="none" width="13" height="13" {...p}><rect x="1.8" y="3.6" width="12.4" height="9" rx="2.2" stroke="currentColor" strokeWidth="1.4" /><path d="M10.6 8.2h1.7" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" /><path d="M2 5.4h8.5" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" /></svg>),
   ext: (p: SvgProps) => (<svg viewBox="0 0 16 16" fill="none" width="12" height="12" {...p}><path d="M6 3h7v7M13 3l-7.5 7.5" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" /></svg>),
   dot: (p: SvgProps) => (<svg viewBox="0 0 8 8" width="8" height="8" {...p}><circle cx="4" cy="4" r="3" fill="currentColor" /></svg>),
+  copy: (p: SvgProps) => (<svg viewBox="0 0 16 16" fill="none" width="12" height="12" {...p}><rect x="5.6" y="5.6" width="8.2" height="8.2" rx="2" stroke="currentColor" strokeWidth="1.4" /><path d="M10.4 3.6a2 2 0 00-2-1.4H4.2a2 2 0 00-2 2v4.2a2 2 0 001.4 2" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" /></svg>),
+  check: (p: SvgProps) => (<svg viewBox="0 0 16 16" fill="none" width="12" height="12" {...p}><path d="M3 8.4l3.2 3.2L13 4.8" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" /></svg>),
 };
 
 // Inline tag marking a token's privacy mode.

--- a/templates/zswap-da/src/utils.test.ts
+++ b/templates/zswap-da/src/utils.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from 'bun:test';
+import { isShieldedAddress, truncateAddress } from './utils';
+
+// Real 135-character shielded address (local JS wallet keys, undeployed).
+const SHIELDED =
+  'mn_shield-addr_undeployed1qrdysugev8mhtgn8wvl64kpepy4zuwj06jrl0jkerfax7xswr3sngr30cu2vwevpj32z2r2z8xtvltzw8cfgcuklx8qhuc7yrthwtdgqhz8fj';
+const SHIELDED_TESTNET = SHIELDED.replace('_undeployed1', '_testnet1');
+// 'mainnet' is the one network whose segment the address format omits.
+const SHIELDED_MAINNET = SHIELDED.replace('_undeployed1', '1');
+
+const UNSHIELDED = 'mn_addr_undeployed14dunrde2fuwg60jmjpm2rsk5umuqj9f88py4qctjsw2q2psd7zgqqtsnha';
+const HEX = 'ab7931b72a4f1c8d3e5b9076a1c2d4e6f80915273849506172839405060df090';
+
+describe('isShieldedAddress', () => {
+  test('recognises shielded addresses on every network', () => {
+    expect(isShieldedAddress(SHIELDED)).toBe(true);
+    expect(isShieldedAddress(SHIELDED_TESTNET)).toBe(true);
+    expect(isShieldedAddress(SHIELDED_MAINNET)).toBe(true);
+  });
+
+  test('rejects everything the menu can show instead', () => {
+    // WalletMenu picks the address font size off this, so an unshielded or
+    // still-syncing value must keep the original 12.5px.
+    expect(isShieldedAddress(UNSHIELDED)).toBe(false);
+    expect(isShieldedAddress(HEX)).toBe(false);
+    expect(isShieldedAddress('')).toBe(false);
+  });
+});
+
+describe('truncateAddress — shielded addresses get a wider head', () => {
+  test('keeps the whole human-readable part', () => {
+    // 26 head + '…' + 6 tail. The old 10-character head stopped inside the
+    // constant tag ('mn_shield-'), hiding the network segment entirely.
+    expect(truncateAddress(SHIELDED)).toBe('mn_shield-addr_undeployed1…qhz8fj');
+  });
+
+  test('the network segment is visible (the point of the wider head)', () => {
+    expect(truncateAddress(SHIELDED)).toContain('_undeployed');
+    expect(truncateAddress(SHIELDED_TESTNET)).toContain('_testnet');
+    // 'undeployed' is the longest network id we ship, so it consumes the whole
+    // head; a shorter id spends the remainder on key material.
+    expect(truncateAddress(SHIELDED_TESTNET)).toBe('mn_shield-addr_testnet1qrd…qhz8fj');
+  });
+
+  test('mainnet (no network segment) still uses the wide head', () => {
+    expect(truncateAddress(SHIELDED_MAINNET)).toBe('mn_shield-addr1qrdysugev8m…qhz8fj');
+  });
+
+  test('two wallets on one network stay distinguishable', () => {
+    // On undeployed the head is all human-readable part, so the tail carries
+    // the difference; on a shorter network id the head does too.
+    const otherTail = SHIELDED.slice(0, -6) + 'zzzzzz';
+    expect(truncateAddress(otherTail)).not.toBe(truncateAddress(SHIELDED));
+    const otherHead = SHIELDED_TESTNET.slice(0, 23) + 'zzz' + SHIELDED_TESTNET.slice(26);
+    expect(truncateAddress(otherHead)).not.toBe(truncateAddress(SHIELDED_TESTNET));
+  });
+
+  test('renders 33 characters — the width the 280px dropdown was measured against', () => {
+    // 210.5px of the 213px the row leaves for text, at the 11px the menu uses
+    // for shielded addresses. Widening the head further wraps onto two lines.
+    expect(truncateAddress(SHIELDED)).toHaveLength(33);
+    expect(truncateAddress(SHIELDED_TESTNET)).toHaveLength(33);
+    expect(truncateAddress(SHIELDED_MAINNET)).toHaveLength(33);
+  });
+
+  test('a shielded address short enough to fit is returned whole', () => {
+    const short = 'mn_shield-addr_undeployed1';
+    expect(truncateAddress(short)).toBe(short);
+  });
+});
+
+describe('truncateAddress — everything else keeps the original 10 + 6 rule', () => {
+  test('an unshielded mn_addr_ address is unchanged', () => {
+    expect(truncateAddress(UNSHIELDED)).toBe('mn_addr_un...qtsnha');
+    expect(truncateAddress(UNSHIELDED)).toBe(UNSHIELDED.slice(0, 10) + '...' + UNSHIELDED.slice(-6));
+  });
+
+  test('raw hex (the no-encryption-key fallback) is unchanged', () => {
+    expect(truncateAddress(HEX)).toBe(HEX.slice(0, 10) + '...' + HEX.slice(-6));
+  });
+
+  test('strings of 16 characters or fewer are returned verbatim', () => {
+    expect(truncateAddress('')).toBe('');
+    expect(truncateAddress('short')).toBe('short');
+    expect(truncateAddress('0123456789abcdef')).toBe('0123456789abcdef');
+    expect(truncateAddress('0123456789abcdefg')).toBe('0123456789...bcdefg');
+  });
+
+  test('a near-miss prefix does not get the wide head', () => {
+    // Only the exact shielded tag opts in; mn_shield_ (no '-addr') does not.
+    const nearMiss = 'mn_shield_undeployed1qrdysugev8mhtgn8wvl64kpepy4zuwj06jrl0jkerfax7';
+    expect(truncateAddress(nearMiss)).toBe(nearMiss.slice(0, 10) + '...' + nearMiss.slice(-6));
+  });
+});

--- a/templates/zswap-da/src/utils.ts
+++ b/templates/zswap-da/src/utils.ts
@@ -6,9 +6,41 @@ export function shortToken(t?: string): string {
   return t.slice(0, 6) + '…' + t.slice(-4);
 }
 
+/** A canonical Midnight shielded address: `mn_shield-addr_<network>1…`. */
+export function isShieldedAddress(addr: string): boolean {
+  return addr.startsWith('mn_shield-addr');
+}
+
+/**
+ * Head kept for a shielded address.
+ *
+ * A shielded address spends its first 15 characters on the constant
+ * `mn_shield-addr_` tag, so the generic 10-character head below renders every
+ * shielded identity as the same `mn_shield-...qhz8fj`: the network segment and
+ * all but 6 characters of key material are invisible, and two wallets look
+ * alike in the dropdown. 26 characters covers the whole human-readable part at
+ * the longest network id we ship (`mn_shield-addr_undeployed1`); shorter ids
+ * spend the remainder on key material (`mn_shield-addr_testnet1qrd`).
+ *
+ * 26 is a measured number, not a taste one — it is what fits on one line beside
+ * the copy glyph in the 280px dropdown card. See the plan's Phase 6.
+ */
+const SHIELDED_HEAD = 26;
+
+const HEAD = 10;
+const TAIL = 6;
+
 export function truncateAddress(addr: string): string {
-  if (addr.length <= 16) return addr;
-  return addr.slice(0, 10) + '...' + addr.slice(-6);
+  if (isShieldedAddress(addr)) {
+    // A one-character ellipsis rather than the '...' below: it buys back two
+    // characters of width, which at this length is the difference between
+    // fitting on one line and wrapping onto two.
+    return addr.length <= SHIELDED_HEAD + TAIL
+      ? addr
+      : addr.slice(0, SHIELDED_HEAD) + '…' + addr.slice(-TAIL);
+  }
+  if (addr.length <= HEAD + TAIL) return addr;
+  return addr.slice(0, HEAD) + '...' + addr.slice(-TAIL);
 }
 
 export function findTokenName(token: string, knownTokens: KnownToken[]): string | undefined {


### PR DESCRIPTION
## What

In the `zswap-da` wallet dropdown, the shielded identity rendered as an unrecognizable hex blob and could not be copied. This makes it show the canonical `mn_shield-addr_<network>1…` address and copies the full address on click.

```
before:  🛡 00da487119...0e1c61                     (raw hex, no copy affordance)
after:   🛡 mn_shield-...qhz8fj              [copy] (canonical; click → "✓ Copied")
```

**Not a breaking change.** Template-only, and display-only within the template — no package API changes, no dependency changes (`bun.lock` untouched), no change to any value that is submitted anywhere.

## Why the address looked wrong

`WalletMenu` rendered `st.shieldedAddress` verbatim. For the **built-in JS wallet** that field is the raw hex **coin public key**, deliberately: `@effectstream/wallets` sets `shieldedAddress = initialShielded.address.coinPublicKeyString()` because the hex form is what shielded-output builders consume. Lace already returns bech32m, so the bug was only visible on the local wallet.

A Midnight shielded address is `bech32m(coin public key ++ encryption public key)`. The connector exposes both halves — the second was simply never carried to the UI.

## How

- New `src/state/shieldedAddress.ts` → `formatShieldedAddress(address, encryptionPublicKey, networkId)`, and `shieldedEncryptionPublicKey` threaded through `WalletState` → `ZSwapApp` so the UI can reach the second half.
- **Raw stored values are untouched.** The faucet, the mint/output builders and offer-sender matching all still see exactly the encodings they see today. This is formatting at the render site only.
- Anything already bech32m passes straight through — Lace's address, and the `mn_addr_…` unshielded fallback — so nothing is double-encoded or mislabelled.
- Falls back to the raw value whenever the address cannot be derived, so the row degrades to today's behavior instead of crashing or blanking.
- The network segment comes from `VITE_MIDNIGHT_NETWORK_ID`, not a hardcoded `undeployed`.

### One subtlety worth a reviewer's eye

The helper checks that **both** hexes are exactly 32 bytes before composing. That is load-bearing rather than defensive: `ShieldedCoinPublicKey` validates its own length, but `ShieldedEncryptionPublicKey` does **not** — handed a short or non-hex string it silently builds a truncated key, which then encodes into a perfectly valid-looking `mn_shield-addr_…` that nobody can receive at. Showing a wrong address is worse than showing the hex, so a `try`/`catch` alone would not have been enough.

## Copy on click

The address is now a real `<button>` (focusable, Enter/Space, `aria-label` carrying the full address) that copies the **full, untruncated** address and shows a transient "Copied" for 1.5 s. The dropdown stays open — the only thing that closes it is a `pointerdown` outside the container, and the button is inside it.

`navigator.clipboard` is capability-checked *before* use and the write is wrapped, so on a non-secure origin or a denied permission the click is a silent no-op. Note `await navigator.clipboard?.writeText(x)` alone would not do: optional chaining yields `undefined`, `await undefined` resolves, and the UI would flash a "Copied" that never happened.

## Faucet

The faucet's "minting … to your shielded balance · `<addr>`" caption reuses the same helper. That string is a caption only — the mint recipient is derived independently inside `contractWallet.getShieldedKeys()` — so nothing about what gets submitted changes.

## Testing

- **`bun test src/` → 30 pass / 0 fail** (11 new + 19 pre-existing). New cases cover the round-trip, the network prefix for `undeployed`/`testnet`/`mainnet`, `0x` and uppercase hex, both pass-through paths, and every degradation case including the short-encryption-key trap above.
- **`bun run build` (`tsc -b && vite build`) clean** — 7091 modules, zero TS errors, no new warnings.
- **Real key derivation exercised**: `ledger-v9` `ZswapSecretKeys.fromSeed` → the exact `ShieldedAddress` construction `wallet-sdk-shielded` performs → the strings the local connector exposes → the helper. Both halves are genuinely 32 bytes and encode to `mn_shield-addr_undeployed1qrdy…qhz8fj`. This was the one real risk (a 35-byte key would have made the guard reject every real address and silently no-op the fix).
- **In-browser**, driving the real `WalletMenu`: full 135-char address reaches `writeText`; dropdown stays open; "Copied" appears and self-clears; Refresh and Disconnect still work. The unavailable-clipboard path was verified against a *genuinely rejecting* API — the automation profile denies clipboard-write, `writeText` threw `NotAllowedError`, and the component showed no "Copied" and did not crash.

### Note for anyone extending this

The round-trip test decodes with `@scure/base` rather than `MidnightBech32m.parse`. That is not a style preference: `@midnightntwrk/wallet-sdk-address-format` encodes with the bech32m length limit disabled but parses with the default 90-character cap still on, and a shielded address is 124–135 characters — so the library cannot read back its own shielded addresses.

```
MidnightBech32m.parse('mn_shield-addr_undeployed1…')
  -> TypeError: invalid string length 135, expected (8..90)
```

Identical at the pinned `3.1.2` and at `4.0.0-beta.2`, so it is upstream behavior, not a pin problem. Nothing here regresses: every `MidnightBech32m.parse` call site in the template parses 77-character *unshielded* addresses. But if the template ever accepts a pasted `mn_shield-addr_…`, it will need the `@scure/base` decoder.


---

## Follow-up in this PR: the truncated form now shows the network segment

The first commit fixed the *value* but not the *render*. `truncateAddress` keeps the first 10 characters, and a shielded address spends its first 15 on the constant `mn_shield-addr_` tag — so every shielded identity still displayed as the same `mn_shield-...qhz8fj`, with the network segment and all but 6 characters of key material invisible.

```
before:  🛡 mn_shield-...qhz8fj                 [copy]
after:   🛡 mn_shield-addr_undeployed1…qhz8fj   [copy]
```

Shielded addresses now keep a **26-character head** plus the last 6. 26 is exactly `mn_shield-addr_undeployed1` — the whole human-readable part at the longest network id this template ships. Shorter ids spend the remainder on key material (`mn_shield-addr_testnet1qrd…qhz8fj`). Unshielded `mn_addr_…` and the raw-hex fallback keep the original 10 + 6 rendering byte for byte.

Two supporting changes, both **measured** against the 280px dropdown card rather than eyeballed. Card inner width is 250px; after the shield icon, two 6px gaps and the copy glyph, the address text gets **213px**.

- **Shielded addresses render at 11px** instead of 12.5px. The 33-character string needs 210.5px; at 12.5px it needs 239px and wraps onto a second line. Checked against the whole font stack in case Google Fonts is blocked — JetBrains Mono 210.5px, SF Mono 173.7px, Menlo/generic `monospace` 211.3px, all under 213px — and `word-break: break-all` still degrades to two lines rather than overflowing if some future font is wider.
- **The copy affordance is glyph-only in both states.** This was the real blocker: spelling out "Copied" grew the feedback span from 12px to 50.4px, leaving 174.6px and reflowing the address onto two lines for the duration of the flash. No head wide enough to clear the `mn_shield-addr_` tag survives that. The word moved into the `aria-live` region as visually-hidden text, so screen readers still hear "Copied"; sighted feedback is the accent-coloured check glyph, which now occupies the exact same 12px slot as the copy glyph. The row no longer reflows on copy at all.

Click-to-copy is unchanged and still copies the **full 135-character** address, not the truncated render.

### Testing for this commit

- **`bun test src/` → 42 pass / 0 fail** across 3 files (12 new in `src/utils.test.ts`, on top of the 30 already here). New cases: the wide head on `undeployed`/`testnet`/`mainnet`, the network segment being visible, two wallets staying distinguishable, the 33-character render, unshielded/hex/short strings unchanged at 10 + 6, and a near-miss `mn_shield_` prefix *not* opting in.
- **`bun run build` clean** — exit 0, 7091 modules, `16 files match manifest.json`, zero TS errors.
- **In-browser**, real `WalletMenu` on a throwaway Vite server: one line in the resting *and* Copied states (row height 34px → 14px), feedback span constant at 12px, full 135-character address still reaching `writeText` while the rendered value is 33 characters, dropdown still open on copy, unshielded and hex rows pixel-identical at 12.5px, Refresh/Disconnect/outside-click all still working.

Still template-only, still display-only, still no dependency or package-API change — **not a breaking change**.
