### PR TITLE
zswap-da (midnight-1): make backend-reported endpoint URIs browser-reachable

### DIFF
--- a/templates/zswap-da/src/services/api.ts
+++ b/templates/zswap-da/src/services/api.ts
@@ -283,6 +283,38 @@ export const api = {
     const res = await fetch(`${V1}/midnight/config`);
     const data = await res.json();
     if (!res.ok) throw new Error(data.message ?? JSON.stringify(data));
+    // THE ONE PLACE endpoint URIs are made browser-reachable. The kernel reports
+    // the URIs it dials ITSELF, which inside Docker Compose are service names on
+    // a network no browser can resolve (indexer, proof-server) on container
+    // ports no host publishes. Every consumer of this config — the in-page JS
+    // wallet, the contract client, the take-offer flow — goes through here, so
+    // fixing it once here fixes all of them.
+    const w = window as unknown as Record<string, string | undefined>;
+    const d = data as Record<string, unknown>;
+    // 1. Explicit overrides win, and are injected even when the backend omits
+    //    the key (`nodeUri` is never reported, but the local wallet needs it).
+    //    <camelCase>Uri maps to window.<SCREAMING_SNAKE_CASE>, which the image
+    //    entrypoint writes into /config.js from the compose environment. This
+    //    is what makes a non-default host-port layout work: a hostname-only
+    //    rewrite keeps the CONTAINER port, which only the default port block
+    //    happens to publish unchanged.
+    for (const key of ['nodeUri', 'indexerUri', 'indexerWsUri', 'proofServerUri']) {
+      const override = w[key.replace(/([A-Z])/g, '_$1').toUpperCase()];
+      if (override) d[key] = override;
+    }
+    // 2. Otherwise a bare (dot-less, non-localhost) hostname is a compose
+    //    service name: re-point it at the page's own host, keeping scheme, port
+    //    and path. Correct whenever the stack publishes each service on the same
+    //    port it uses internally, which is the default port block.
+    const pageHost = typeof location !== 'undefined' ? location.hostname : '127.0.0.1';
+    for (const key of Object.keys(d)) {
+      const value = d[key];
+      if (!key.endsWith('Uri') || typeof value !== 'string') continue;
+      const m = value.match(/^(\w+:\/\/)([^/:]+)(.*)$/);
+      if (m && !m[2].includes('.') && m[2] !== 'localhost') {
+        d[key] = `${m[1]}${pageHost}${m[3]}`;
+      }
+    }
     return data;
   },
 


### PR DESCRIPTION
Targets **`midnight-1`** (the 1.x / ledger-v8 / `@effectstream` 0.1xx line). One file, one function: `api.getMidnightConfig` in `templates/zswap-da/src/services/api.ts` (+32 lines, no other changes).

## Problem

`GET /v1/midnight/config` reports the URIs the kernel dials *itself*. In a Docker Compose deployment those are service names (`indexer`, `proof-server`) on a network no browser can resolve, on container ports the host may publish elsewhere. The in-page JS wallet, the contract client and the take-offer flow all read that config, so they fail with `ERR_NAME_NOT_RESOLVED` / connection refused.

## Change

At the single chokepoint every consumer goes through:

1. **Explicit overrides win** — `<camelCase>Uri` reads `window.<SCREAMING_SNAKE_CASE>` (`NODE_URI`, `INDEXER_URI`, `INDEXER_WS_URI`, `PROOF_SERVER_URI`), following the hosting-page convention `src/config.ts` already uses for `window.API_BASE` / `window.BATCHER_URL`. Applied even when the backend omits the key (`nodeUri` is never reported; the local wallet needs it).
2. **Otherwise rewrite a bare hostname** — a dot-less, non-`localhost` host is a compose service name and is re-pointed at the page's own host, keeping scheme, port and path.

Step 1 is not optional sugar: a hostname-only rewrite keeps the *container* port, which is only right when the stack publishes each service on the same port it uses internally. Deployments on a chosen free port block otherwise dial ports nothing is listening on.

With no overrides injected and a backend that reports real hostnames (anything containing a dot, or `localhost`), the function is a no-op — existing deployments are unaffected.

## Evidence

This exact diff has been applied at image-build time onto exactly this subtree (`templates/zswap-da` @ `af6023ed`, which `midnight-1` carries) by [acedward/midnight-1-offers](https://github.com/acedward/midnight-1-offers) (`images/zswap-da/browser-network-urls.patch`). Its browser gate on a live 1.x stack passed: faucet mint, offer create and offer take settle on chain; 106 browser requests, zero compose-internal hostnames; also exercised by hand with Lace on 2026-09-01. Applies to `midnight-1` at zero offset (`git apply --check` clean).

## Why upstream now

midnight-1-offers just moved its `FRONTEND_REF` to `midnight-1` and retired its dependency patch; this is the last build-time patch it carries. Once this merges it pins the new head and builds an unmodified upstream tree — and the same tree serves the coming preview deployment.