### PR TITLE
feat(zswap-da): randomize a new offer's Intent segment so unshielded-leg ladders merge

### DIFF
--- a/templates/zswap-da/src/services/localTradeOffers.ts
+++ b/templates/zswap-da/src/services/localTradeOffers.ts
@@ -8,7 +8,8 @@
 // balanceSealedTransaction and the shielded mirror+merge workaround. The
 // facade's swap API was built for this handshake:
 //
-//   maker:  initSwap → [signRecipe if unshielded gives] → finalizeRecipe(prove)
+//   maker:  initSwap → move the Intent to a random segment (if there is one)
+//           → [signRecipe if unshielded gives] → finalizeRecipe(prove)
 //           → serialize → MIP-0005 encode
 //   taker:  decode N → merge the N maker txs → balanceFinalizedTransaction →
 //           [signRecipe if the taker pays unshielded anywhere in the batch] →
@@ -29,7 +30,10 @@
 // Omitting it is not an immediate error; the node rejects the settlement later
 // with SIGNATURE_INVALID (exactly the trap the kernel repo's e2e STRETCH hit).
 // Shielded legs carry no signatures (ZK proofs + Pedersen binding), so the
-// sign step is skipped when no unshielded leg is involved.
+// sign step is skipped when no unshielded leg is involved. For the same reason
+// the Intent's segment is randomized BEFORE signing: `signatureData` is
+// segment-dependent, so a signature taken first would not cover the segment the
+// offer is published with (services/offerSegment.ts).
 
 import { type NetworkId, setNetworkId } from '@midnight-ntwrk/midnight-js-network-id';
 import { MidnightBech32m, UnshieldedAddress } from '@midnightntwrk/wallet-sdk-address-format';
@@ -37,6 +41,11 @@ import { OfferFiles } from '@effectstream/mip-zswap-offer/mip5';
 import type { OfferLeg } from './makerOffer';
 import type { MidnightBrowserConfig } from './browserContract';
 import { batchPaysUnshielded, decodeMakerOffers, mergeMakerOffers } from './offerBatch';
+import {
+  INTENT_SEGMENT_MAX,
+  INTENT_SEGMENT_MIN,
+  randomizeRecipeIntentSegment,
+} from './offerSegment';
 import { submitToBatcher } from './api';
 import { dlog, timed } from '../debug';
 
@@ -138,7 +147,7 @@ export async function buildMakerOfferBlobLocal(
   });
 
   setNetworkId(networkId as NetworkId);
-  let recipe = await timed('localOffer.build: facade.initSwap', () =>
+  let recipe: any = await timed('localOffer.build: facade.initSwap', () =>
     facade.initSwap(inputs, outputs, secretKeys, {
       ttl: new Date(Date.now() + OFFER_TTL_MS),
       // The offer stays imbalanced and carries no Dust — taker balances,
@@ -146,6 +155,28 @@ export async function buildMakerOfferBlobLocal(
       payFees: false,
     }),
   );
+
+  // Move this offer's Intent off segment 1, where `initSwap` always puts it, so
+  // two unshielded-leg offers can be taken in ONE action instead of colliding
+  // ("key (segment_id) collision during intents merge: 1"). See
+  // services/offerSegment.ts for the full rationale. This is the only moment it
+  // can happen: the transaction is still unproven and unbound, and the
+  // signature below has to cover the segment the offer ends up carrying.
+  // Shielded-only offers carry no Intent, so they pass through untouched.
+  const resegmented = randomizeRecipeIntentSegment(recipe);
+  recipe = resegmented.recipe;
+  if (resegmented.skipped) {
+    dlog('localOffer.build: Intent re-segment SKIPPED — recipe is not an unproven transaction', {
+      recipeType: (recipe as { type?: string } | null)?.type,
+    });
+  } else if (resegmented.moves.length === 0) {
+    dlog('localOffer.build: no Intent to re-segment (shielded-only offer)');
+  } else {
+    dlog('localOffer.build: Intent moved to a random segment (so ladders can merge)', {
+      moves: resegmented.moves,
+      range: `${INTENT_SEGMENT_MIN}..${INTENT_SEGMENT_MAX}`,
+    });
+  }
 
   if (gives.some((g) => g.kind === 'unshielded')) {
     recipe = await timed('localOffer.build: facade.signRecipe (unshielded gives)', () =>

--- a/templates/zswap-da/src/services/offerBatch.ts
+++ b/templates/zswap-da/src/services/offerBatch.ts
@@ -17,15 +17,22 @@
 // one coin selection, one proof pass, one dust fee and one submission: the
 // double-spend window is removed rather than waited out.
 //
-// The one limit is segment ids. The facade builds an offer's unshielded half
-// with `Transaction.fromParts`, which always lands its Intent at segment 1, and
-// `merge` refuses two transactions that both occupy it ("key (segment_id)
-// collision during intents merge: 1"). Shielded-only offers carry no Intent at
-// all, so they always compose. Re-segmenting is not an option on this side: it
-// needs an unproven transaction, and a maker blob decodes to a bound one
-// ("Transaction is already bound."). A batch that would collide is therefore
-// rejected HERE, before anything is submitted — a ladder settles whole or not
-// at all.
+// The one limit is segment ids. `merge` keys intents by segment, and refuses
+// two transactions that occupy the same one ("key (segment_id) collision during
+// intents merge: 1"). Shielded-only offers carry no Intent at all, so they
+// always compose; offers with an unshielded leg do carry one, and where it
+// lands decides whether they can share a ladder:
+//
+//   - offers created by THIS template's JS-wallet maker path put it on a random
+//     segment (services/offerSegment.ts), so any number of them compose;
+//   - offers created before that change, and every Lace-made offer, sit at
+//     segment 1 — so at most one of THOSE fits in a batch.
+//
+// Re-segmenting is not an option on this side: it needs an unproven
+// transaction, and a maker blob decodes to a bound one ("Transaction is already
+// bound."). A batch that would collide — two legacy offers, or the ~1-in-65534
+// case of two random ids matching — is therefore rejected HERE, before anything
+// is submitted: a ladder settles whole or not at all.
 //
 // BOTH wallets fold their ladder through this module. The JS wallet facade
 // takes the merged ledger object (services/localTradeOffers.ts); Lace takes its
@@ -101,9 +108,9 @@ function mergeFailureMessage(cause: unknown, count: number): string {
   if (/segment_id|intents merge/i.test(detail)) {
     return (
       `These ${count} offers can't be settled together — two of them occupy the same ` +
-      `transaction segment (${detail}). Offers with an unshielded leg are always built ` +
-      `at segment 1, so only one of those fits in a batch. Take them one at a time. ` +
-      `Nothing was submitted.`
+      `transaction segment (${detail}). Older offers with an unshielded leg, and ` +
+      `Lace-made ones, all sit at segment 1, so only one of those fits in a batch. ` +
+      `Take them one at a time. Nothing was submitted.`
     );
   }
   if (/same coins?|spend the same/i.test(detail)) {

--- a/templates/zswap-da/src/services/offerSegment.test.ts
+++ b/templates/zswap-da/src/services/offerSegment.test.ts
@@ -1,0 +1,346 @@
+// Maker-side Intent re-segmentation, against the real ledger — no network, no
+// facade, no wallet.
+//
+// The fixtures build an offer the way `buildMakerOfferBlobLocal` does: the
+// wallet facade's unshielded `initSwap` is
+// `Intent.new(ttl)` + `guaranteedUnshieldedOffer`, then
+// `Transaction.fromParts(net, undefined, undefined, intent)`. So "legacy" here
+// is literally what the template published before this change, and "new" is
+// that same transaction put through the shipped `randomizeIntentSegments`
+// before `mockProve()` — the ordering the production path uses, minus the proof
+// server.
+//
+// What that buys: the merge results below are the ledger's own verdict on real
+// offer blobs, not a model of it.
+import { describe, expect, test } from 'bun:test';
+import * as ledger from '@midnight-ntwrk/ledger-v8';
+import { OfferFiles } from '@effectstream/mip-zswap-offer/mip5';
+import type { NetworkId } from '@midnight-ntwrk/midnight-js-network-id';
+import {
+  INTENT_SEGMENT_MAX,
+  INTENT_SEGMENT_MIN,
+  randomIntentSegmentId,
+  randomizeIntentSegments,
+  randomizeRecipeIntentSegment,
+} from './offerSegment';
+import {
+  batchPaysUnshielded,
+  chooseLaceBalancing,
+  decodeMakerOffers,
+  mergeMakerOffers,
+  pickSwapSegment,
+} from './offerBatch';
+import { parseTakerLegs } from './offerParse';
+import { parseOfferSender, isOwnOffer } from './offerSender';
+
+const L = ledger as any;
+const NETWORK = 'undeployed' as NetworkId;
+const ttl = () => new Date(Date.now() + 3600_000);
+
+const TOKEN = 'cc'.repeat(32);
+const OWNER = 'dd'.repeat(32);
+const HASH = 'ee'.repeat(32);
+
+const segments = (tx: any): number[] => (tx?.intents ? Array.from(tx.intents.keys()) : []);
+const encode = (tx: any): string => OfferFiles.encode(tx.serialize());
+
+/**
+ * The UNPROVEN transaction the facade's `initSwap` hands back for an offer with
+ * an unshielded leg — Intent at segment 1, every time.
+ *
+ * `direction: 'pays'` puts the value in an output: the maker pays it out, so the
+ * TAKER pays for it. `'gets'` puts it in an input the maker spends, so the taker
+ * receives it.
+ */
+const unprovenUnshielded = (direction: 'pays' | 'gets' = 'pays') => {
+  const offer =
+    direction === 'gets'
+      ? L.UnshieldedOffer.new(
+          [{ value: 7n, owner: OWNER, type: TOKEN, intentHash: HASH, outputNo: 0 }],
+          [],
+          [],
+        )
+      : L.UnshieldedOffer.new([], [{ value: 7n, owner: OWNER, type: TOKEN }], []);
+  const intent = L.Intent.new(ttl());
+  intent.guaranteedUnshieldedOffer = offer;
+  return L.Transaction.fromParts(NETWORK, undefined, undefined, intent);
+};
+
+/** A published offer in the OLD format: Intent left at segment 1. */
+const legacyOffer = (direction: 'pays' | 'gets' = 'pays') =>
+  unprovenUnshielded(direction).mockProve();
+
+/**
+ * A published offer in the NEW format: the same transaction, re-segmented by the
+ * shipped helper before proving — exactly the order `buildMakerOfferBlobLocal`
+ * uses.
+ */
+const newOffer = (direction: 'pays' | 'gets' = 'pays', pick?: () => number) =>
+  randomizeIntentSegments(unprovenUnshielded(direction), pick).tx.mockProve();
+
+/** Shielded-only: no Intent anywhere, the branch that must stay untouched. */
+const shieldedOffer = (value = 7n) => {
+  const keys = L.ZswapSecretKeys.fromSeed(new Uint8Array(32).fill(3));
+  const coin = L.createShieldedCoinInfo(TOKEN, value);
+  const output = L.ZswapOutput.new(coin, undefined, keys.coinPublicKey, keys.encryptionPublicKey);
+  return L.Transaction.fromParts(NETWORK, L.ZswapOffer.fromOutput(output)).mockProve();
+};
+
+describe('randomIntentSegmentId', () => {
+  test('every draw is inside the documented range and never 0 or 1', () => {
+    const draws = Array.from({ length: 5000 }, () => randomIntentSegmentId());
+    expect(draws.every((n) => Number.isInteger(n))).toBe(true);
+    expect(draws.every((n) => n >= INTENT_SEGMENT_MIN && n <= INTENT_SEGMENT_MAX)).toBe(true);
+    // 0 is the guaranteed section, 1 is where fromParts and Lace both land — an
+    // offer on either would be exactly as unmergeable as the ones this replaces.
+    expect(draws.includes(0)).toBe(false);
+    expect(draws.includes(1)).toBe(false);
+  });
+
+  test('the range is 2..65535 and the draw actually spreads across it', () => {
+    expect(INTENT_SEGMENT_MIN).toBe(2);
+    expect(INTENT_SEGMENT_MAX).toBe(65535);
+    const draws = Array.from({ length: 5000 }, () => randomIntentSegmentId());
+    // Uniform over 65,534 ids: both halves are hit, and 5000 draws collide only
+    // rarely, so the id is not being clamped or bucketed somewhere narrow.
+    expect(draws.some((n) => n < 32768)).toBe(true);
+    expect(draws.some((n) => n >= 32768)).toBe(true);
+    expect(new Set(draws).size).toBeGreaterThan(4500);
+  });
+});
+
+describe('randomizeIntentSegments', () => {
+  test('an unshielded-leg offer moves off segment 1', () => {
+    const before = unprovenUnshielded();
+    expect(segments(before)).toEqual([1]);
+
+    const { tx, moves } = randomizeIntentSegments(before);
+    expect(moves.length).toBe(1);
+    expect(moves[0]!.from).toBe(1);
+    expect(moves[0]!.to).toBeGreaterThanOrEqual(INTENT_SEGMENT_MIN);
+    expect(moves[0]!.to).toBeLessThanOrEqual(INTENT_SEGMENT_MAX);
+    expect(segments(tx)).toEqual([moves[0]!.to]);
+  });
+
+  test('the segment source is injectable, so the placement is exact', () => {
+    const { tx, moves } = randomizeIntentSegments(unprovenUnshielded(), () => 4242);
+    expect(moves).toEqual([{ from: 1, to: 4242 }]);
+    expect(segments(tx)).toEqual([4242]);
+  });
+
+  test('a shielded-only offer is returned untouched, by identity', () => {
+    // FR-002 structurally, not just behaviourally: there is no Intent, so no
+    // code runs on this path at all.
+    const before = L.Transaction.fromParts(NETWORK);
+    const { tx, moves } = randomizeIntentSegments(before);
+    expect(moves).toEqual([]);
+    expect(tx).toBe(before);
+  });
+
+  test('the Intent survives the move intact — legs, value and owner all preserved', () => {
+    const moved = randomizeIntentSegments(unprovenUnshielded('pays'), () => 777).tx;
+    const intent = (moved.intents as Map<number, any>).get(777);
+    const outputs = intent.guaranteedUnshieldedOffer.outputs;
+    expect(outputs.length).toBe(1);
+    expect(outputs[0].value).toBe(7n);
+    expect(String(outputs[0].type)).toBe(TOKEN);
+    // The imbalance the taker must cover is unchanged by the move.
+    expect(Array.from((moved.mockProve().imbalances(0) as Map<any, bigint>).values())).toEqual([
+      -7n,
+    ]);
+  });
+
+  test('several Intents all move, to DISTINCT segments', () => {
+    const two = unprovenUnshielded().addIntent(
+      { tag: 'specific', value: 5 },
+      (unprovenUnshielded('gets').intents as Map<number, any>).get(1),
+    );
+    expect(new Set(segments(two))).toEqual(new Set([1, 5]));
+
+    const { tx, moves } = randomizeIntentSegments(two);
+    expect(moves.length).toBe(2);
+    expect(new Set(moves.map((m) => m.from))).toEqual(new Set([1, 5]));
+    const to = moves.map((m) => m.to);
+    expect(new Set(to).size).toBe(2);
+    expect(new Set(segments(tx))).toEqual(new Set(to));
+  });
+
+  test('a colliding segment source is re-drawn rather than dropping an Intent', () => {
+    // Forces the dedup loop: the first two draws are the same id.
+    const queue = [900, 900, 901];
+    const { tx, moves } = randomizeIntentSegments(
+      unprovenUnshielded().addIntent(
+        { tag: 'specific', value: 5 },
+        (unprovenUnshielded('gets').intents as Map<number, any>).get(1),
+      ),
+      () => queue.shift() ?? 902,
+    );
+    expect(new Set(moves.map((m) => m.to))).toEqual(new Set([900, 901]));
+    expect(segments(tx).length).toBe(2);
+  });
+
+  test('re-segmenting is impossible once the transaction is bound — the ordering is enforced by the ledger', () => {
+    // The reason this lives at creation time and can never be a taker-side
+    // repair: a published blob decodes to a bound transaction.
+    const bound = unprovenUnshielded().mockProve();
+    expect(() => randomizeIntentSegments(bound)).toThrow('already bound');
+  });
+
+  test('the signable payload is segment-dependent, which is why signing must come after', () => {
+    const before = unprovenUnshielded('gets');
+    const intent = (before.intents as Map<number, any>).get(1);
+    const hex = (b: Uint8Array) => Array.from(b, (x) => x.toString(16).padStart(2, '0')).join('');
+    // A signature taken at segment 1 would not cover segment 4242, so the
+    // node would reject the settlement with SIGNATURE_INVALID.
+    expect(hex(intent.signatureData(1))).not.toBe(hex(intent.signatureData(4242)));
+  });
+});
+
+describe('randomizeRecipeIntentSegment — the facade-recipe wrapper', () => {
+  test('an unproven recipe comes back with the re-segmented transaction and its other fields', () => {
+    const blockData = { some: 'value' };
+    const recipe = {
+      type: 'UNPROVEN_TRANSACTION',
+      transaction: unprovenUnshielded(),
+      blockData,
+    };
+    const out = randomizeRecipeIntentSegment(recipe, () => 3131);
+    expect(out.skipped).toBeUndefined();
+    expect(out.moves).toEqual([{ from: 1, to: 3131 }]);
+    expect(out.recipe.type).toBe('UNPROVEN_TRANSACTION');
+    expect(out.recipe.blockData).toBe(blockData);
+    expect(segments(out.recipe.transaction)).toEqual([3131]);
+  });
+
+  test('a shielded-only recipe is the SAME object — creation is structurally unchanged', () => {
+    const recipe = { type: 'UNPROVEN_TRANSACTION', transaction: L.Transaction.fromParts(NETWORK) };
+    const out = randomizeRecipeIntentSegment(recipe);
+    expect(out.recipe).toBe(recipe);
+    expect(out.moves).toEqual([]);
+    expect(out.skipped).toBeUndefined();
+  });
+
+  test('an unexpected recipe shape is passed through and flagged, never mangled', () => {
+    const recipe = { type: 'FINALIZED_TRANSACTION', originalTransaction: {} } as any;
+    const out = randomizeRecipeIntentSegment(recipe);
+    expect(out.recipe).toBe(recipe);
+    expect(out.skipped).toBe('not-an-unproven-recipe');
+    expect(randomizeRecipeIntentSegment(undefined as any).skipped).toBe('not-an-unproven-recipe');
+  });
+});
+
+// The point of the whole change: what a ladder can now contain.
+describe('what merges, end to end through real offer blobs', () => {
+  test('TWO new-format unshielded-leg offers MERGE — this is what used to be refused', () => {
+    const blobs = [encode(newOffer()), encode(newOffer())];
+    const merged = mergeMakerOffers(decodeMakerOffers(blobs, NETWORK));
+    expect(segments(merged).length).toBe(2);
+    expect(segments(merged)).not.toContain(1);
+    // One balancing pass covers the ladder: two offers of 7 → the taker owes 14.
+    expect(Array.from((merged.imbalances(0) as Map<any, bigint>).values())).toEqual([-14n]);
+  });
+
+  test('a new-format ladder round-trips through serialize/deserialize with both segments', () => {
+    const merged = mergeMakerOffers(
+      decodeMakerOffers([encode(newOffer()), encode(newOffer())], NETWORK),
+    );
+    const back = L.Transaction.deserialize('signature', 'proof', 'binding', merged.serialize());
+    expect(new Set(segments(back))).toEqual(new Set(segments(merged)));
+  });
+
+  test('new × legacy merges — only one of them occupies segment 1', () => {
+    const merged = mergeMakerOffers(
+      decodeMakerOffers([encode(newOffer()), encode(legacyOffer())], NETWORK),
+    );
+    expect(segments(merged)).toContain(1);
+    expect(segments(merged).length).toBe(2);
+  });
+
+  test('legacy × legacy is STILL refused before submission — the PR #910 guard stays', () => {
+    const decoded = decodeMakerOffers([encode(legacyOffer()), encode(legacyOffer())], NETWORK);
+    let err: any;
+    try {
+      mergeMakerOffers(decoded);
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeDefined();
+    expect(err.message).toContain("can't be settled together");
+    expect(err.message).toContain('segment_id');
+    expect(err.message).toContain('Nothing was submitted');
+  });
+
+  test('the 1-in-65534 case — two new offers that draw the SAME id — is caught by the same guard', () => {
+    const a = randomizeIntentSegments(unprovenUnshielded(), () => 5150).tx.mockProve();
+    const b = randomizeIntentSegments(unprovenUnshielded(), () => 5150).tx.mockProve();
+    const decoded = decodeMakerOffers([encode(a), encode(b)], NETWORK);
+    expect(() => mergeMakerOffers(decoded)).toThrow("can't be settled together");
+  });
+
+  test('new-format offers still merge with shielded-only ones', () => {
+    const merged = mergeMakerOffers(
+      decodeMakerOffers([encode(newOffer()), encode(shieldedOffer())], NETWORK),
+    );
+    expect(segments(merged).length).toBe(1);
+  });
+
+  test('N=1 new-format still passes through the settle pipeline untouched', () => {
+    const decoded = decodeMakerOffers([encode(newOffer())], NETWORK);
+    expect(mergeMakerOffers(decoded)).toBe(decoded[0]!.tx);
+  });
+});
+
+// FR-004: everything that locates the Intent must work for any segment id.
+describe('unmodified consumers still read a new-format blob', () => {
+  test('the blob is a valid MIP-0005 offer and decodes to the randomized segment', () => {
+    const tx = newOffer('pays', () => 20250);
+    const blob = encode(tx);
+    expect(blob.startsWith('swapoffer1')).toBe(true);
+    const back = L.Transaction.deserialize(
+      'signature',
+      'proof',
+      'binding',
+      OfferFiles.decode(blob),
+    );
+    expect(segments(back)).toEqual([20250]);
+  });
+
+  test('parseTakerLegs reads the legs from any segment', () => {
+    const pays = parseTakerLegs(encode(newOffer('pays')), NETWORK);
+    expect(pays?.pays).toEqual([{ color: TOKEN, kind: 'unshielded', amount: 7n }]);
+    const gets = parseTakerLegs(encode(newOffer('gets')), NETWORK);
+    expect(gets?.gets).toEqual([{ color: TOKEN, kind: 'unshielded', amount: 7n }]);
+    // Same answer as the legacy blob it replaces — the preview does not change.
+    expect(parseTakerLegs(encode(legacyOffer('pays')), NETWORK)).toEqual(pays!);
+  });
+
+  test('batchPaysUnshielded still sees the unshielded leg', () => {
+    expect(batchPaysUnshielded([encode(newOffer('pays'))], NETWORK)).toBe(true);
+    expect(batchPaysUnshielded([encode(newOffer('gets'))], NETWORK)).toBe(false);
+  });
+
+  test('the maker is still identified, so “Yours” keeps working', () => {
+    // parseOfferSender walks intents.values(), so the key it was stored under is
+    // irrelevant — asserted rather than assumed.
+    const info = parseOfferSender(encode(newOffer('gets')), NETWORK);
+    expect(info?.unshieldedOwners).toContain(OWNER);
+    expect(isOwnOffer(info, OWNER)).toBe(true);
+  });
+
+  test('Lace dispatch is unchanged: an unshielded-leg offer still routes to sealed-balance', () => {
+    const legacy = chooseLaceBalancing(legacyOffer());
+    const fresh = chooseLaceBalancing(newOffer());
+    expect(fresh.useMirrorMerge).toBe(legacy.useMirrorMerge);
+    expect(fresh.useMirrorMerge).toBe(false);
+    expect(fresh.segId).toBe(0);
+  });
+
+  test('a merged new-format ladder still has exactly ONE swap segment', () => {
+    // More than one would throw "Multi-segment offers are not supported" and
+    // break the wallet dispatch — the randomized Intent slots carry no assets.
+    const merged = mergeMakerOffers(
+      decodeMakerOffers([encode(newOffer()), encode(newOffer())], NETWORK),
+    );
+    expect(pickSwapSegment(merged).segId).toBe(0);
+  });
+});

--- a/templates/zswap-da/src/services/offerSegment.ts
+++ b/templates/zswap-da/src/services/offerSegment.ts
@@ -1,0 +1,168 @@
+// Put a new offer's Intent on a RANDOM transaction segment, so unshielded-leg
+// offers can be taken as a ladder.
+//
+// Why this exists. An offer carries an Intent exactly when it has an unshielded
+// leg: the wallet facade's `initSwap` only builds an unshielded half when there
+// are unshielded inputs or outputs, and that half is
+// `Transaction.fromParts(networkId, undefined, undefined, intent)` — which
+// ALWAYS lands the Intent at segment 1. Ledger `merge` keys intents by segment
+// id, so two such offers refuse to compose:
+//
+//   key (segment_id) collision during intents merge: 1
+//
+// Taking several offers in one action means merging their maker halves
+// (services/offerBatch.ts), so under that rule a ladder could hold at most ONE
+// unshielded-leg offer. The ledger's own answer is `fromPartsRandomized`,
+// documented as existing "to better allow merging"; this module applies the same
+// idea to the transaction the facade has already built.
+//
+// Why it can only happen HERE, at creation time:
+//   - re-segmenting requires an UNPROVEN, UNBOUND transaction — a published
+//     offer blob decodes to a bound, proven one ("Transaction is already
+//     bound."), so a taker can never repair a collision;
+//   - it must precede signing — `Intent.signatureData(segment)` is
+//     segment-dependent (verified: the payload for segment 1 differs from the
+//     payload for segment 4242), so a signature taken before the move would not
+//     cover the segment the transaction ends up carrying.
+//
+// Everything downstream is already segment-agnostic and stays untouched: the
+// wallet's own signing service signs whatever segments `tx.intents` holds
+// (`collectSignableData` → `intent.signatureData(thatSegment)`), the taker's
+// `balanceFinalizedTransaction` picks its own slot with
+// `findAvailableSegmentId` (the first unused id in 1..65535), and this
+// template's readers (`offerParse.parseTakerLegs`, `offerSender.parseOfferSender`,
+// `offerBatch.pickSwapSegment`/`chooseLaceBalancing`, `decodeOffer`) all
+// enumerate `intents.keys()` rather than assuming 1.
+//
+// Nothing is imported here on purpose. The transaction handed to us belongs to
+// whichever ledger wasm module the facade was built against, and wasm-bindgen
+// classes carry per-instance type identity — so this module only uses the
+// instance's own documented API (`intents`, `addIntent`), which both ledger-v8
+// and ledger-v9 expose identically. Keeping it dependency-free is also what
+// makes it unit-testable without a wallet, a network or a browser, the same
+// discipline services/offerBatch.ts follows.
+
+/**
+ * Lowest segment id a new offer's Intent may take.
+ *
+ * 0 is the guaranteed section (never an Intent slot) and 1 is where
+ * `Transaction.fromParts` — and Lace's unshielded `makeIntent` — put theirs, so
+ * both are excluded by construction: an offer that took 1 would be no more
+ * mergeable than the offers this module exists to replace.
+ */
+export const INTENT_SEGMENT_MIN = 2;
+
+/**
+ * Highest segment id a new offer's Intent may take.
+ *
+ * Segment ids are 16-bit: the wallet SDK's own `findAvailableSegmentId` scans
+ * `1..65535`, and the ledger's `fromPartsRandomized` was sampled 400 times on
+ * both ledger-v8 and ledger-v9 and never produced 0, 1, or a value above 65535
+ * (observed 120…65465). So `2..65535` is the ledger's own space minus the two
+ * reserved slots.
+ */
+export const INTENT_SEGMENT_MAX = 65535;
+
+/**
+ * A uniform segment id in `[INTENT_SEGMENT_MIN, INTENT_SEGMENT_MAX]`.
+ *
+ * Rejection sampling on a 16-bit draw rather than a modulo, so the distribution
+ * is exactly uniform across the 65,534 usable ids. Two offers in one ladder
+ * collide with probability 1/65534; that residual case is caught — before
+ * anything is submitted — by the same guard that catches legacy segment-1 pairs
+ * (services/offerBatch.ts).
+ */
+export function randomIntentSegmentId(): number {
+  const buf = new Uint16Array(1);
+  for (;;) {
+    crypto.getRandomValues(buf);
+    const id = buf[0]!;
+    if (id >= INTENT_SEGMENT_MIN && id <= INTENT_SEGMENT_MAX) return id;
+  }
+}
+
+/** One Intent's relocation, for logging and tests. */
+export interface SegmentMove {
+  from: number;
+  to: number;
+}
+
+/**
+ * Move every Intent on an UNPROVEN, UNBOUND transaction to a fresh random
+ * segment id, and return the rebuilt transaction.
+ *
+ * A shielded-only offer has no Intent at all, so it comes back untouched (by
+ * identity) with no moves — that path is structurally unchanged.
+ *
+ * The facade produces exactly one Intent, at segment 1; the loop is written for
+ * the map because that is what the ledger exposes, and it keeps the chosen ids
+ * distinct so a multi-Intent transaction could not collide with itself.
+ *
+ * @param unprovenTx A ledger `Transaction` in the unproven, unbound state.
+ * @param pick Segment-id source; injectable so tests can force a value.
+ * @throws Whatever `addIntent` throws — notably "Transaction is already bound."
+ * if this is ever called after proving or binding, which is the failure mode we
+ * WANT to be loud.
+ */
+export function randomizeIntentSegments(
+  unprovenTx: any,
+  pick: () => number = randomIntentSegmentId,
+): { tx: any; moves: SegmentMove[] } {
+  const intents = unprovenTx?.intents as Map<number, unknown> | undefined;
+  if (!intents || intents.size === 0) return { tx: unprovenTx, moves: [] };
+
+  // Snapshot before mutating: `addIntent` rebuilds the transaction, and the
+  // Intent values have to be held onto across the removal.
+  const held = Array.from(intents.entries());
+
+  let tx = unprovenTx;
+  for (const [from] of held) {
+    tx = tx.addIntent({ tag: 'specific', value: from }, undefined);
+  }
+
+  const moves: SegmentMove[] = [];
+  const taken = new Set<number>();
+  for (const [from, intent] of held) {
+    let to = pick();
+    while (taken.has(to)) to = pick();
+    taken.add(to);
+    tx = tx.addIntent({ tag: 'specific', value: to }, intent);
+    moves.push({ from, to });
+  }
+
+  return { tx, moves };
+}
+
+/** What {@link randomizeRecipeIntentSegment} did, so the caller can log it. */
+export interface RecipeResegmentResult<T> {
+  recipe: T;
+  moves: SegmentMove[];
+  /** Set when the recipe was not an unproven transaction — nothing was moved. */
+  skipped?: 'not-an-unproven-recipe';
+}
+
+/**
+ * {@link randomizeIntentSegments} applied to a wallet-facade balancing recipe —
+ * the shape `facade.initSwap` returns
+ * (`{ type: 'UNPROVEN_TRANSACTION', transaction, blockData? }`).
+ *
+ * The recipe is returned unchanged, by identity, in the two cases where there is
+ * nothing to do: a shielded-only offer (no Intent) and any recipe that is not an
+ * unproven transaction. Only an unproven transaction can be re-segmented at all,
+ * and publishing an offer at segment 1 is a far better outcome than mangling a
+ * shape this function did not expect.
+ */
+export function randomizeRecipeIntentSegment<T extends { type?: string; transaction?: any }>(
+  recipe: T,
+  pick: () => number = randomIntentSegmentId,
+): RecipeResegmentResult<T> {
+  if (recipe?.type !== 'UNPROVEN_TRANSACTION' || !recipe.transaction) {
+    return { recipe, moves: [], skipped: 'not-an-unproven-recipe' };
+  }
+
+  const { tx, moves } = randomizeIntentSegments(recipe.transaction, pick);
+  // Shielded-only offer: no Intent, nothing moved, same recipe object.
+  if (moves.length === 0) return { recipe, moves };
+
+  return { recipe: { ...recipe, transaction: tx }, moves };
+}


### PR DESCRIPTION
## Why this is a DRAFT

Two things are **not verified**, and both need environments that do not exist right now:

1. **No node has yet accepted a settlement whose maker Intent was signed at a randomized segment.** That is the spec's SC-001/SC-002 (live: two new-format unshielded-leg offers taken in one action → one submission, one tx, both consumed, balances exact, zero `NullifierAlreadyPresent`, zero segment-collision errors). The `midnight-2-offers` demo stack this line of work was verified against is being replaced, so the live run is **deferred to the new infrastructure version**. Signature validity and well-formedness under a randomized segment are exactly what this change puts at risk, so it stays a draft until a node says yes.
2. **Lace *taking* a randomized-segment offer is unverified** (FR-006). No node-2.x browser wallet accepts the `payFees: false` fee policy this template requires — the batcher pays dust — so the injected-wallet take path cannot be exercised here at all. The dispatch is provably unchanged for such offers (see below), and a non-1 maker segment should if anything *help* Lace, whose `balanceSealedTransaction` lands its own Intent at segment 1 — but that is reasoning, not evidence.

Everything offline is green (90/90, both ledger lines). Undrafting/merging waits on item 1.

---

## The problem

An offer carries an Intent **exactly when it has an unshielded leg**: the wallet facade's `initSwap` only builds an unshielded half when there are unshielded inputs or outputs, and that half is

```js
// @midnightntwrk/wallet-sdk-unshielded-wallet/dist/v1/Transacting.js:212-215
const intent = ledger.Intent.new(ttl);
intent.guaranteedUnshieldedOffer = offer;
const tx = ledger.Transaction.fromParts(networkId, undefined, undefined, intent);
```

`fromParts` **always** lands the Intent at **segment 1**. Ledger `merge` keys intents by segment, so two such offers refuse to compose:

```
key (segment_id) collision during intents merge: 1
```

#910 made a ladder take settle as **one** merged transaction and added a pre-submission guard that refuses a batch which would collide. Correct and atomic — but it left unshielded-leg offers able to hold at most **one** slot in any ladder. Shielded↔shielded ladders were fine (no Intent at all); a taker looking at two unshielded-leg offers was told to take them one at a time.

This changes offer **creation**, so newly created offers compose with each other.

## Why it has to happen at creation time

- **Re-segmenting needs an unproven, unbound transaction.** A published blob decodes to a bound one:
  ```
  assigning intents on a BOUND tx: THREW -> Transaction is already bound.
  ```
  So a taker can never repair a collision. This is maker-side or nowhere.
- **It must precede signing.** `Intent.signatureData(segment)` is segment-dependent — verified, the payload for segment 1 differs from the payload for 4242 — so a signature taken first would not cover the segment the offer is published with, and the node would reject the settlement with `SIGNATURE_INVALID`.

The call therefore sits between `initSwap` and `signRecipe`:

```
maker:  initSwap → move the Intent to a random segment (if there is one)
        → [signRecipe if unshielded gives] → finalizeRecipe(prove)
        → serialize → MIP-0005 encode
```

## What changed

**New `src/services/offerSegment.ts`** (template-only, 4 files total, all under `templates/zswap-da/src/services/`):

- `randomIntentSegmentId()` — uniform in **`2..65535`**, by **rejection sampling on a 16-bit `crypto.getRandomValues` draw** (exactly uniform over the 65,534 usable ids, unlike a modulo). 0 is the guaranteed section and 1 is where `fromParts` *and* Lace both land, so both are excluded **by construction** — an offer that took either would be exactly as unmergeable as the ones this replaces.
- Why that range, measured rather than assumed: the wallet SDK's own `findAvailableSegmentId` scans `IterableOps.range(1, 65535)` (`TransactionOps.js:47-50`), and the ledger's `fromPartsRandomized` — which the typings document as existing *"to better allow merging"* — was sampled **400× on each ledger** and produced min 120 / max 65465 (v8) and min 338 / max 65379 (v9), **never 0, never 1, never >65535**.
- `randomizeIntentSegments(unprovenTx, pick?)` — rebuilds the transaction with `addIntent({tag:'specific', …})`. Chosen over three other working mechanisms (assigning `tx.intents`, mutating the getter's map, `addIntent({tag:'random'})`) because it is the ledger's documented public API — typed `@throws If called on bound transactions`, which is the loud failure we *want* if this ever drifts past proving — it returns a new transaction rather than mutating, and it preserves any other Intent. `{tag:'random'}` was rejected for one reason: it gives no control over the range and no guarantee against landing on 1.
- **The module imports nothing at all.** The transaction belongs to whichever ledger wasm module the facade was built against, and wasm-bindgen classes carry per-instance type identity — so it only touches `intents` / `addIntent`, which ledger-v8 and ledger-v9 expose identically. That is also what makes it unit-testable with no wallet, network or browser (same discipline as `offerBatch.ts`).

**`localTradeOffers.ts`** — one call, plus the docstring's pipeline line and signing note.

**`offerBatch.ts`** — **the #910 guard is unchanged and still needed**: legacy blobs, every Lace-made offer, and the ~1-in-65534 case of two random draws matching. Only its narrative changed, because it had become false: the docstring now distinguishes new offers (random) from legacy/Lace ones (segment 1), and the user-facing message says "Older offers … and Lace-made ones" instead of "always".

**Shielded-only creation is structurally untouched** — no Intent, so the helper returns the same recipe object *by identity*.

## Nothing downstream needed changing (FR-004)

Audited every site that locates an Intent. **None was hardcoded to segment 1**:

| Site | Why it already works |
|---|---|
| facade `signRecipe` → `Signing.js` `makeDefaultSigningService` | `TransactionOps.collectSignableData` iterates `getSegments(tx)` = `tx.intents.keys()` and calls `intent.signatureData(thatSegment)`; `attachSignatures` re-keys by the same id. Segment-agnostic — which is the whole reason "re-segment then sign" needs **zero** SDK changes. |
| `offerParse.parseTakerLegs` (preview, `batchPaysUnshielded`) | candidates = `{0} ∪ intents.keys() ∪ fallibleOffer.keys()` |
| `offerSender.parseOfferSender` ("Yours" badge) | iterates `intents.values()`, never keys |
| `offerBatch.pickSwapSegment` / `chooseLaceBalancing` | same candidate union; `useMirrorMerge = segId===0 && !makerHasIntents`, so a randomized-segment offer routes to sealed-balance exactly as a segment-1 one does |
| `browserContract.ts` (Lace taker) | dispatch comes from `chooseLaceBalancing`; diagnostics enumerate keys |
| `decodeOffer.ts` | labels 0 guaranteed, every other key "fallible" |
| `makerOffer.ts` (Lace maker, untouched) | already randomizes — `pickMakerIntentId()` returns `max(2, u32 & 0x7fffffff)` |
| `useZSwapApp.ts`, `tradeWallet.ts`, `takerBalance.ts` | no segment references at all |

## Compatibility — not breaking, but a real format change

State it plainly:

- **Newly created unshielded-leg offer blobs place their Intent at a random segment in `2..65535`** instead of at 1.
- **Legacy blobs are unchanged** and keep working; so do Lace-made offers.
- **Unmodified consumers decode both identically** — asserted, not assumed: `parseTakerLegs` on a new-format blob returns the *same legs* as on the legacy blob it replaces, `parseOfferSender` + `isOwnOffer` still identify the maker, `chooseLaceBalancing` gives the *same* dispatch (`useMirrorMerge: false`, `segId: 0`), and the blob is still `swapoffer1…` and still round-trips through `OfferFiles` + `Transaction.deserialize`.
- Shielded-only offers: no behavioural or structural change.
- No package API change, no dependency change, contract untouched (`build:contract` → `✓ 16 files match manifest.json`, `manifest.json` unmodified).

## Testing

New `src/services/offerSegment.test.ts`, **26 tests**, against the real ledger — no network, no facade, no wallet. **The fixtures are the production shape, not a model of it**: `unprovenUnshielded()` reproduces the facade's unshielded `initSwap` verbatim, so `legacyOffer()` is literally what this template published before, and `newOffer()` is that same transaction put through the **shipped** `randomizeIntentSegments` before `mockProve()` — the exact order `buildMakerOfferBlobLocal` uses, minus the proof server. Every merge verdict below is the ledger's own.

| Command (in `templates/zswap-da`) | Result |
|---|---|
| `bun test src/services/offerSegment.test.ts` | **26 pass / 0 fail**, 69 expect() (new) |
| `bun test src/` | **90 pass / 0 fail**, 5 files (baseline on `v-next` was 64 — `offerBatch` 22, `takerBalance` 19, `shieldedAddress` 11, `utils` 12; all still green, none modified) |
| `bun run build` (`tsc -b && vite build`) | **green**, zero TS errors |
| `bun run build:contract` | **✓ 16 files match manifest.json** |

What the new tests establish:

- **Range and exclusions** — 5,000 draws all integer, all in `2..65535`, never 0, never 1; >4,500 distinct values in 5,000 draws, so the id is not clamped or bucketed somewhere narrow.
- **The move** — segment 1 → in-range id; injectable source places it exactly; the Intent survives intact (outputs, value, token type) with `imbalances(0)` unchanged; several Intents all move to **distinct** ids; a colliding source is re-drawn rather than dropping an Intent.
- **The ordering, enforced by the ledger rather than by comment** — re-segmenting a bound (published) transaction **throws "already bound"**, and `signatureData(1) !== signatureData(4242)`.
- **Shielded-only untouched** — same object **by identity**; ditto the recipe wrapper; an unexpected recipe shape is passed through and flagged, never mangled; `blockData` preserved.
- **What merges** — **two new-format offers MERGE** (2 segments, neither is 1, `imbalances(0)` sums to `-14n` for two offers of 7, so one balancing pass covers the ladder) and the merged tx round-trips; **new × legacy merges**; **legacy × legacy is STILL refused** pre-submission with #910's message; **the 1-in-65534 same-draw case is caught by that same guard**; new × shielded-only merges; N=1 returns the decoded tx by identity.
- **A merged new-format ladder still has exactly ONE swap segment** — i.e. the randomized Intent slots carry no assets and never trigger "Multi-segment offers are not supported".

**Cross-ledger.** Because `offerSegment.ts` imports nothing, the **shipped** function was also run directly against `@midnightntwrk/ledger-v9@1.0.0-rc.3` — the ledger the wallet facade actually resolves at runtime, not the template's direct `ledger-v8`. **10/10 checks pass**: facade shape is Intent@1 on v9 too; the helper moves it in range; it proves and round-trips; **two new-format offers merge (`[52349, 44659]`, imbalances `-14`)**; new × legacy merges (`[1, 44659]`); **legacy × legacy still throws `key (segment_id) collision during intents merge: 1`**; shielded-only untouched by identity; the recipe wrapper keeps `blockData`.

## Not verified (repeated here so it is not missed)

- **SC-001 / SC-002 (live)**: no node has accepted a settlement whose maker Intent was signed at a randomized segment. Deferred to the user's new infrastructure version; this is what keeps the PR in draft.
- **FR-006**: Lace taking a randomized-segment offer — no node-2.x browser wallet accepts `payFees: false`.

---

Follow-up to #910's open question (maker-side Intent-segment randomization, authorized as its own project). Guard from #910 stays as the backstop.
