### PR TITLE
fix(zswap-da): settle a multi-offer take as ONE merged transaction

### DIFF
--- a/templates/zswap-da/src/services/browserContract.ts
+++ b/templates/zswap-da/src/services/browserContract.ts
@@ -38,9 +38,13 @@ import { parseCoinPublicKeyToHex } from '@midnight-ntwrk/midnight-js-utils';
 // below: that is the MIP-0005 codec, unrelated to this contract despite the
 // name.
 import * as OfferFilesContract from '../contract/managed/contract/index.js';
-import { OfferFiles } from '@effectstream/mip-zswap-offer/mip5';
 import { API_BASE } from '../config';
 import { submitToBatcher } from './api';
+import {
+  chooseLaceBalancing,
+  decodeMakerOffers,
+  mergeMakerOffersToBytes,
+} from './offerBatch';
 import { dlog, timed } from '../debug';
 
 export interface MidnightBrowserConfig {
@@ -250,54 +254,6 @@ export async function connectBrowserContract(
 }
 
 /**
- * Inspect the maker tx and pick the single segment that carries the swap's
- * shielded/unshielded asset imbalances. Used to decide which balancing
- * strategy `proveAndSubmitOffer` will use.
- */
-function pickSwapSegment(makerTx: any): { segId: number; imbalances: Map<any, bigint> } {
-  // Lace's makeIntent populates `intents` (Intent objects) and may also touch
-  // `fallibleOffer` (ZswapOffer). Union them with segment 0 (guaranteed),
-  // then keep only segments with non-empty asset imbalances.
-  const intentIds: number[] = makerTx.intents
-    ? (Array.from(makerTx.intents.keys()) as number[])
-    : [];
-  const fallibleIds: number[] = makerTx.fallibleOffer
-    ? (Array.from(makerTx.fallibleOffer.keys()) as number[])
-    : [];
-  const candidates = Array.from(new Set<number>([0, ...intentIds, ...fallibleIds]));
-
-  const swaps: Array<{ segId: number; imbalances: Map<any, bigint> }> = [];
-  for (const segId of candidates) {
-    let imb: Map<any, bigint>;
-    try {
-      imb = makerTx.imbalances(segId) as Map<any, bigint>;
-    } catch {
-      continue;
-    }
-    const hasAssets = Array.from(imb.entries()).some(([tt, v]) => {
-      const tag = (tt as any).tag;
-      return (tag === 'shielded' || tag === 'unshielded') && v !== 0n;
-    });
-    if (hasAssets) swaps.push({ segId, imbalances: imb });
-  }
-
-  if (swaps.length === 0) {
-    throw new Error(
-      `Maker offer has no shielded/unshielded asset imbalances — nothing to mirror. ` +
-        `(intent ids: ${JSON.stringify(intentIds)}, fallible ids: ${JSON.stringify(fallibleIds)})`,
-    );
-  }
-  if (swaps.length > 1) {
-    throw new Error(
-      `Multi-segment offers are not supported (asset imbalances in segments ${
-        swaps.map(s => s.segId).join(', ')
-      }).`,
-    );
-  }
-  return swaps[0]!;
-}
-
-/**
  * Shielded-only path: maker tx has no Intent slots and asset deltas live in
  * segment 0's guaranteed Zswap offer. `balanceSealedTransaction` can't be
  * used here — it walks `tx.intents` and throws "No segments found in the
@@ -306,7 +262,7 @@ function pickSwapSegment(makerTx: any): { segId: number; imbalances: Map<any, bi
  * keyed Intents.
  *
  * Unshielded offers are dispatched away from this function in
- * `proveAndSubmitOffer` because Lace's unshielded `makeIntent` adds an
+ * `proveAndSubmitOffers` because Lace's unshielded `makeIntent` adds an
  * empty structural Intent[1] to *both* maker and taker txs, which collides
  * on merge with "key (segment_id) collision during intents merge: 1".
  */
@@ -397,7 +353,7 @@ async function balanceShieldedViaMirrorMerge(
   );
 
   // Full taker tx shape (mirror of the maker tx segment log earlier in
-  // proveAndSubmitOffer). Tells us which segIds Lace actually populated and
+  // proveAndSubmitOffers). Tells us which segIds Lace actually populated and
   // what's in each segment — enough to diagnose any "intents merge: N"
   // collision or zswap-offer composition error.
   const takerIntentIds: number[] = takerTx.intents
@@ -431,7 +387,7 @@ async function balanceShieldedViaMirrorMerge(
 
   // Sanity check: under the shielded-only dispatch, neither maker nor taker
   // should have any Intent slots, so `overlapping` is expected to be empty.
-  // A non-empty list here means the dispatch in `proveAndSubmitOffer` is
+  // A non-empty list here means the dispatch in `proveAndSubmitOffers` is
   // mis-routing an offer that has Intents into mirror+merge.
   const overlap = makerIntentIds.filter((id) => takerIntentIds.includes(id));
   console.log('[browserContract] complete (mirror+merge): about to merge', {
@@ -500,9 +456,28 @@ async function balanceMixedViaSealedBalance(
 }
 
 /**
- * Complete a maker's bech32m offer blob as the connected browser wallet.
+ * Complete one or more makers' bech32m offer blobs as the connected browser
+ * wallet, in a SINGLE transaction.
  *
- * Two strategies, dispatched on the maker tx shape:
+ * The N maker halves are decoded and folded together first (see
+ * services/offerBatch.ts), and the wallet then balances the merged result once.
+ * Settling a ladder offer-by-offer re-spent the taker's only coin — nothing
+ * told the wallet about take #k's spend before take #k+1 was balanced, and the
+ * node rejected everything after the first with
+ * `Zswap(NullifierAlreadyPresent)`. One balancing pass, one submission, no
+ * window.
+ *
+ * A merged shielded↔shielded ladder is the same SHAPE as one shielded offer as
+ * far as this function's dispatch is concerned — no Intents, deltas summed in
+ * segment 0 — so it takes the same mirror+merge route, and the mirrored taker
+ * side covers the ladder's totals. `offerBatch.test.ts` asserts that against
+ * the real ledger. Offers that cannot compose (two unshielded legs both at
+ * segment 1) are refused by `mergeMakerOffersToBytes` before anything is sent.
+ *
+ * N=1 is byte-for-byte the old single-offer path: the wallet is handed the
+ * blob's own decoded bytes, not a re-serialization of them.
+ *
+ * Two balancing strategies, dispatched on the merged maker tx's shape:
  *   - segment-0 deltas, no Intent slots (shielded-only) → mirror+merge
  *   - any Intent slot present (unshielded or numbered)  → balanceSealedTransaction
  *
@@ -514,32 +489,32 @@ async function balanceMixedViaSealedBalance(
  *     merge: 1" on unshielded offers — Lace's unshielded `makeIntent` always
  *     lands its Intent at segId 1, so maker and taker would both carry it.
  */
-export async function proveAndSubmitOffer(
+export async function proveAndSubmitOffers(
   connectedApi: ConnectedAPI,
   config: MidnightBrowserConfig,
-  offerBech32m: string,
+  offerBech32ms: string[],
 ): Promise<{ txHash: string }> {
-  dlog('proveAndSubmitOffer: enter', {
+  dlog('proveAndSubmitOffers: enter', {
     networkId: config.networkId,
     contractAddress: config.contractAddress,
     proofServerUri: config.proofServerUri,
-    offerLen: offerBech32m.length,
+    offers: offerBech32ms.length,
+    offerLens: offerBech32ms.map((b) => b.length),
   });
   setNetworkId(config.networkId as NetworkId);
 
   console.log('[browserContract] complete: decoding offer bytes');
-  dlog('proveAndSubmitOffer: → OfferFiles.decode + deserialize maker tx (sync)');
-  const rawBytes = OfferFiles.decode(offerBech32m);
-  const makerTx = LedgerV8Transaction.deserialize(
-    'signature',
-    'proof',
-    'binding',
-    rawBytes,
-  );
-  dlog('proveAndSubmitOffer: ✓ maker tx deserialized', { bytes: rawBytes.length });
+  dlog('proveAndSubmitOffers: → decode + merge maker txs (sync)');
+  const decoded = decodeMakerOffers(offerBech32ms, config.networkId as NetworkId);
+  const { tx: makerTx, bytes: makerBytes } = mergeMakerOffersToBytes(decoded);
+  dlog('proveAndSubmitOffers: ✓ maker txs deserialized + merged', {
+    offers: decoded.length,
+    bytes: decoded.map((d) => d.raw.length),
+    mergedBytes: makerBytes.length,
+  });
 
-  // Diagnostic: full segment shape of the maker tx. Drives the dispatch
-  // decision below (Intent slot present? → sealed balance; else →
+  // Diagnostic: full segment shape of the (merged) maker tx. Drives the
+  // dispatch decision below (Intent slot present? → sealed balance; else →
   // mirror+merge) and gives fast triage on any balance/merge error.
   const intentIds: number[] = makerTx.intents
     ? (Array.from(makerTx.intents.keys()) as number[])
@@ -548,6 +523,7 @@ export async function proveAndSubmitOffer(
     ? (Array.from(makerTx.fallibleOffer.keys()) as number[])
     : [];
   console.log('[browserContract] complete: maker tx segments', {
+    offers: decoded.length,
     intentIds,
     fallibleIds,
     segmentImbalances: Object.fromEntries(
@@ -569,15 +545,7 @@ export async function proveAndSubmitOffer(
     ),
   });
 
-  const swap = pickSwapSegment(makerTx);
-
-  // Mirror+merge requires both halves to have no Intent slots (see function
-  // docstring). Unshielded makeIntent puts asset deltas in segment 0 but
-  // also tacks on an empty Intent[1] — that empty Intent doesn't move
-  // `swap.segId` away from 0, so the segId test alone is insufficient.
-  const makerHasIntents = !!makerTx.intents
-    && Array.from(makerTx.intents.keys() as Iterable<number>).length > 0;
-  const useMirrorMerge = swap.segId === 0 && !makerHasIntents;
+  const { useMirrorMerge, ...swap } = chooseLaceBalancing(makerTx);
   const strategy = useMirrorMerge
     ? 'mirror+merge (segment 0 / guaranteed offer)'
     : 'balanceSealedTransaction (numbered Intent)';
@@ -595,13 +563,14 @@ export async function proveAndSubmitOffer(
       ));
     } else {
       ({ balancedHex, txHash } = await timed('balance via sealed-balance', () =>
-        balanceMixedViaSealedBalance(connectedApi, toHex(rawBytes)),
+        balanceMixedViaSealedBalance(connectedApi, toHex(makerBytes)),
       ));
     }
-    dlog('proveAndSubmitOffer: ✓ balanced', { strategy, balancedBytes: balancedHex.length / 2, txHash });
+    dlog('proveAndSubmitOffers: ✓ balanced', { strategy, balancedBytes: balancedHex.length / 2, txHash });
   } catch (e: any) {
     console.error('[browserContract] complete: balancing failed', {
       strategy,
+      offers: decoded.length,
       name: e?.name,
       message: e?.message,
       raw: e,
@@ -613,15 +582,18 @@ export async function proveAndSubmitOffer(
   }
 
   const coinPublicKeyHex = parseCoinPublicKeyToHex(
-    (await timed('proveAndSubmitOffer: wallet.getShieldedAddresses() (for batcher addr)', () =>
+    (await timed('proveAndSubmitOffers: wallet.getShieldedAddresses() (for batcher addr)', () =>
       connectedApi.getShieldedAddresses(),
     )).shieldedCoinPublicKey,
     config.networkId as NetworkId,
   );
 
-  console.log('[browserContract] complete: submitting to batcher', { txHash });
+  console.log('[browserContract] complete: submitting to batcher', {
+    txHash,
+    offers: decoded.length,
+  });
   try {
-    await timed('proveAndSubmitOffer: submitToBatcher', () =>
+    await timed('proveAndSubmitOffers: submitToBatcher (one submission for the whole batch)', () =>
       submitToBatcher(balancedHex, 'finalized', coinPublicKeyHex),
     );
   } catch (e: any) {
@@ -635,6 +607,18 @@ export async function proveAndSubmitOffer(
     );
   }
 
-  console.log('[browserContract] complete: done', { txHash });
+  console.log('[browserContract] complete: done', { txHash, offers: decoded.length });
   return { txHash };
+}
+
+/**
+ * Single-offer take — the degenerate N=1 of {@link proveAndSubmitOffers}, so
+ * both paths decode, balance and submit through exactly the same code.
+ */
+export function proveAndSubmitOffer(
+  connectedApi: ConnectedAPI,
+  config: MidnightBrowserConfig,
+  offerBech32m: string,
+): Promise<{ txHash: string }> {
+  return proveAndSubmitOffers(connectedApi, config, [offerBech32m]);
 }

--- a/templates/zswap-da/src/services/localTradeOffers.ts
+++ b/templates/zswap-da/src/services/localTradeOffers.ts
@@ -190,7 +190,7 @@ export async function settleOffersLocal(
   const makerTx = mergeMakerOffers(decoded);
   dlog('localOffer.settle: maker txs decoded + merged', {
     offers: decoded.length,
-    bytes: decoded.map((d) => d.bytes),
+    bytes: decoded.map((d) => d.raw.length),
   });
 
   // What the taker pays = the makers' wants. Any unshielded leg anywhere in the

--- a/templates/zswap-da/src/services/localTradeOffers.ts
+++ b/templates/zswap-da/src/services/localTradeOffers.ts
@@ -10,9 +10,14 @@
 //
 //   maker:  initSwap → [signRecipe if unshielded gives] → finalizeRecipe(prove)
 //           → serialize → MIP-0005 encode
-//   taker:  decode → balanceFinalizedTransaction → [signRecipe if the taker
-//           pays unshielded] → finalizeRecipe (proves the balancing tx and
-//           merges it with the maker tx) → batcher submit
+//   taker:  decode N → merge the N maker txs → balanceFinalizedTransaction →
+//           [signRecipe if the taker pays unshielded anywhere in the batch] →
+//           finalizeRecipe (proves the balancing tx and merges it with the
+//           merged maker tx) → ONE batcher submit
+//
+// Taking several offers is one settlement, not several: see
+// services/offerBatch.ts for why (per-offer settlement double-spent the taker's
+// only coin) and for the single constraint on merging.
 //
 // Fee policy matches the rest of the app: nobody here pays Dust. The maker
 // offer is intentionally imbalanced (payFees:false); the taker balances only
@@ -26,15 +31,12 @@
 // Shielded legs carry no signatures (ZK proofs + Pedersen binding), so the
 // sign step is skipped when no unshielded leg is involved.
 
-import {
-  Transaction as LedgerV8Transaction,
-} from '@midnight-ntwrk/ledger-v8';
 import { type NetworkId, setNetworkId } from '@midnight-ntwrk/midnight-js-network-id';
 import { MidnightBech32m, UnshieldedAddress } from '@midnightntwrk/wallet-sdk-address-format';
 import { OfferFiles } from '@effectstream/mip-zswap-offer/mip5';
 import type { OfferLeg } from './makerOffer';
 import type { MidnightBrowserConfig } from './browserContract';
-import { parseTakerLegs } from './offerParse';
+import { batchPaysUnshielded, decodeMakerOffers, mergeMakerOffers } from './offerBatch';
 import { submitToBatcher } from './api';
 import { dlog, timed } from '../debug';
 
@@ -161,25 +163,39 @@ export async function buildMakerOfferBlobLocal(
 }
 
 /**
- * Take an offer via the wallet facade: balance the taker side of the maker's
- * proven, imbalanced tx and route the merged settlement through the batcher.
+ * Take one or more offers via the wallet facade, as a SINGLE transaction: fold
+ * the makers' proven, imbalanced txs together, balance the taker side of the
+ * whole ladder once, and route the merged settlement through the batcher.
  * Facade twin of browserContract.proveAndSubmitOffer (Lace).
+ *
+ * Balancing the batch once is what makes a ladder work at all. Per-offer
+ * settlement re-selected the taker's coins from wallet state that had not seen
+ * the previous take's spend, so the node rejected take #2 as a double spend
+ * (`Zswap(NullifierAlreadyPresent)`) and only the first offer was ever bought.
+ * See services/offerBatch.ts for the merge and its one constraint.
+ *
+ * The whole batch is decoded and merged BEFORE anything is submitted, so a
+ * ladder either settles as one transaction or does not settle at all.
  */
-export async function settleOfferLocal(
+export async function settleOffersLocal(
   localApi: LocalApiShape,
   config: MidnightBrowserConfig,
-  offerBech32m: string,
+  offerBech32ms: string[],
 ): Promise<{ txHash: string }> {
   const { facade, secretKeys, keystore } = facadeParts(localApi);
-  setNetworkId(config.networkId as NetworkId);
+  const networkId = config.networkId as NetworkId;
+  setNetworkId(networkId);
 
-  const rawBytes = OfferFiles.decode(offerBech32m);
-  const makerTx = LedgerV8Transaction.deserialize('signature', 'proof', 'binding', rawBytes);
-  dlog('localOffer.settle: maker tx decoded', { bytes: rawBytes.length });
+  const decoded = decodeMakerOffers(offerBech32ms, networkId);
+  const makerTx = mergeMakerOffers(decoded);
+  dlog('localOffer.settle: maker txs decoded + merged', {
+    offers: decoded.length,
+    bytes: decoded.map((d) => d.bytes),
+  });
 
-  // What the taker pays = the maker's wants. Drives the sign decision below.
-  const parsed = parseTakerLegs(offerBech32m, config.networkId as NetworkId);
-  const paysUnshielded = parsed?.pays.some((l) => l.kind === 'unshielded') ?? true;
+  // What the taker pays = the makers' wants. Any unshielded leg anywhere in the
+  // batch puts an unshielded input in the settlement, so it must be signed.
+  const paysUnshielded = batchPaysUnshielded(offerBech32ms, networkId);
 
   let recipe = await timed('localOffer.settle: facade.balanceFinalizedTransaction', () =>
     facade.balanceFinalizedTransaction(makerTx, secretKeys, {
@@ -195,14 +211,30 @@ export async function settleOfferLocal(
     );
   }
 
-  // Proves the taker's balancing tx and merges it with the maker tx —
-  // merge keeps each party's signatures on their own segments.
+  // Proves the taker's balancing tx and merges it with the (already merged)
+  // maker txs — merge keeps each party's signatures on their own segments.
   const settlement: any = await timed('localOffer.settle: facade.finalizeRecipe (prove+merge)', () =>
     facade.finalizeRecipe(recipe),
   );
 
   const serializedHex = toHex(settlement.serialize());
   const address = localApi.unshieldedAddress ?? keystore.getBech32Address().asString();
+  dlog('localOffer.settle: → submitToBatcher (one submission for the whole batch)', {
+    offers: decoded.length,
+    bytes: serializedHex.length / 2,
+  });
   const { txHash } = await submitToBatcher(serializedHex, 'finalized', address);
   return { txHash };
+}
+
+/**
+ * Single-offer take — the degenerate N=1 of {@link settleOffersLocal}, so both
+ * paths prove, merge and submit through exactly the same code.
+ */
+export function settleOfferLocal(
+  localApi: LocalApiShape,
+  config: MidnightBrowserConfig,
+  offerBech32m: string,
+): Promise<{ txHash: string }> {
+  return settleOffersLocal(localApi, config, [offerBech32m]);
 }

--- a/templates/zswap-da/src/services/offerBatch.test.ts
+++ b/templates/zswap-da/src/services/offerBatch.test.ts
@@ -10,7 +10,14 @@ import { describe, expect, test } from 'bun:test';
 import * as ledger from '@midnight-ntwrk/ledger-v8';
 import { OfferFiles } from '@effectstream/mip-zswap-offer/mip5';
 import type { NetworkId } from '@midnight-ntwrk/midnight-js-network-id';
-import { batchPaysUnshielded, decodeMakerOffers, mergeMakerOffers } from './offerBatch';
+import {
+  batchPaysUnshielded,
+  chooseLaceBalancing,
+  decodeMakerOffers,
+  mergeMakerOffers,
+  mergeMakerOffersToBytes,
+  pickSwapSegment,
+} from './offerBatch';
 
 const L = ledger as any;
 const NETWORK = 'undeployed' as NetworkId;
@@ -28,6 +35,22 @@ const encode = (tx: any): string => OfferFiles.encode(tx.serialize());
  * compose. This is the shape a shielded↔shielded ladder has.
  */
 const intentFreeTx = () => L.Transaction.fromParts(NETWORK).mockProve();
+
+/** Deterministic shielded keys — a fixture recipient, nothing secret. */
+const KEYS = L.ZswapSecretKeys.fromSeed(new Uint8Array(32).fill(3));
+
+/**
+ * A shielded-only offer that actually moves value: one output of TOKEN, so the
+ * maker pays it out and the TAKER pays for it. Shielded value lives in the
+ * transaction's guaranteed Zswap offer — segment 0, no Intent anywhere — which
+ * is the shape a shielded↔shielded ladder has, and the shape Lace's
+ * mirror+merge strategy exists for.
+ */
+const shieldedTx = (value = 7n) => {
+  const coin = L.createShieldedCoinInfo(TOKEN, value);
+  const output = L.ZswapOutput.new(coin, undefined, KEYS.coinPublicKey, KEYS.encryptionPublicKey);
+  return L.Transaction.fromParts(NETWORK, L.ZswapOffer.fromOutput(output)).mockProve();
+};
 
 /**
  * An offer with an unshielded leg. `fromParts` is what the wallet facade uses,
@@ -65,7 +88,7 @@ describe('decodeMakerOffers', () => {
     const decoded = decodeMakerOffers(blobs, NETWORK);
     expect(decoded.length).toBe(3);
     expect(decoded.map((d) => d.blob)).toEqual(blobs);
-    expect(decoded.every((d) => d.bytes > 0)).toBe(true);
+    expect(decoded.every((d) => d.raw.length > 0)).toBe(true);
     expect(decoded.every((d) => typeof d.tx?.merge === 'function')).toBe(true);
   });
 
@@ -153,6 +176,87 @@ describe('mergeMakerOffers', () => {
 
   test('an empty batch is rejected', () => {
     expect(() => mergeMakerOffers([])).toThrow('No offers to settle.');
+  });
+});
+
+// Lace takes bytes, not a ledger object, and picks a balancing strategy from
+// the maker transaction's shape. Both are asserted here because there is no
+// Lace wallet in this environment: what CAN be proved offline is that a merged
+// ladder is handed the right bytes and still selects the strategy Lace has
+// always been given.
+describe('mergeMakerOffersToBytes — the Lace entry point', () => {
+  test("N=1 hands the wallet the blob's OWN bytes, not a re-serialization", () => {
+    const blob = encode(shieldedTx());
+    const decoded = decodeMakerOffers([blob], NETWORK);
+    const batch = mergeMakerOffersToBytes(decoded);
+    // Identity, not equality: a single take must reach the wallet through the
+    // same object and the same bytes it did before batching existed.
+    expect(batch.tx).toBe(decoded[0]!.tx);
+    expect(batch.bytes).toBe(decoded[0]!.raw);
+    expect(batch.bytes).toEqual(OfferFiles.decode(blob));
+  });
+
+  test('N offers are folded into one transaction and serialized once', () => {
+    const blobs = [encode(shieldedTx()), encode(shieldedTx()), encode(shieldedTx())];
+    const decoded = decodeMakerOffers(blobs, NETWORK);
+    const batch = mergeMakerOffersToBytes(decoded);
+    // The bytes are the ladder's, not any single offer's.
+    for (const d of decoded) expect(batch.bytes).not.toEqual(d.raw);
+    const back = L.Transaction.deserialize('signature', 'proof', 'binding', batch.bytes);
+    // Three offers of 7 → the wallet is asked for 21 in ONE balancing pass.
+    expect(Array.from((back.imbalances(0) as Map<any, bigint>).values())).toEqual([-21n]);
+    expect(segments(back)).toEqual([]);
+  });
+
+  test('a batch that cannot compose yields NO bytes — nothing reaches the wallet', () => {
+    const decoded = decodeMakerOffers(
+      [encode(unshieldedTx('pays')), encode(unshieldedTx('pays'))],
+      NETWORK,
+    );
+    expect(() => mergeMakerOffersToBytes(decoded)).toThrow("can't be settled together");
+  });
+});
+
+describe('chooseLaceBalancing — a merged ladder keeps Lace’s strategy', () => {
+  test('one shielded offer → mirror+merge at segment 0 (today’s behaviour)', () => {
+    const choice = chooseLaceBalancing(shieldedTx());
+    expect(choice.useMirrorMerge).toBe(true);
+    expect(choice.segId).toBe(0);
+  });
+
+  test('a MERGED shielded ladder is the same shape, and the mirror covers the SUM', () => {
+    const blobs = [encode(shieldedTx()), encode(shieldedTx())];
+    const merged = mergeMakerOffers(decodeMakerOffers(blobs, NETWORK));
+    // Both legs of the dispatch predicate, checked explicitly: still segment 0,
+    // and still no Intent for Lace's taker-side makeIntent to collide with.
+    expect(segments(merged)).toEqual([]);
+    const choice = chooseLaceBalancing(merged);
+    expect(choice.useMirrorMerge).toBe(true);
+    expect(choice.segId).toBe(0);
+    // What Lace is asked to mirror is the ladder's total, so one taker side
+    // settles both offers.
+    const deltas = Array.from(choice.imbalances.entries()).map(([tt, v]) => [
+      (tt as any).tag,
+      v,
+    ]);
+    expect(deltas).toEqual([['shielded', -14n]]);
+  });
+
+  test('pickSwapSegment agrees, and a ladder still has exactly ONE swap segment', () => {
+    const merged = mergeMakerOffers(
+      decodeMakerOffers([encode(shieldedTx()), encode(shieldedTx(5n))], NETWORK),
+    );
+    // More than one segment carrying assets would throw "Multi-segment offers
+    // are not supported" — merging must not produce that.
+    expect(pickSwapSegment(merged).segId).toBe(0);
+  });
+
+  test('an unshielded-leg offer still routes to sealed-balance', () => {
+    // Regression: the empty structural Intent[1] keeps mirror+merge off, exactly
+    // as before batching. A single unshielded offer is unaffected by the merge.
+    const choice = chooseLaceBalancing(unshieldedTx('pays'));
+    expect(choice.useMirrorMerge).toBe(false);
+    expect(choice.segId).toBe(0);
   });
 });
 

--- a/templates/zswap-da/src/services/offerBatch.test.ts
+++ b/templates/zswap-da/src/services/offerBatch.test.ts
@@ -1,0 +1,182 @@
+// Batch-settlement helpers, against the real ledger — no network, no facade.
+//
+// Fixtures are genuine `swapoffer1…` blobs: a ledger transaction built from
+// parts, `mockProve()`d (real proving needs a proof server; mock proving
+// produces the same 'signature'/'proof'/'binding' shape the settle path
+// deserializes) and MIP-0005 encoded. So `decodeMakerOffers` and
+// `mergeMakerOffers` are exercised against actual ledger behaviour, including
+// the segment-collision rule that bounds what a ladder can contain.
+import { describe, expect, test } from 'bun:test';
+import * as ledger from '@midnight-ntwrk/ledger-v8';
+import { OfferFiles } from '@effectstream/mip-zswap-offer/mip5';
+import type { NetworkId } from '@midnight-ntwrk/midnight-js-network-id';
+import { batchPaysUnshielded, decodeMakerOffers, mergeMakerOffers } from './offerBatch';
+
+const L = ledger as any;
+const NETWORK = 'undeployed' as NetworkId;
+const ttl = () => new Date(Date.now() + 3600_000);
+
+const TOKEN = 'cc'.repeat(32);
+const OWNER = 'dd'.repeat(32);
+const HASH = 'ee'.repeat(32);
+
+const segments = (tx: any): number[] => (tx?.intents ? Array.from(tx.intents.keys()) : []);
+const encode = (tx: any): string => OfferFiles.encode(tx.serialize());
+
+/**
+ * A shielded-only offer carries no Intent at all, so any number of them
+ * compose. This is the shape a shielded↔shielded ladder has.
+ */
+const intentFreeTx = () => L.Transaction.fromParts(NETWORK).mockProve();
+
+/**
+ * An offer with an unshielded leg. `fromParts` is what the wallet facade uses,
+ * and it always lands the Intent at segment 1 — which is exactly why two such
+ * offers cannot be batched. `randomize` uses the ledger's own
+ * `fromPartsRandomized` (documented as existing "to better allow merging") to
+ * produce the mergeable counterexample.
+ *
+ * `direction: 'pays'` puts the value in an output — the maker pays it out, so
+ * the TAKER pays. `'gets'` puts it in an input — the maker spends it, so the
+ * taker receives.
+ */
+const unshieldedTx = (direction: 'pays' | 'gets', randomize = false) => {
+  const offer =
+    direction === 'gets'
+      ? L.UnshieldedOffer.new(
+          [{ value: 7n, owner: OWNER, type: TOKEN, intentHash: HASH, outputNo: 0 }],
+          [],
+          [],
+        )
+      : L.UnshieldedOffer.new([], [{ value: 7n, owner: OWNER, type: TOKEN }], []);
+  const intent = L.Intent.new(ttl());
+  intent.guaranteedUnshieldedOffer = offer;
+  return L.Transaction[randomize ? 'fromPartsRandomized' : 'fromParts'](
+    NETWORK,
+    undefined,
+    undefined,
+    intent,
+  ).mockProve();
+};
+
+describe('decodeMakerOffers', () => {
+  test('decodes every blob in the batch', () => {
+    const blobs = [encode(intentFreeTx()), encode(intentFreeTx()), encode(intentFreeTx())];
+    const decoded = decodeMakerOffers(blobs, NETWORK);
+    expect(decoded.length).toBe(3);
+    expect(decoded.map((d) => d.blob)).toEqual(blobs);
+    expect(decoded.every((d) => d.bytes > 0)).toBe(true);
+    expect(decoded.every((d) => typeof d.tx?.merge === 'function')).toBe(true);
+  });
+
+  test('an empty batch is rejected', () => {
+    expect(() => decodeMakerOffers([], NETWORK)).toThrow('No offers to settle.');
+  });
+
+  test('ONE bad blob rejects the WHOLE batch, naming the offer', () => {
+    const blobs = [encode(intentFreeTx()), 'swapoffer1notarealblob', encode(intentFreeTx())];
+    let err: any;
+    try {
+      decodeMakerOffers(blobs, NETWORK);
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeDefined();
+    expect(err.message).toContain('Offer 2 of 3');
+    // Atomic: the user must be told nothing went out, not left guessing which
+    // half of the ladder they now own.
+    expect(err.message).toContain('Nothing was submitted');
+    expect(err.cause).toBeDefined();
+  });
+
+  test('a single bad blob reports without batch wording', () => {
+    let err: any;
+    try {
+      decodeMakerOffers(['definitely-not-an-offer'], NETWORK);
+    } catch (e) {
+      err = e;
+    }
+    expect(err.message).toContain('This offer could not be read');
+    expect(err.message).not.toContain('of 1');
+  });
+});
+
+describe('mergeMakerOffers', () => {
+  test('N=1 is the degenerate case — the decoded tx passes through untouched', () => {
+    const decoded = decodeMakerOffers([encode(intentFreeTx())], NETWORK);
+    expect(mergeMakerOffers(decoded)).toBe(decoded[0]!.tx);
+  });
+
+  test('N shielded-only offers merge, and the merged tx round-trips', () => {
+    const blobs = [encode(intentFreeTx()), encode(intentFreeTx()), encode(intentFreeTx())];
+    const merged = mergeMakerOffers(decodeMakerOffers(blobs, NETWORK));
+    const bytes = merged.serialize();
+    const back = L.Transaction.deserialize('signature', 'proof', 'binding', bytes);
+    expect(bytes.length).toBeGreaterThan(0);
+    expect(segments(back)).toEqual([]);
+  });
+
+  test('merging sums the imbalances, so ONE balancing pass covers the ladder', () => {
+    const blobs = [encode(unshieldedTx('pays', true)), encode(unshieldedTx('pays', true))];
+    const merged = mergeMakerOffers(decodeMakerOffers(blobs, NETWORK));
+    const imbalance = merged.imbalances(0) as Map<any, bigint>;
+    // Each offer has the maker paying out 7 of TOKEN; the merged transaction
+    // owes 14, which is what the taker's single balancing side must cover.
+    expect(Array.from(imbalance.values())).toEqual([-14n]);
+    expect(segments(merged).length).toBe(2);
+  });
+
+  test('offers on distinct segments merge and keep both', () => {
+    const a = unshieldedTx('pays', true);
+    const b = unshieldedTx('pays', true);
+    const merged = mergeMakerOffers(decodeMakerOffers([encode(a), encode(b)], NETWORK));
+    expect(new Set(segments(merged))).toEqual(new Set([...segments(a), ...segments(b)]));
+  });
+
+  test('two offers with an unshielded leg collide at segment 1 and are refused BEFORE submission', () => {
+    const blobs = [encode(unshieldedTx('pays')), encode(unshieldedTx('pays'))];
+    const decoded = decodeMakerOffers(blobs, NETWORK);
+    let err: any;
+    try {
+      mergeMakerOffers(decoded);
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeDefined();
+    expect(err.message).toContain("can't be settled together");
+    expect(err.message).toContain('one at a time');
+    expect(err.message).toContain('Nothing was submitted');
+    // The ledger's own wording is kept so the cause is diagnosable.
+    expect(err.message).toContain('segment_id');
+    expect(err.cause).toBeDefined();
+  });
+
+  test('an empty batch is rejected', () => {
+    expect(() => mergeMakerOffers([])).toThrow('No offers to settle.');
+  });
+});
+
+describe('batchPaysUnshielded', () => {
+  test('true when the taker pays an unshielded leg in the only offer', () => {
+    expect(batchPaysUnshielded([encode(unshieldedTx('pays'))], NETWORK)).toBe(true);
+  });
+
+  test('true when ANY offer in the batch has an unshielded taker leg', () => {
+    const blobs = [encode(unshieldedTx('gets', true)), encode(unshieldedTx('pays', true))];
+    expect(batchPaysUnshielded(blobs, NETWORK)).toBe(true);
+  });
+
+  test('false when no offer in the batch has the taker paying unshielded', () => {
+    const blobs = [encode(unshieldedTx('gets', true)), encode(unshieldedTx('gets', true))];
+    expect(batchPaysUnshielded(blobs, NETWORK)).toBe(false);
+  });
+
+  test('an unreadable leg set counts as unshielded — an unsigned settlement is only caught by the node', () => {
+    expect(batchPaysUnshielded([encode(intentFreeTx())], NETWORK)).toBe(true);
+    expect(batchPaysUnshielded(['not-an-offer'], NETWORK)).toBe(true);
+  });
+
+  test('an empty batch pays nothing', () => {
+    expect(batchPaysUnshielded([], NETWORK)).toBe(false);
+  });
+});

--- a/templates/zswap-da/src/services/offerBatch.ts
+++ b/templates/zswap-da/src/services/offerBatch.ts
@@ -26,6 +26,14 @@
 // ("Transaction is already bound."). A batch that would collide is therefore
 // rejected HERE, before anything is submitted — a ladder settles whole or not
 // at all.
+//
+// BOTH wallets fold their ladder through this module. The JS wallet facade
+// takes the merged ledger object (services/localTradeOffers.ts); Lace takes its
+// serialized bytes and picks a balancing strategy from its shape
+// (services/browserContract.ts), which is why `pickSwapSegment` and
+// `chooseLaceBalancing` live here too — a merged transaction has to satisfy the
+// same dispatch a single offer did, and that is something a unit test can check
+// without a wallet in the room.
 
 import { Transaction as LedgerV8Transaction } from '@midnight-ntwrk/ledger-v8';
 import { setNetworkId, type NetworkId } from '@midnight-ntwrk/midnight-js-network-id';
@@ -40,8 +48,11 @@ export interface DecodedMakerOffer {
   blob: string;
   /** ledger-v8 `Transaction<'signature','proof','binding'>`. */
   tx: any;
-  /** Size of the decoded maker transaction, for the debug log. */
-  bytes: number;
+  /**
+   * The blob's own decoded bytes, kept so a single-offer take can hand a wallet
+   * exactly the bytes it always got rather than a re-serialization of `tx`.
+   */
+  raw: Uint8Array;
 }
 
 const reason = (e: unknown): string => {
@@ -65,7 +76,7 @@ export function decodeMakerOffers(blobs: string[], networkId: NetworkId): Decode
       return {
         blob,
         tx: LedgerV8Transaction.deserialize('signature', 'proof', 'binding', raw),
-        bytes: raw.length,
+        raw,
       };
     } catch (cause) {
       throw new Error(
@@ -125,6 +136,116 @@ export function mergeMakerOffers(decoded: DecodedMakerOffer[]): any {
     }
   }
   return merged;
+}
+
+/**
+ * The folded maker side, plus the serialized form a wallet that speaks bytes
+ * (Lace) needs.
+ */
+export interface MergedMakerBatch {
+  /** ledger-v8 transaction — the merged maker half. */
+  tx: any;
+  /**
+   * `tx` as bytes. For a single offer these are the blob's OWN decoded bytes,
+   * NOT a re-serialization, so a single take hands the wallet byte-for-byte
+   * what it has always been handed.
+   */
+  bytes: Uint8Array;
+}
+
+/**
+ * {@link mergeMakerOffers} for a wallet that takes bytes rather than a ledger
+ * object.
+ *
+ * @throws If the batch is empty, or if two offers cannot compose.
+ */
+export function mergeMakerOffersToBytes(decoded: DecodedMakerOffer[]): MergedMakerBatch {
+  const tx = mergeMakerOffers(decoded);
+  return { tx, bytes: decoded.length === 1 ? decoded[0]!.raw : tx.serialize() };
+}
+
+/**
+ * Find the single segment carrying the swap's shielded/unshielded asset
+ * imbalances. On a MERGED maker transaction those imbalances are the ladder's
+ * sums, which is what makes one balancing pass enough for the whole batch.
+ *
+ * @throws If no segment carries asset imbalances, or if more than one does —
+ * the balancing strategies below each mirror exactly one segment.
+ */
+export function pickSwapSegment(makerTx: any): { segId: number; imbalances: Map<any, bigint> } {
+  // Lace's makeIntent populates `intents` (Intent objects) and may also touch
+  // `fallibleOffer` (ZswapOffer). Union them with segment 0 (guaranteed),
+  // then keep only segments with non-empty asset imbalances.
+  const intentIds: number[] = makerTx.intents
+    ? (Array.from(makerTx.intents.keys()) as number[])
+    : [];
+  const fallibleIds: number[] = makerTx.fallibleOffer
+    ? (Array.from(makerTx.fallibleOffer.keys()) as number[])
+    : [];
+  const candidates = Array.from(new Set<number>([0, ...intentIds, ...fallibleIds]));
+
+  const swaps: Array<{ segId: number; imbalances: Map<any, bigint> }> = [];
+  for (const segId of candidates) {
+    let imb: Map<any, bigint>;
+    try {
+      imb = makerTx.imbalances(segId) as Map<any, bigint>;
+    } catch {
+      continue;
+    }
+    const hasAssets = Array.from(imb.entries()).some(([tt, v]) => {
+      const tag = (tt as any).tag;
+      return (tag === 'shielded' || tag === 'unshielded') && v !== 0n;
+    });
+    if (hasAssets) swaps.push({ segId, imbalances: imb });
+  }
+
+  if (swaps.length === 0) {
+    throw new Error(
+      `Maker offer has no shielded/unshielded asset imbalances — nothing to mirror. ` +
+        `(intent ids: ${JSON.stringify(intentIds)}, fallible ids: ${JSON.stringify(fallibleIds)})`,
+    );
+  }
+  if (swaps.length > 1) {
+    throw new Error(
+      `Multi-segment offers are not supported (asset imbalances in segments ${
+        swaps.map(s => s.segId).join(', ')
+      }).`,
+    );
+  }
+  return swaps[0]!;
+}
+
+/** Which side Lace is asked to build — see services/browserContract.ts. */
+export interface LaceBalancing {
+  segId: number;
+  imbalances: Map<any, bigint>;
+  /**
+   * `true` → mirror the taker side with `makeIntent` and merge;
+   * `false` → hand the sealed maker tx to `balanceSealedTransaction`.
+   */
+  useMirrorMerge: boolean;
+}
+
+/**
+ * Pick Lace's balancing strategy from the maker transaction's shape.
+ *
+ * Mirror+merge requires both halves to have no Intent slots: Lace's unshielded
+ * `makeIntent` puts asset deltas in segment 0 but also tacks on an empty
+ * Intent[1], and two of those collide on merge — so the segment test alone is
+ * not enough, the maker must additionally carry no Intent.
+ *
+ * A merged shielded↔shielded ladder satisfies both conditions exactly as one
+ * shielded offer does (no Intents anywhere, deltas summed in segment 0), which
+ * is why merging is safe to hand Lace; `offerBatch.test.ts` asserts that on a
+ * genuinely merged transaction rather than trusting the reasoning.
+ *
+ * @throws Whatever {@link pickSwapSegment} throws.
+ */
+export function chooseLaceBalancing(makerTx: any): LaceBalancing {
+  const swap = pickSwapSegment(makerTx);
+  const makerHasIntents = !!makerTx.intents
+    && Array.from(makerTx.intents.keys() as Iterable<number>).length > 0;
+  return { ...swap, useMirrorMerge: swap.segId === 0 && !makerHasIntents };
 }
 
 /**

--- a/templates/zswap-da/src/services/offerBatch.ts
+++ b/templates/zswap-da/src/services/offerBatch.ts
@@ -1,0 +1,144 @@
+// Fold a ladder of maker offers into ONE settlement.
+//
+// Taking N offers used to mean N separate settlements, back to back. The
+// taker's JS wallet usually holds a single coin per token, and nothing tells it
+// about take #k's spend before take #k+1 is balanced — the template submits
+// through the batcher, not `facade.submitTransaction`, so the facade's coin
+// selection still offers up the coin that was just spent. The node saw the same
+// nullifier twice and rejected the second settlement with
+// `Zswap(NullifierAlreadyPresent)`: only the first offer of a ladder was ever
+// bought.
+//
+// ZSwap offers are built to compose. An offer blob decodes to a finalized,
+// deliberately imbalanced maker transaction, and ledger `merge` places two of
+// them side by side — the batcher already merges its dust intent into every
+// transaction, and `finalizeRecipe` merges the taker's balancing half into the
+// maker's. Folding the N maker halves FIRST and balancing the result once means
+// one coin selection, one proof pass, one dust fee and one submission: the
+// double-spend window is removed rather than waited out.
+//
+// The one limit is segment ids. The facade builds an offer's unshielded half
+// with `Transaction.fromParts`, which always lands its Intent at segment 1, and
+// `merge` refuses two transactions that both occupy it ("key (segment_id)
+// collision during intents merge: 1"). Shielded-only offers carry no Intent at
+// all, so they always compose. Re-segmenting is not an option on this side: it
+// needs an unproven transaction, and a maker blob decodes to a bound one
+// ("Transaction is already bound."). A batch that would collide is therefore
+// rejected HERE, before anything is submitted — a ladder settles whole or not
+// at all.
+
+import { Transaction as LedgerV8Transaction } from '@midnight-ntwrk/ledger-v8';
+import { setNetworkId, type NetworkId } from '@midnight-ntwrk/midnight-js-network-id';
+import { OfferFiles } from '@effectstream/mip-zswap-offer/mip5';
+import { parseTakerLegs } from './offerParse';
+
+/**
+ * A decoded maker half, kept alongside the blob it came from so a failure can
+ * name the offer that caused it.
+ */
+export interface DecodedMakerOffer {
+  blob: string;
+  /** ledger-v8 `Transaction<'signature','proof','binding'>`. */
+  tx: any;
+  /** Size of the decoded maker transaction, for the debug log. */
+  bytes: number;
+}
+
+const reason = (e: unknown): string => {
+  const m = (e as { message?: unknown } | null)?.message;
+  return typeof m === 'string' && m.length > 0 ? m : String(e);
+};
+
+/**
+ * Decode every blob in the batch up front. Nothing is submitted until all of
+ * them are readable, so a bad blob costs the user a message rather than a
+ * half-filled ladder.
+ *
+ * @throws If the batch is empty, or if any blob fails to decode.
+ */
+export function decodeMakerOffers(blobs: string[], networkId: NetworkId): DecodedMakerOffer[] {
+  if (blobs.length === 0) throw new Error('No offers to settle.');
+  setNetworkId(networkId);
+  return blobs.map((blob, i) => {
+    try {
+      const raw = OfferFiles.decode(blob);
+      return {
+        blob,
+        tx: LedgerV8Transaction.deserialize('signature', 'proof', 'binding', raw),
+        bytes: raw.length,
+      };
+    } catch (cause) {
+      throw new Error(
+        blobs.length === 1
+          ? `This offer could not be read: ${reason(cause)}`
+          : `Offer ${i + 1} of ${blobs.length} could not be read: ${reason(cause)}. Nothing was submitted.`,
+        { cause },
+      );
+    }
+  });
+}
+
+/**
+ * Turn a ledger merge failure into something a taker can act on. The two
+ * documented causes are a segment collision (`merge`'s intents map is keyed by
+ * segment id) and two offers spending the same coin — in both cases the offers
+ * are mutually exclusive as a batch, and taking them one at a time is the
+ * answer.
+ */
+function mergeFailureMessage(cause: unknown, count: number): string {
+  const detail = reason(cause);
+  if (/segment_id|intents merge/i.test(detail)) {
+    return (
+      `These ${count} offers can't be settled together — two of them occupy the same ` +
+      `transaction segment (${detail}). Offers with an unshielded leg are always built ` +
+      `at segment 1, so only one of those fits in a batch. Take them one at a time. ` +
+      `Nothing was submitted.`
+    );
+  }
+  if (/same coins?|spend the same/i.test(detail)) {
+    return (
+      `These ${count} offers can't be settled together — two of them spend the same coin, ` +
+      `so only one of them can ever be taken. Take them one at a time. Nothing was submitted.`
+    );
+  }
+  return (
+    `These ${count} offers can't be merged into one settlement (${detail}). ` +
+    `Take them one at a time. Nothing was submitted.`
+  );
+}
+
+/**
+ * Fold the maker halves into a single transaction. N=1 returns the one decoded
+ * transaction untouched, so a single take runs exactly the pipeline it always
+ * did.
+ *
+ * @throws If the batch is empty, or if two offers cannot compose.
+ */
+export function mergeMakerOffers(decoded: DecodedMakerOffer[]): any {
+  if (decoded.length === 0) throw new Error('No offers to settle.');
+  let merged = decoded[0]!.tx;
+  for (let i = 1; i < decoded.length; i++) {
+    try {
+      merged = merged.merge(decoded[i]!.tx);
+    } catch (cause) {
+      throw new Error(mergeFailureMessage(cause, decoded.length), { cause });
+    }
+  }
+  return merged;
+}
+
+/**
+ * Does the taker pay an unshielded leg anywhere in this batch?
+ *
+ * Unshielded inputs are signed, and the signature covers the segment, so
+ * `signRecipe` has to run before `finalizeRecipe` binds the settlement.
+ * Omitting it is not an immediate error — the node rejects the settlement later
+ * with SIGNATURE_INVALID — so an unreadable blob counts as "yes" here, matching
+ * what the single-offer path has always done.
+ */
+export function batchPaysUnshielded(blobs: string[], networkId: NetworkId): boolean {
+  return blobs.some((blob) => {
+    const parsed = parseTakerLegs(blob, networkId);
+    return parsed?.pays.some((l) => l.kind === 'unshielded') ?? true;
+  });
+}

--- a/templates/zswap-da/src/services/takerBalance.ts
+++ b/templates/zswap-da/src/services/takerBalance.ts
@@ -113,8 +113,10 @@ export function batchTakerShortfalls(
  * Greedily pick the offers (by their `pays` legs, in the given order — the book
  * is already best-price-first) the wallet can afford when their cost accumulates.
  * An offer is included only if adding it keeps EVERY (kind, color) within balance.
- * Conservative: sums pays, ignores receives — settle is sequential, so an earlier
- * offer can't be assumed funded by a later one. Returns the indices to take.
+ * Conservative: sums pays, ignores receives. The taker's balancing side is built
+ * by coin selection over the wallet's own state, so what an offer in the batch
+ * pays out to the taker cannot fund another offer in the same settlement.
+ * Returns the indices to take.
  */
 export function affordableIndices(
   offerPays: ParsedLeg[][],

--- a/templates/zswap-da/src/state/tradeWallet.ts
+++ b/templates/zswap-da/src/state/tradeWallet.ts
@@ -28,7 +28,18 @@ export interface TradeWallet {
   mintShielded(domainSep: Uint8Array, amount: bigint, nonce: bigint, name: string): Promise<BrowserMintResult>;
   mintUnshielded(domainSep: Uint8Array, amount: bigint, name: string): Promise<BrowserMintResult>;
   buildOfferBlob(networkId: string, gives: OfferLeg[], wants: OfferLeg[]): Promise<string>;
-  settleOffer(config: MidnightBrowserConfig, blob: string): Promise<{ txHash: string }>;
+  /**
+   * Take one or more offers. The whole selection goes through a single call so
+   * the wallet can settle a ladder as ONE transaction — settling offer by offer
+   * re-spent the taker's only coin and the node rejected everything after the
+   * first (`Zswap(NullifierAlreadyPresent)`).
+   *
+   * The JS wallet merges the maker halves and submits once. Lace still settles
+   * one at a time (see `makeInjectedTradeWallet`).
+   *
+   * @returns The settlement's tx hash — for Lace, the last one submitted.
+   */
+  settleOffers(config: MidnightBrowserConfig, blobs: string[]): Promise<{ txHash: string }>;
 }
 
 export interface MintFns {
@@ -46,13 +57,26 @@ export function makeInjectedTradeWallet(connectedApi: ConnectedAPI, mint: MintFn
     mintShielded: mint.mintShielded,
     mintUnshielded: mint.mintUnshielded,
     buildOfferBlob: (networkId, gives, wants) => buildMakerOfferBlob(connectedApi, networkId, gives, wants),
-    settleOffer: (config, blob) => {
-      dlog('tradeWallet.settleOffer → proveAndSubmitOffer (injected/Lace)', {
+    // Lace keeps settling one offer at a time. Merging the maker halves first
+    // would change what `proveAndSubmitOffer` is handed — its mirror+merge and
+    // sealed-balance strategies both reason about the maker tx's segments — and
+    // there is no Lace wallet on a headless stack to verify that against, so
+    // this path is left exactly as it was rather than changed on a guess.
+    // Consequence: a ladder taken through Lace is still N transactions, and a
+    // single-coin Lace wallet still hits the double spend the JS wallet no
+    // longer can.
+    settleOffers: async (config, blobs) => {
+      if (blobs.length === 0) throw new Error('No offers to settle.');
+      dlog('tradeWallet.settleOffers → proveAndSubmitOffer ×N (injected/Lace, sequential)', {
         networkId: config.networkId,
         contractAddress: config.contractAddress,
-        blobLen: blob.length,
+        offers: blobs.length,
       });
-      return proveAndSubmitOffer(connectedApi, config, blob);
+      let last: { txHash: string } | undefined;
+      for (const blob of blobs) {
+        last = await proveAndSubmitOffer(connectedApi, config, blob);
+      }
+      return last!;
     },
   };
 }
@@ -76,13 +100,15 @@ export function makeLocalTradeWallet(localApi: unknown, mint: MintFns): TradeWal
       const { buildMakerOfferBlobLocal } = await import('../services/localTradeOffers');
       return buildMakerOfferBlobLocal(localApi as never, networkId, gives, wants);
     },
-    settleOffer: async (config, blob) => {
-      dlog('tradeWallet.settleOffer → settleOfferLocal (JS wallet facade)', {
+    // One settlement for the whole selection: the maker halves are merged, the
+    // taker side is balanced once, and the batcher sees a single submission.
+    settleOffers: async (config, blobs) => {
+      dlog('tradeWallet.settleOffers → settleOffersLocal (JS wallet facade, merged)', {
         networkId: config.networkId,
-        blobLen: blob.length,
+        offers: blobs.length,
       });
-      const { settleOfferLocal } = await import('../services/localTradeOffers');
-      return settleOfferLocal(localApi as never, config, blob);
+      const { settleOffersLocal } = await import('../services/localTradeOffers');
+      return settleOffersLocal(localApi as never, config, blobs);
     },
   };
 }

--- a/templates/zswap-da/src/state/tradeWallet.ts
+++ b/templates/zswap-da/src/state/tradeWallet.ts
@@ -13,7 +13,7 @@
 
 import type { ConnectedAPI } from '@midnight-ntwrk/dapp-connector-api';
 import type { BrowserMintResult } from '../hooks/useContract';
-import { proveAndSubmitOffer, type MidnightBrowserConfig } from '../services/browserContract';
+import { proveAndSubmitOffers, type MidnightBrowserConfig } from '../services/browserContract';
 import { buildMakerOfferBlob, type OfferLeg } from '../services/makerOffer';
 import { dlog } from '../debug';
 
@@ -34,10 +34,10 @@ export interface TradeWallet {
    * re-spent the taker's only coin and the node rejected everything after the
    * first (`Zswap(NullifierAlreadyPresent)`).
    *
-   * The JS wallet merges the maker halves and submits once. Lace still settles
-   * one at a time (see `makeInjectedTradeWallet`).
+   * BOTH wallets merge the maker halves and submit once; the merge itself is
+   * shared code (services/offerBatch.ts), so the two paths cannot drift.
    *
-   * @returns The settlement's tx hash — for Lace, the last one submitted.
+   * @returns The settlement's tx hash.
    */
   settleOffers(config: MidnightBrowserConfig, blobs: string[]): Promise<{ txHash: string }>;
 }
@@ -48,7 +48,7 @@ export interface MintFns {
 }
 
 // Injected (Lace): mint via the OfferFiles contract client (useContract),
-// create via makeIntent+encodeOffer, take via proveAndSubmitOffer.
+// create via makeIntent+encodeOffer, take via proveAndSubmitOffers.
 export function makeInjectedTradeWallet(connectedApi: ConnectedAPI, mint: MintFns): TradeWallet {
   return {
     kind: 'injected',
@@ -57,26 +57,23 @@ export function makeInjectedTradeWallet(connectedApi: ConnectedAPI, mint: MintFn
     mintShielded: mint.mintShielded,
     mintUnshielded: mint.mintUnshielded,
     buildOfferBlob: (networkId, gives, wants) => buildMakerOfferBlob(connectedApi, networkId, gives, wants),
-    // Lace keeps settling one offer at a time. Merging the maker halves first
-    // would change what `proveAndSubmitOffer` is handed — its mirror+merge and
-    // sealed-balance strategies both reason about the maker tx's segments — and
-    // there is no Lace wallet on a headless stack to verify that against, so
-    // this path is left exactly as it was rather than changed on a guess.
-    // Consequence: a ladder taken through Lace is still N transactions, and a
-    // single-coin Lace wallet still hits the double spend the JS wallet no
-    // longer can.
+    // Lace settles the whole ladder in one transaction, like the JS wallet:
+    // `proveAndSubmitOffers` folds the maker halves through the shared
+    // services/offerBatch.ts helpers (same pre-submission guard for offers that
+    // cannot compose) and Lace balances the merged result once. A ladder taken
+    // through Lace would otherwise be N transactions built from wallet state
+    // that has not seen the previous take's spend — the same double spend the
+    // JS wallet used to hit.
+    //
+    // N=1 is byte-for-byte the old path: one blob's own decoded bytes, one
+    // balance, one submission.
     settleOffers: async (config, blobs) => {
-      if (blobs.length === 0) throw new Error('No offers to settle.');
-      dlog('tradeWallet.settleOffers → proveAndSubmitOffer ×N (injected/Lace, sequential)', {
+      dlog('tradeWallet.settleOffers → proveAndSubmitOffers (injected/Lace, merged)', {
         networkId: config.networkId,
         contractAddress: config.contractAddress,
         offers: blobs.length,
       });
-      let last: { txHash: string } | undefined;
-      for (const blob of blobs) {
-        last = await proveAndSubmitOffer(connectedApi, config, blob);
-      }
-      return last!;
+      return proveAndSubmitOffers(connectedApi, config, blobs);
     },
   };
 }

--- a/templates/zswap-da/src/state/useZSwapApp.ts
+++ b/templates/zswap-da/src/state/useZSwapApp.ts
@@ -510,22 +510,33 @@ export function useZSwapApp(): ZSwapApp {
     [requireWallet, connected, contract.config, knownTokens, toast, zapi, refreshBalances],
   );
 
-  // Take an existing offer: reconstruct the maker tx from its blob, balance the
-  // taker side via the browser wallet, and route to the batcher to settle.
-  const takeOffer = useCallback(
-    async (blob: string) => {
-      dlog('takeOffer: enter', { blobLen: blob.length, blobHead: blob.slice(0, 24) });
+  // Take one or more existing offers: reconstruct the maker txs from their
+  // blobs, balance the taker side via the browser wallet, and route to the
+  // batcher to settle.
+  //
+  // The whole selection is handed to the wallet in ONE call. The JS wallet
+  // merges the maker halves and settles the ladder as a single transaction —
+  // taking them one at a time re-spent the taker's only coin, so the node threw
+  // out everything after the first offer. N=1 runs the identical path, so a
+  // single take is unchanged.
+  const takeOffers = useCallback(
+    async (blobs: string[]) => {
+      const n = blobs.length;
+      if (n === 0) return;
+      dlog('takeOffers: enter', { offers: n, blobHeads: blobs.map((b) => b.slice(0, 24)) });
       const w = requireWallet();
-      dlog('takeOffer: wallet', { kind: w.kind, canTrade: w.canTrade });
+      dlog('takeOffers: wallet', { kind: w.kind, canTrade: w.canTrade });
 
       // Authoritative balance guard: every take path funnels here, so block once
       // on fresh balances (a missing input coin makes Lace's makeIntent hang).
+      // The guard is on the AGGREGATE cost — checking each offer against the
+      // full balance would pass a batch that only overspends in sum.
       if (connected) {
-        const fresh = await timed('takeOffer: readState (fresh balances)', () =>
+        const fresh = await timed('takeOffers: readState (fresh balances)', () =>
           readState(connected),
         );
-        const short = takerShortfalls(
-          blob,
+        const short = batchTakerShortfalls(
+          blobs,
           fresh.shieldedBalances,
           fresh.unshieldedBalances,
           NETWORK_ID as any,
@@ -533,35 +544,42 @@ export function useZSwapApp(): ZSwapApp {
         );
         if (short.length > 0) {
           const msg = shortfallMessage(short)!;
-          dlog('takeOffer: BLOCKED — insufficient balance', {
+          dlog('takeOffers: BLOCKED — insufficient balance', {
+            offers: n,
             shortfalls: short.map((s) => ({ ...s, need: s.need.toString(), have: s.have.toString() })),
           });
           throw new Error(msg);
         }
-        dlog('takeOffer: balance check passed');
+        dlog('takeOffers: balance check passed');
       }
 
       const cfg = contract.config
-        ? (dlog('takeOffer: using cached midnight config', contract.config), contract.config)
-        : await timed('takeOffer: GET /v1/midnight/config', () => api.getMidnightConfig());
-      dlog('takeOffer: config resolved', {
+        ? (dlog('takeOffers: using cached midnight config', contract.config), contract.config)
+        : await timed('takeOffers: GET /v1/midnight/config', () => api.getMidnightConfig());
+      dlog('takeOffers: config resolved', {
         contractAddress: cfg.contractAddress,
         indexerUri: cfg.indexerUri,
         proofServerUri: cfg.proofServerUri,
         networkId: cfg.networkId,
       });
-      const res = await timed('takeOffer: settleOffer (wallet balance + batcher submit)', () =>
-        w.settleOffer(cfg, blob),
+      const res = await timed('takeOffers: settleOffers (wallet balance + batcher submit)', () =>
+        w.settleOffers(cfg, blobs),
       );
-      dlog('takeOffer: settleOffer returned', res);
-      toast('Offer taken — settling via batcher', 'ok');
-      dlog('takeOffer: refreshing offers + balances');
+      dlog('takeOffers: settleOffers returned', res);
+      toast(
+        n > 1 ? `${n} offers taken — settling via batcher` : 'Offer taken — settling via batcher',
+        'ok',
+      );
+      dlog('takeOffers: refreshing offers + balances');
       zapi.fetchOffers();
       refreshBalances();
-      dlog('takeOffer: exit');
+      dlog('takeOffers: exit');
     },
     [requireWallet, connected, knownTokens, contract.config, toast, zapi, refreshBalances],
   );
+
+  /** Single take — the N=1 case of {@link takeOffers}, same code, same result. */
+  const takeOffer = useCallback((blob: string) => takeOffers([blob]), [takeOffers]);
 
   // Proactive (pre-settle) balance check for an offer blob against the CURRENT
   // wallet balances.
@@ -639,7 +657,8 @@ export function useZSwapApp(): ZSwapApp {
 
   // Take one or more order-book offers in a single confirm dialog. Filters out
   // your own offers (you can't take them) and blobs we can't settle; aggregates
-  // the pay/receive across the selection; settles each via the batcher in turn.
+  // the pay/receive across the selection; settles the whole selection as one
+  // transaction via the batcher.
   const requestTakeMany = useCallback(
     async (orders: Order[]) => {
       if (!tradeWallet?.canTrade) {
@@ -699,10 +718,17 @@ export function useZSwapApp(): ZSwapApp {
       const n = takeable.length;
       const payAmt = takeable.reduce((s, o) => s + o.amtTo, 0);
       const recvAmt = takeable.reduce((s, o) => s + o.amtFrom, 0);
-      // Settle each selected offer via the batcher, in book order.
+      // Settle the whole selection as ONE transaction. This used to loop
+      // `takeOffer` per offer, which re-spent the taker's coin from wallet state
+      // that hadn't seen the previous take, so the node rejected every offer
+      // after the first with `Zswap(NullifierAlreadyPresent)`.
+      //
+      // History stays per offer — the UI's unit is the offer even though the
+      // chain's unit is now a single settlement — and nothing is recorded unless
+      // that settlement succeeded, so a failed batch leaves no phantom trades.
       const settle = (orders: (Order & { blob: string })[]) => async () => {
+        await takeOffers(orders.map((o) => o.blob));
         for (const o of orders) {
-          await takeOffer(o.blob);
           addTrade({
             kind: 'take',
             give: { sym: o.to, amt: o.amtTo },
@@ -756,7 +782,7 @@ export function useZSwapApp(): ZSwapApp {
         onConfirm: settle(takeable),
       });
     },
-    [toast, takeOffer, tradeWallet, wstate, knownTokens, loadOfferBlob, selfUnshieldedHex, zapi],
+    [toast, takeOffers, tradeWallet, wstate, knownTokens, loadOfferBlob, selfUnshieldedHex, zapi],
   );
   const closeConfirm = useCallback(() => setPendingConfirm(null), []);
 


### PR DESCRIPTION
## What

In `zswap-da`, "Take N offers" settled each selected offer as its own transaction, back to back, from the same wallet. A taker's JS wallet typically holds **one coin per token**, so take #2 was built from local state that had not yet seen take #1's spend and re-spent the same coin. The node rejected it as a double spend and **only the first offer of a ladder was ever bought** — silently, from the user's point of view.

This makes a multi-offer take one merged settlement transaction: decode the N maker halves, fold them with ledger `merge`, then run the existing single-offer pipeline **once**.

```
before:  take 2 offers → 2 balancings, 2 proofs, 2 submissions
                          #2 spends #1's coin → Zswap(NullifierAlreadyPresent) → 1 of 2 bought
after:   take 2 offers → 1 balancing, 1 proof, 1 submission, both offers consumed
```

**Not a breaking change.** Template-only (`templates/zswap-da/src/**`), no package API changes, no dependency or lockfile changes. `takeOffer(blob)` and `settleOfferLocal(blob)` are kept as one-line delegates to the batch entry points, so N=1 is the same behavior it is today — verified live, not just asserted.

## The defect signature (for anyone matching logs)

- SPA: `takeOffer` ran once per offer; each did `facade.balanceFinalizedTransaction` → `facade.finalizeRecipe` → `POST /send-input (txStage: finalized)`.
- Batcher: take #1 `✅ Submitted` with a receipt; take #2 `❌ Submit failed` ×3 → `[Storage] DROPPING input after 3 failed retries`.
- Node: `attempted double spend inp.nullifier=Nullifier(…)` / `🚫 Rejected … Zswap(NullifierAlreadyPresent(…))`, surfaced to the batcher only as the opaque `1010: Invalid Transaction: Custom error: 239`.

The root cause is one line of sequencing, not the facade: `finalizeRecipe` does register a pending transaction, but the template submits through `submitToBatcher` rather than `facade.submitTransaction`, and the shielded coin selection for take #2 still returned the coin take #1 had spent. Merging removes the window entirely — there is only ever **one** coin selection for the whole ladder.

## How

- **New `src/services/offerBatch.ts`** — the batch primitives, kept network-free and facade-free so they are unit-testable:
  - `decodeMakerOffers(blobs, networkId)` decodes **every** blob up front; one bad blob names itself ("Offer 2 of 3 …") and states *"Nothing was submitted."*
  - `mergeMakerOffers(decoded)` is a left fold of ledger `Transaction.merge`. **N=1 returns the decoded transaction by identity** — no merge call at all.
  - `batchPaysUnshielded(blobs, networkId)` — the sign decision must be true if **any** offer's taker leg is unshielded, not just the first one's.
- `localTradeOffers.ts`: `settleOffersLocal(localApi, config, blobs)` decodes and merges **before any submission**, then runs today's pipeline once — balance → sign (if needed) → `finalizeRecipe` → `submitToBatcher`. Balancing a merged transaction is sound rather than lucky: the unshielded wallet picks its balancing segment with `findAvailableSegmentId(transaction)`, and `imbalances(GUARANTEED_SEGMENT)` on a merged transaction returns the **summed** deltas — exactly the aggregate the taker must cover.
- `tradeWallet.ts`: `settleOffer` → **`settleOffers(config, blobs)`**, a single batch seam so the two wallet paths cannot drift.
- `useZSwapApp.ts`: `takeOffer(blob)` → **`takeOffers(blobs)`**; the confirm dialog's `settle()` closure no longer loops. The balance guard moved from the per-offer `takerShortfalls` to the aggregate `batchTakerShortfalls` (identical for N=1), and `addTrade` runs once per offer **only after** the settlement resolves, so a failed batch records no phantom trades and the existing catch renders the error.
- Trade history semantics are unchanged: still one entry per offer taken, even though settlement is one transaction.

## The one real constraint: unshielded-leg ladders (guarded, not papered over)

The wallet facade builds an offer's unshielded half with `ledger.Transaction.fromParts(...)`, and `fromParts` **always** lands its Intent at **segment 1**. Ledger `merge` refuses two transactions that both occupy it:

```
merge(fromParts A, fromParts B):        THREW -> key (segment_id) collision during intents merge: 1
merge(randomized C, randomized D):      OK -> [ 11765, 12343 ]
merge(intent-free E, intent-free F):    OK -> []
```

An offer is Intent-bearing **iff it has an unshielded leg**, so shielded↔shielded offers carry no Intent and always compose — which covers the reproduced defect (a *shielded* nullifier) and every shielded ladder. A batch containing **two or more unshielded-leg offers** cannot merge as offers stand today, and it cannot be repaired on the taker side: re-segmenting an Intent needs an unproven transaction, and a maker blob decodes to a bound+proven one (`bound.addIntent(...): THREW -> Transaction is already bound.`).

Such a batch is therefore **rejected before any submission**, with an actionable message telling the user to take those offers one at a time. That is strictly better than today, where the batch half-settles and the rest is silently lost. The maker-side fix (randomize the Intent segment before signing, mirroring ledger's own `fromPartsRandomized`, documented as existing *"to better allow merging"*) is feasible but changes the offer format for new offers and cannot be validated against a real Lace wallet here, so it is deliberately left out of this PR.

## Lace (injected) stays sequential — on purpose

`TradeWallet.settleOffers` is the single entry point; the local JS/facade wallet merges, and the **injected (Lace) wallet keeps looping the blobs through the existing `proveAndSubmitOffer` one at a time — byte-for-byte today's behavior**, with the reason written into the code. `proveAndSubmitOffer` would in principle accept a pre-merged shielded-only maker transaction (`pickSwapSegment` still sees one segment, `useMirrorMerge` stays true, the mirror covers the summed imbalances), but there is no Lace wallet on a headless local stack, so shipping that would be an unverified change to the wallet path most users are on. Lace ladders therefore keep today's non-atomic behavior until they can be tested with a real wallet; nothing about them regresses here.

## Testing

**New unit tests — `src/services/offerBatch.test.ts`, 15 tests, no network.** Fixtures are genuine `swapoffer1…` blobs built from real ledger parts, `mockProve()`d and MIP-0005 encoded, so decode and merge run against actual ledger behavior rather than fakes. Covered: N blobs decode; empty batch rejected; **one bad blob rejects the whole batch** (message names the offer, says nothing was submitted, preserves `cause`); **N=1 returns the decoded tx by identity**; N shielded-only offers merge and the merged tx round-trips `serialize`→`deserialize`; **merging SUMS the imbalances** (`imbalances(0)` = `-14n` for two offers of 7 — direct evidence that one balancing pass covers a ladder); distinct segments merge and both survive; two unshielded-leg offers collide at segment 1 and are refused pre-submission; `batchPaysUnshielded` true/false/any-leg/unreadable-is-conservative/empty.

**Lace batch seam — 7 more tests (second commit).** A new fixture builds a *real* shielded-only offer that moves value (`createShieldedCoinInfo` → `ZswapOutput.new` → `ZswapOffer.fromOutput` → `Transaction.fromParts(...).mockProve()`), because the existing intent-free fixture carries no imbalances at all. Covered: N=1 returns the blob's own bytes **and** tx by identity; N=3 folds to one transaction whose `imbalances(0)` is `-21n` (three offers of 7 — one balancing pass for the whole ladder) and which round-trips; a non-composing batch produces **no bytes at all**, so nothing can reach the wallet; one shielded offer chooses mirror+merge at segment 0; a **merged** shielded ladder chooses mirror+merge at segment 0 too, still with zero Intents, and its imbalances are the summed `[['shielded', -14n]]`; `pickSwapSegment` finds exactly ONE swap segment on a merged ladder (merging never provokes "Multi-segment offers are not supported"); an unshielded-leg offer still routes to sealed-balance.

| Command (in `templates/zswap-da`) | Result |
|---|---|
| `bun test src/` | **41 pass / 0 fail** (22 `offerBatch` + 19 pre-existing `takerBalance`) |
| `bun run build` (`tsc -b && vite build`) | **green**, zero TS errors |

**Live, on a running local Midnight stack** (node 2.0.0-rc.4 + indexer + proof server + offerfiles kernel + batcher), taker = a fresh in-page JS wallet holding exactly **one coin** of the token it pays — the precondition that used to double-spend:

- **Ladder take, N=2 → one transaction.** Confirm dialog "Take 2 offers — pay 200, receive 1,000". The template logged one `balanceFinalizedTransaction`, one `finalizeRecipe`, and `submitToBatcher (one submission for the whole batch) {offers: 2}`, returning a single hash `c91b22d2…aca2e5`. The batcher built **one** batch (`✅ Submitted`, receipt at block 6463); the kernel reported **both** offers `consumed`; balances moved by exactly the dialog's amounts (−200 / +1,000); trade history gained exactly two entries.
- **Zero `NullifierAlreadyPresent`.** The node's count was identical before and after the whole session, and no `double spend` / `Rejected` line appeared in the window.
- **Single-offer take unchanged.** "Take offer — pay 50, receive 200" → `{offers: 1}`, one submission (`085a396e…91883f`, receipt at block 6507), offer `consumed`, balances exact.
- **Partial affordability.** A 2-offer selection costing 1,200 against a 1,000 balance showed the full total, marked the unaffordable leg, and offered "Take affordable 1 of 2"; pressing it settled only that subset in one submission (`18a206f0…064385`, block 6614) and left the unaffordable offer `live`.
