### PR TITLE
fix(zswap-da): wallet-scoped local records, own-offer decision, per-offer ladder take

### DIFF
--- a/templates/zswap-da/src/App.tsx
+++ b/templates/zswap-da/src/App.tsx
@@ -17,6 +17,7 @@ import { Market } from './screens/Market';
 import { Faucet } from './screens/Faucet';
 import { HowItWorks } from './screens/HowItWorks';
 import { ConfirmModal } from './ui/ConfirmModal';
+import { DecisionModal } from './ui/DecisionModal';
 // Place Order + My trades live in the bottom console dock, not in the top nav.
 type PageId = 'market' | 'how' | 'faucet';
 
@@ -107,6 +108,9 @@ export default function App() {
         onPickLocal={st.connectLocalWallet}
       />
       <ConfirmModal payload={st.pendingConfirm} onClose={st.closeConfirm} />
+      {/* Asked BEFORE the confirm dialog when a selection contains your own
+          offers — answering it opens the confirm dialog (or settles nothing). */}
+      <DecisionModal payload={st.pendingDecision} onClose={st.closeDecision} />
       <Toasts items={st.toasts} />
     </div>
   );

--- a/templates/zswap-da/src/screens/Market.tsx
+++ b/templates/zswap-da/src/screens/Market.tsx
@@ -3,8 +3,9 @@
 // (price / amount / total) are built from REAL open offers (st.orders); only the
 // 24h stats + trade history still come from the backend GET /v1/chart/** routes.
 // Selecting price levels and pressing "Take" settles the underlying real offers
-// via the shared confirm dialog (st.requestTakeMany); your own offers are
-// skipped (you can't take your own ZSwap).
+// via the shared confirm dialog (st.requestTakeMany); levels holding one of your
+// own offers are marked "Yours" and ask before taking it (taking your own ZSwap
+// is allowed on-chain, so it is a question, not a block).
 
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { Coin, Icon, isShielded } from '../ui/icons';
@@ -244,8 +245,8 @@ export function Market({ st, onStartOrder }: { st: ZSwapApp; onStartOrder?: () =
 
   const takeDepth = () => {
     // Settle the real offers behind the selected price levels via the shared
-    // confirm dialog (st.requestTakeMany filters out your own offers + guards
-    // the wallet, then opens the Take popup).
+    // confirm dialog (st.requestTakeMany guards the wallet, asks about any of
+    // your own offers in the selection, then opens the Take popup).
     const side = activeSide;
     if (!side) return;
     const rows = side === 'ask' ? asks : bids;
@@ -260,6 +261,9 @@ export function Market({ st, onStartOrder }: { st: ZSwapApp; onStartOrder?: () =
     const on = isActive(side, idx);
     const prev = isPreview(side, idx);
     const dPct = (r.price / mid - 1) * 100;
+    // A level aggregates same-price offers, so one of yours in it is enough to
+    // mark it: the take path will ask about that offer specifically.
+    const mine = r.orders.some((o) => o.isMine);
     return (
       <div onClick={() => clickRow(side, idx)} onMouseEnter={() => setHover({ side, idx })}
         title={on ? 'Click to remove this row' : 'Click to select up to here'}
@@ -268,6 +272,7 @@ export function Market({ st, onStartOrder }: { st: ZSwapApp; onStartOrder?: () =
         <span className="zs-num" style={{ position: 'relative', fontSize: 13, fontWeight: 600, color: col, display: 'inline-flex', alignItems: 'center', gap: 5 }}>
           {fmtPrice(r.price)}
           {(on || prev) && <span style={{ fontSize: 10.5, color: 'var(--ink-3)', fontWeight: 600 }}>{dPct >= 0 ? '↑' : '↓'}{Math.abs(dPct).toFixed(2)}%</span>}
+          {mine && <span className="zs-pill" title="You created an offer at this price. Taking it is allowed — we'll ask first." style={{ padding: '1px 6px', fontSize: 9.5, fontWeight: 700, color: 'var(--accent)', background: 'var(--accent-soft)', borderColor: 'var(--accent-line)' }}>Yours</span>}
         </span>
         <span className="zs-num" style={{ position: 'relative', fontSize: 13, textAlign: 'right', color: 'var(--ink)' }}>{fmtQty(r.amt)}</span>
         <span className="zs-num" style={{ position: 'relative', fontSize: 13, textAlign: 'right', color: 'var(--ink-2)' }}>{fmtQty(r.total)}</span>

--- a/templates/zswap-da/src/screens/MyTrades.tsx
+++ b/templates/zswap-da/src/screens/MyTrades.tsx
@@ -60,23 +60,6 @@ function StatusBadge({ status }: { status: MyTrade['status'] }) {
   return <span title={s.hint} style={{ display: 'inline-flex', alignItems: 'center', gap: 5, fontSize: 11.5, fontWeight: 700, color: s.c, background: s.bg, borderRadius: 'var(--r-pill)', padding: '4px 10px', whiteSpace: 'nowrap', cursor: s.hint ? 'help' : undefined }}><Icon.dot /> {s.label}</span>;
 }
 
-/**
- * Records written before the log was scoped per wallet. They cannot be
- * attributed to a wallet, so they are shown to every wallet — say so, rather
- * than letting them read as "trades of the wallet you have connected".
- */
-function LegacyPill() {
-  return (
-    <span
-      className="zs-pill"
-      title="Recorded before this browser kept trades per wallet, so we can't tell which wallet made it. Shown for every wallet until you clear it."
-      style={{ padding: '3px 8px', fontSize: 10.5, color: 'var(--ink-3)', whiteSpace: 'nowrap', cursor: 'help' }}
-    >
-      before wallet scoping
-    </span>
-  );
-}
-
 function Cell({ amt, sym, accent }: { amt: number; sym: string; accent?: boolean }) {
   return (
     <span style={{ display: 'inline-flex', alignItems: 'center', gap: 7, whiteSpace: 'nowrap' }}>
@@ -183,7 +166,7 @@ export function MyTrades({ st, compact }: { st: ZSwapApp; compact?: boolean }) {
                         <div className="zs-num" style={{ fontSize: 12.5, color: 'var(--ink-2)', whiteSpace: 'nowrap' }}>{d.toISOString().slice(0, 10)}</div>
                         <div className="zs-num" style={{ fontSize: 11, color: 'var(--ink-3)' }}>{d.toTimeString().slice(0, 8)}</div>
                       </td>
-                      <td><div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}><StatusBadge status={t.status} />{t.shielded && <Icon.shield style={{ color: 'var(--accent)' }} />}{t.legacy && <LegacyPill />}</div></td>
+                      <td><div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}><StatusBadge status={t.status} />{t.shielded && <Icon.shield style={{ color: 'var(--accent)' }} />}</div></td>
                       <td style={{ textAlign: 'right' }}>
                         <div style={{ display: 'inline-flex', gap: 6 }}>
                           <button onClick={() => setViewing(t)} title="View offer file" className="zs-btn" style={{ padding: '6px 11px', fontSize: 12.5 }} disabled={!t.blob}>View</button>

--- a/templates/zswap-da/src/screens/MyTrades.tsx
+++ b/templates/zswap-da/src/screens/MyTrades.tsx
@@ -60,6 +60,23 @@ function StatusBadge({ status }: { status: MyTrade['status'] }) {
   return <span title={s.hint} style={{ display: 'inline-flex', alignItems: 'center', gap: 5, fontSize: 11.5, fontWeight: 700, color: s.c, background: s.bg, borderRadius: 'var(--r-pill)', padding: '4px 10px', whiteSpace: 'nowrap', cursor: s.hint ? 'help' : undefined }}><Icon.dot /> {s.label}</span>;
 }
 
+/**
+ * Records written before the log was scoped per wallet. They cannot be
+ * attributed to a wallet, so they are shown to every wallet — say so, rather
+ * than letting them read as "trades of the wallet you have connected".
+ */
+function LegacyPill() {
+  return (
+    <span
+      className="zs-pill"
+      title="Recorded before this browser kept trades per wallet, so we can't tell which wallet made it. Shown for every wallet until you clear it."
+      style={{ padding: '3px 8px', fontSize: 10.5, color: 'var(--ink-3)', whiteSpace: 'nowrap', cursor: 'help' }}
+    >
+      before wallet scoping
+    </span>
+  );
+}
+
 function Cell({ amt, sym, accent }: { amt: number; sym: string; accent?: boolean }) {
   return (
     <span style={{ display: 'inline-flex', alignItems: 'center', gap: 7, whiteSpace: 'nowrap' }}>
@@ -128,6 +145,15 @@ export function MyTrades({ st, compact }: { st: ZSwapApp; compact?: boolean }) {
     </div>
   );
 
+  // The log is per wallet, so with none connected this list can only be the
+  // unattributable pre-scoping records — otherwise "no trades yet" reads as
+  // data loss to someone who posted offers a minute ago with a wallet.
+  const scopeHint = !st.walletScope ? (
+    <div style={{ fontSize: 12.5, color: 'var(--ink-3)', lineHeight: 1.5, marginBottom: 10 }}>
+      Trades are kept per wallet — connect a wallet to see its trades.
+    </div>
+  ) : null;
+
   const tableCard = (
     <div className="zs-card" style={compact ? { padding: '8px 6px 6px', maxHeight: 380, overflowY: 'auto' } : { padding: '16px 8px 8px' }}>
       {rows.length === 0 ? (
@@ -157,7 +183,7 @@ export function MyTrades({ st, compact }: { st: ZSwapApp; compact?: boolean }) {
                         <div className="zs-num" style={{ fontSize: 12.5, color: 'var(--ink-2)', whiteSpace: 'nowrap' }}>{d.toISOString().slice(0, 10)}</div>
                         <div className="zs-num" style={{ fontSize: 11, color: 'var(--ink-3)' }}>{d.toTimeString().slice(0, 8)}</div>
                       </td>
-                      <td><div style={{ display: 'flex', alignItems: 'center', gap: 8 }}><StatusBadge status={t.status} />{t.shielded && <Icon.shield style={{ color: 'var(--accent)' }} />}</div></td>
+                      <td><div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}><StatusBadge status={t.status} />{t.shielded && <Icon.shield style={{ color: 'var(--accent)' }} />}{t.legacy && <LegacyPill />}</div></td>
                       <td style={{ textAlign: 'right' }}>
                         <div style={{ display: 'inline-flex', gap: 6 }}>
                           <button onClick={() => setViewing(t)} title="View offer file" className="zs-btn" style={{ padding: '6px 11px', fontSize: 12.5 }} disabled={!t.blob}>View</button>
@@ -235,6 +261,7 @@ export function MyTrades({ st, compact }: { st: ZSwapApp; compact?: boolean }) {
           {filterSeg}
           {actions}
         </div>
+        {scopeHint}
         {tableCard}
         {modals}
       </div>
@@ -260,6 +287,7 @@ export function MyTrades({ st, compact }: { st: ZSwapApp; compact?: boolean }) {
 
       <div style={{ marginBottom: 16 }}>{filterSeg}</div>
 
+      {scopeHint}
       {tableCard}
       {modals}
     </div>

--- a/templates/zswap-da/src/services/ownOffers.test.ts
+++ b/templates/zswap-da/src/services/ownOffers.test.ts
@@ -1,0 +1,120 @@
+// The own-offer question: which offers of a selection are yours, what to ask,
+// and what continues after each answer. The regression this pins is issue
+// 00003 — an all-mine selection must produce a QUESTION, never a dead end.
+import { describe, expect, test } from 'bun:test';
+import {
+  applyOwnOfferChoice,
+  decideOwnOffers,
+  ownOfferChoiceLabel,
+  partitionOwn,
+} from './ownOffers';
+
+// Stand-in for the Order rows the take path works with: `isMine` is the local
+// record, `sender` is what the unshielded-sender match finds once the blob is
+// loaded. The predicate composes both, exactly as useZSwapApp's `ownsOffer` does.
+interface Row { id: string; isMine: boolean; sender?: string }
+const SELF = 'ab'.repeat(32);
+const row = (id: string, isMine = false, sender?: string): Row => ({ id, isMine, sender });
+const owns = (o: Row) => o.isMine || o.sender === SELF;
+const split = (rows: Row[]) => partitionOwn(rows, owns);
+
+describe('partitionOwn', () => {
+  test('splits by the predicate and keeps the original order in `all`', () => {
+    const rows = [row('a'), row('b', true), row('c')];
+    const s = split(rows);
+    expect(s.mine.map((o) => o.id)).toEqual(['b']);
+    expect(s.others.map((o) => o.id)).toEqual(['a', 'c']);
+    expect(s.all).toBe(rows);
+  });
+
+  test('the unshielded-sender match counts as mine, after blob load', () => {
+    // Not in the local record — only the decoded sender gives it away.
+    const s = split([row('a'), row('b', false, SELF)]);
+    expect(s.mine.map((o) => o.id)).toEqual(['b']);
+  });
+
+  test('empty selection', () => {
+    const s = split([]);
+    expect(s.mine).toEqual([]);
+    expect(s.others).toEqual([]);
+  });
+});
+
+describe('decideOwnOffers', () => {
+  test('none of yours → nothing to ask', () => {
+    const d = decideOwnOffers(split([row('a'), row('b')]));
+    expect(d.kind).toBe('none');
+    expect(d.message).toBeNull();
+    expect(d.choices).toEqual([]);
+  });
+
+  test('a single own offer → "take anyway?" with a cancel', () => {
+    const d = decideOwnOffers(split([row('a', true)]));
+    expect(d.kind).toBe('all-mine');
+    expect(d.message).toBe('This is your own offer. Take it anyway?');
+    expect(d.choices).toEqual(['take-all', 'cancel']);
+    // Never "skip mine": it would continue with nothing.
+    expect(d.choices).not.toContain('skip-mine');
+  });
+
+  test('every offer of a level is yours → plural phrasing', () => {
+    const d = decideOwnOffers(split([row('a', true), row('b', true)]));
+    expect(d.kind).toBe('all-mine');
+    expect(d.mine).toBe(2);
+    expect(d.message).toContain('All 2 selected offers are yours');
+  });
+
+  test('mixed → counts + all three choices', () => {
+    const d = decideOwnOffers(split([row('a', true), row('b'), row('c'), row('d', false, SELF)]));
+    expect(d.kind).toBe('mixed');
+    expect(d.mine).toBe(2);
+    expect(d.total).toBe(4);
+    expect(d.message).toBe('2 of 4 selected offers are yours. Skip them, or take them too?');
+    expect(d.choices).toEqual(['skip-mine', 'take-all', 'cancel']);
+  });
+
+  test('empty selection asks nothing', () => {
+    expect(decideOwnOffers(split([])).kind).toBe('none');
+  });
+});
+
+describe('applyOwnOfferChoice', () => {
+  const s = split([row('a', true), row('b'), row('c')]);
+
+  test('take-all continues with the whole selection, in order', () => {
+    expect(applyOwnOfferChoice(s, 'take-all')!.map((o) => o.id)).toEqual(['a', 'b', 'c']);
+  });
+
+  test('skip-mine continues with the others only', () => {
+    expect(applyOwnOfferChoice(s, 'skip-mine')!.map((o) => o.id)).toEqual(['b', 'c']);
+  });
+
+  test('cancel settles nothing', () => {
+    expect(applyOwnOfferChoice(s, 'cancel')).toBeNull();
+  });
+
+  test('a choice that would leave nothing settles nothing (FR-005)', () => {
+    const allMine = split([row('a', true)]);
+    expect(applyOwnOfferChoice(allMine, 'skip-mine')).toBeNull();
+    expect(applyOwnOfferChoice(split([]), 'take-all')).toBeNull();
+  });
+});
+
+describe('ownOfferChoiceLabel', () => {
+  test('single own offer', () => {
+    const d = decideOwnOffers(split([row('a', true)]));
+    expect(ownOfferChoiceLabel('take-all', d)).toBe('Take anyway');
+    expect(ownOfferChoiceLabel('cancel', d)).toBe('Cancel');
+  });
+
+  test('several own offers', () => {
+    const d = decideOwnOffers(split([row('a', true), row('b', true)]));
+    expect(ownOfferChoiceLabel('take-all', d)).toBe('Take them anyway');
+  });
+
+  test('mixed selection', () => {
+    const d = decideOwnOffers(split([row('a', true), row('b')]));
+    expect(ownOfferChoiceLabel('take-all', d)).toBe('Include mine');
+    expect(ownOfferChoiceLabel('skip-mine', d)).toBe('Skip mine');
+  });
+});

--- a/templates/zswap-da/src/services/ownOffers.ts
+++ b/templates/zswap-da/src/services/ownOffers.ts
@@ -1,0 +1,93 @@
+// "Some of these offers are yours" — the pure part of the take path's own-offer
+// handling, kept out of the React hook so it can be tested without a wallet.
+//
+// Taking your own offer is legal on-chain (maker = taker), so this is a WARNING,
+// never a block. It used to be neither: `requestTakeMany` silently opened the
+// "Connect a wallet" modal when every selected offer was flagged mine, which
+// with a per-browser ownership record was a dead end for anyone testing two
+// wallets in one browser (issue 00003).
+//
+// Ownership itself is decided by the caller and handed in as a predicate,
+// because it comes from two different places: the on-device record (the only
+// signal a shielded offer has) and — once the blob is loaded — the offer's
+// unshielded sender.
+
+/** The selection split by ownership. `all` keeps the caller's original order,
+ *  which is significant: the book hands offers over best-price-first and the
+ *  affordability prefix depends on it. */
+export interface OwnOfferSplit<T> {
+  all: T[];
+  mine: T[];
+  others: T[];
+}
+
+export function partitionOwn<T>(items: T[], isMine: (item: T) => boolean): OwnOfferSplit<T> {
+  const mine: T[] = [];
+  const others: T[] = [];
+  for (const item of items) (isMine(item) ? mine : others).push(item);
+  return { all: items, mine, others };
+}
+
+/** What the user picked in the decision dialog. */
+export type OwnOfferChoice = 'take-all' | 'skip-mine' | 'cancel';
+
+export interface OwnOfferDecision {
+  /** `none` = nothing of yours in the selection, so don't ask at all. */
+  kind: 'none' | 'all-mine' | 'mixed';
+  mine: number;
+  total: number;
+  /** Dialog body, or null when there is nothing to ask. */
+  message: string | null;
+  /** Offered choices, in display order. Always ends with `cancel`. */
+  choices: OwnOfferChoice[];
+}
+
+/**
+ * Decide what (if anything) to ask before taking this selection.
+ *
+ * `skip-mine` is only ever offered when something would remain to take — an
+ * option that continues with an empty selection would just be a confusing
+ * second Cancel (FR-005).
+ */
+export function decideOwnOffers<T>(split: OwnOfferSplit<T>): OwnOfferDecision {
+  const mine = split.mine.length;
+  const total = split.all.length;
+  if (mine === 0) return { kind: 'none', mine, total, message: null, choices: [] };
+  if (split.others.length === 0) {
+    return {
+      kind: 'all-mine',
+      mine,
+      total,
+      message: mine === 1
+        ? 'This is your own offer. Take it anyway?'
+        : `All ${mine} selected offers are yours. Take them anyway?`,
+      choices: ['take-all', 'cancel'],
+    };
+  }
+  return {
+    kind: 'mixed',
+    mine,
+    total,
+    message: `${mine} of ${total} selected offers are yours. Skip them, or take them too?`,
+    choices: ['skip-mine', 'take-all', 'cancel'],
+  };
+}
+
+/**
+ * The offers to continue with for a choice — `null` means "stop, settle
+ * nothing" (Cancel, or a choice that would leave an empty selection).
+ */
+export function applyOwnOfferChoice<T>(split: OwnOfferSplit<T>, choice: OwnOfferChoice): T[] | null {
+  if (choice === 'cancel') return null;
+  const next = choice === 'skip-mine' ? split.others : split.all;
+  return next.length > 0 ? next : null;
+}
+
+/** Button label for a choice — one place, so dialog and tests can't drift. */
+export function ownOfferChoiceLabel(choice: OwnOfferChoice, decision: OwnOfferDecision): string {
+  if (choice === 'cancel') return 'Cancel';
+  if (choice === 'skip-mine') return 'Skip mine';
+  return decision.kind === 'mixed'
+    ? 'Include mine'
+    : decision.mine === 1 ? 'Take anyway' : 'Take them anyway';
+}

--- a/templates/zswap-da/src/services/takeSelection.test.ts
+++ b/templates/zswap-da/src/services/takeSelection.test.ts
@@ -123,6 +123,24 @@ describe('defaultSelection', () => {
     expect(summarize(items, defaultSelection(items, balances('1')), balances('1'), known).blocked)
       .toBe('Insufficient WETH: need 12, have 1');
   });
+
+  // `settle(ids)` has no "if nothing is checked, take everything" fallback any
+  // more — an empty id list settles nothing. That is only safe because a
+  // non-empty selection always opens with at least one row checked, including
+  // the single-offer dialog, which renders no checkbox list at all and would
+  // otherwise confirm with an empty set.
+  test('a non-empty selection never opens with nothing checked', () => {
+    for (const bal of ['100', '8', '1', '0']) {
+      expect(defaultSelection(items, balances(bal)).length).toBeGreaterThan(0);
+    }
+    const single = [offer('solo', 5, 20)];
+    expect(defaultSelection(single, balances('100'))).toEqual(['solo']);
+    expect(defaultSelection(single, balances('0'))).toEqual(['solo']);
+  });
+
+  test('an empty item list yields an empty default — the dialog is never opened for it', () => {
+    expect(defaultSelection([], balances('100'))).toEqual([]);
+  });
 });
 
 describe('own offers stay identifiable in the list', () => {

--- a/templates/zswap-da/src/services/takeSelection.test.ts
+++ b/templates/zswap-da/src/services/takeSelection.test.ts
@@ -1,0 +1,136 @@
+// Per-offer selection inside a take: totals, the aggregate affordability
+// verdict, the CTA and what starts checked. A price level used to be
+// all-or-nothing; these cases pin the arithmetic the checkboxes drive.
+import { describe, expect, test } from 'bun:test';
+import type { ParsedLeg } from './offerParse';
+import type { KnownToken } from '../types';
+import { affordableSelection, defaultSelection, summarize, type SelectableOffer } from './takeSelection';
+
+const WETH = 'aa'.repeat(32);
+const known: KnownToken[] = [{ token_color: WETH, name: 'WETH', kind: 'shielded' } as KnownToken];
+const leg = (amount: bigint): ParsedLeg => ({ color: WETH, kind: 'shielded', amount });
+
+/** Taker pays `cost` WETH and receives `gets` WBTC — the shape of one book row. */
+const offer = (id: string, cost: number, gets: number, mine = false): SelectableOffer => ({
+  id,
+  pay: { sym: 'WETH', amt: cost },
+  receive: { sym: 'WBTC', amt: gets },
+  pays: [leg(BigInt(cost))],
+  mine,
+});
+
+const items = [offer('a', 3, 15), offer('b', 4, 18), offer('c', 5, 20)];
+const balances = (weth: string) => ({ shielded: { [WETH]: weth }, unshielded: null });
+
+describe('summarize totals', () => {
+  test('all checked → the full pay/receive of the selection', () => {
+    const s = summarize(items, ['a', 'b', 'c'], balances('100'), known);
+    expect(s.count).toBe(3);
+    expect(s.pay).toEqual({ sym: 'WETH', amt: 12 });
+    expect(s.receive).toEqual({ sym: 'WBTC', amt: 53 });
+    expect(s.blocked).toBeNull();
+  });
+
+  test('unchecking a row recomputes both totals', () => {
+    const s = summarize(items, ['a', 'c'], balances('100'), known);
+    expect(s.count).toBe(2);
+    expect(s.pay.amt).toBe(8);
+    expect(s.receive.amt).toBe(35);
+  });
+
+  test('the checked order is irrelevant — it is a fold, not a sequence', () => {
+    expect(summarize(items, ['c', 'a'], balances('100')).pay.amt)
+      .toBe(summarize(items, ['a', 'c'], balances('100')).pay.amt);
+  });
+
+  test('unknown ids are ignored', () => {
+    expect(summarize(items, ['a', 'ghost'], balances('100')).count).toBe(1);
+  });
+
+  test('nothing checked → zero totals, the pair still named', () => {
+    const s = summarize(items, [], balances('100'), known);
+    expect(s.count).toBe(0);
+    expect(s.pay).toEqual({ sym: 'WETH', amt: 0 });
+    expect(s.receive).toEqual({ sym: 'WBTC', amt: 0 });
+    // Not a shortfall: an empty selection costs nothing, it is simply not
+    // confirmable (the dialog disables the CTA).
+    expect(s.blocked).toBeNull();
+  });
+
+  test('an empty item list does not throw', () => {
+    const s = summarize([], [], balances('100'));
+    expect(s.count).toBe(0);
+    expect(s.pay.sym).toBe('—');
+  });
+});
+
+describe('summarize blocked message', () => {
+  test('the checked subset is what gets balance-checked', () => {
+    // 12 WETH for all three, but only 9 in the wallet.
+    expect(summarize(items, ['a', 'b', 'c'], balances('9'), known).blocked)
+      .toBe('Insufficient WETH: need 12, have 9');
+    // Uncheck the 5 and it fits.
+    expect(summarize(items, ['a', 'b'], balances('9'), known).blocked).toBeNull();
+  });
+
+  test('the cost is aggregated, not compared per offer', () => {
+    // Each offer alone fits in 5; together they do not.
+    expect(summarize(items, ['a', 'b'], balances('5'), known).blocked)
+      .toBe('Insufficient WETH: need 7, have 5');
+  });
+
+  test('an undecodable blob contributes no cost', () => {
+    const undecodable: SelectableOffer = { ...offer('x', 99, 1), pays: [] };
+    expect(summarize([undecodable], ['x'], balances('0')).blocked).toBeNull();
+  });
+});
+
+describe('summarize cta', () => {
+  test('names the size of the commitment', () => {
+    expect(summarize(items, ['a'], balances('100')).cta).toBe('Take offer');
+    expect(summarize(items, ['a', 'b'], balances('100')).cta).toBe('Take 2 offers');
+    expect(summarize(items, ['a', 'b', 'c'], balances('100')).cta).toBe('Take 3 offers');
+  });
+
+  test('empty selection says what is missing instead of "Take 0 offers"', () => {
+    expect(summarize(items, [], balances('100')).cta).toBe('Select an offer');
+  });
+});
+
+describe('affordableSelection', () => {
+  test('everything, when the wallet covers the batch', () => {
+    expect(affordableSelection(items, balances('100'))).toEqual(['a', 'b', 'c']);
+  });
+
+  test('the best-price-first prefix that still fits', () => {
+    // 3 + 4 = 7 ≤ 8, adding 5 would not fit.
+    expect(affordableSelection(items, balances('8'))).toEqual(['a', 'b']);
+  });
+
+  test('nothing, when even the first offer is out of reach', () => {
+    expect(affordableSelection(items, balances('1'))).toEqual([]);
+  });
+});
+
+describe('defaultSelection', () => {
+  test('starts with the affordable rows checked', () => {
+    expect(defaultSelection(items, balances('8'))).toEqual(['a', 'b']);
+  });
+
+  test('when nothing is affordable, everything starts checked so the dialog explains itself', () => {
+    expect(defaultSelection(items, balances('1'))).toEqual(['a', 'b', 'c']);
+    // …and the summary of that default carries the reason.
+    expect(summarize(items, defaultSelection(items, balances('1')), balances('1'), known).blocked)
+      .toBe('Insufficient WETH: need 12, have 1');
+  });
+});
+
+describe('own offers stay identifiable in the list', () => {
+  test('the `mine` flag rides along with the row', () => {
+    const withMine = [offer('a', 3, 15, true), offer('b', 4, 18)];
+    expect(withMine.filter((i) => i.mine).map((i) => i.id)).toEqual(['a']);
+    // Including your own offer is a normal selection — it costs and pays like
+    // any other row.
+    expect(summarize(withMine, ['a', 'b'], balances('100')).pay.amt).toBe(7);
+  });
+});

--- a/templates/zswap-da/src/services/takeSelection.ts
+++ b/templates/zswap-da/src/services/takeSelection.ts
@@ -1,0 +1,96 @@
+// Which offers of a ladder the taker actually wants — the pure half of the
+// take-confirm dialog's checkbox list.
+//
+// A price level aggregates every offer at that price, and the dialog used to be
+// all-or-nothing: the only escape from a batch you couldn't fully fund was the
+// "take the affordable prefix" button. Now every row has a checkbox, and the
+// totals, the affordability verdict and the CTA are recomputed from whatever is
+// checked — which is exactly what this module does, without React or a wallet.
+
+import type { ParsedLeg } from './offerParse';
+import type { KnownToken } from '../types';
+import { affordableIndices, shortfallMessage, shortfallsFromLegs, sumLegs } from './takerBalance';
+
+/** One selectable offer of a take. Display amounts are floats (the book's own
+ *  unit); `pays` carries the exact bigint legs the balance check needs. */
+export interface SelectableOffer {
+  id: string;
+  pay: { sym: string; amt: number };
+  receive: { sym: string; amt: number };
+  /** Legs the taker must SUPPLY for this offer. Empty for an undecodable blob,
+   *  which then contributes no cost — the settle path surfaces those. */
+  pays: ParsedLeg[];
+  /** This offer is the connected wallet's own (marked in the list). */
+  mine?: boolean;
+}
+
+export interface TakerBalances {
+  shielded?: Record<string, string> | null;
+  unshielded?: Record<string, string> | null;
+}
+
+export interface TakeSummary {
+  count: number;
+  pay: { sym: string; amt: number };
+  receive: { sym: string; amt: number };
+  /** Why the checked set can't be funded, or null. */
+  blocked: string | null;
+  cta: string;
+}
+
+const idsOf = (items: SelectableOffer[]): string[] => items.map((i) => i.id);
+
+/**
+ * The offers that fit the wallet when taken TOGETHER, in the given order (the
+ * book hands them over best-price-first, so this is the best affordable prefix).
+ * The aggregate is what matters: each offer on its own can look affordable while
+ * the batch overspends.
+ */
+export function affordableSelection(items: SelectableOffer[], balances: TakerBalances): string[] {
+  const idx = new Set(affordableIndices(items.map((i) => i.pays), balances.shielded, balances.unshielded));
+  return items.filter((_, i) => idx.has(i)).map((i) => i.id);
+}
+
+/**
+ * What starts checked: everything the wallet can cover.
+ *
+ * When it can cover NOTHING, everything starts checked instead of nothing — an
+ * empty dialog with a disabled CTA and no explanation is worse than a full one
+ * showing the shortfall the user has to fix.
+ */
+export function defaultSelection(items: SelectableOffer[], balances: TakerBalances): string[] {
+  const affordable = affordableSelection(items, balances);
+  return affordable.length > 0 ? affordable : idsOf(items);
+}
+
+/**
+ * Totals, affordability and CTA for the checked subset. Called on every toggle,
+ * so it stays a pure fold over the items — no decoding, no network.
+ */
+export function summarize(
+  items: SelectableOffer[],
+  checkedIds: Iterable<string>,
+  balances: TakerBalances,
+  knownTokens: KnownToken[] = [],
+): TakeSummary {
+  const checked = new Set(checkedIds);
+  const sel = items.filter((i) => checked.has(i.id));
+  const n = sel.length;
+  // Symbols come from the selection when there is one, else from the first row,
+  // so an empty selection still renders the pair instead of blanking the dialog.
+  const shape = sel[0] ?? items[0];
+  const blocked = n === 0
+    ? null
+    : shortfallMessage(
+        shortfallsFromLegs(sumLegs(sel.map((i) => i.pays)), balances.shielded, balances.unshielded, knownTokens),
+      );
+  return {
+    count: n,
+    pay: { sym: shape?.pay.sym ?? '—', amt: sel.reduce((s, i) => s + i.pay.amt, 0) },
+    receive: { sym: shape?.receive.sym ?? '—', amt: sel.reduce((s, i) => s + i.receive.amt, 0) },
+    blocked,
+    // The CTA states the size of the commitment; with nothing checked it names
+    // what's missing rather than offering "Take 0 offers".
+    cta: n === 0 ? 'Select an offer' : n === 1 ? 'Take offer' : `Take ${n} offers`,
+  };
+}

--- a/templates/zswap-da/src/services/takerBalance.ts
+++ b/templates/zswap-da/src/services/takerBalance.ts
@@ -78,17 +78,15 @@ export function takerShortfalls(
 }
 
 /**
- * Sum the `pays` legs across many offer blobs into one leg per (kind, color).
- * Undecodable blobs are skipped. Used to check a whole batch against the wallet
- * in a single comparison — checking each offer against the full balance would
- * wrongly pass a batch that only overspends in aggregate.
+ * Sum per-offer `pays` legs into one leg per (kind, color). Used to check a
+ * whole batch against the wallet in a single comparison — checking each offer
+ * against the full balance would wrongly pass a batch that only overspends in
+ * aggregate.
  */
-export function aggregatePays(blobs: string[], networkId: NetworkId): ParsedLeg[] {
+export function sumLegs(perOffer: ParsedLeg[][]): ParsedLeg[] {
   const need = new Map<string, ParsedLeg>();
-  for (const blob of blobs) {
-    const parsed = parseTakerLegs(blob, networkId);
-    if (!parsed) continue;
-    for (const leg of parsed.pays) {
+  for (const legs of perOffer) {
+    for (const leg of legs) {
       const key = `${leg.kind}:${leg.color}`;
       const cur = need.get(key);
       if (cur) cur.amount += leg.amount;
@@ -96,6 +94,14 @@ export function aggregatePays(blobs: string[], networkId: NetworkId): ParsedLeg[
     }
   }
   return [...need.values()];
+}
+
+/**
+ * {@link sumLegs} over offer blobs. Undecodable blobs contribute nothing — the
+ * settle path surfaces them, this check must not invent a cost for them.
+ */
+export function aggregatePays(blobs: string[], networkId: NetworkId): ParsedLeg[] {
+  return sumLegs(blobs.map((blob) => parseTakerLegs(blob, networkId)?.pays ?? []));
 }
 
 /** Aggregate `pays` across a batch of blobs, then return the uncovered legs. */

--- a/templates/zswap-da/src/state/myOffers.test.ts
+++ b/templates/zswap-da/src/state/myOffers.test.ts
@@ -83,34 +83,34 @@ describe('no wallet connected (null scope)', () => {
     expect(mem.has(KEY)).toBe(false);
   });
 
-  test('nothing is mine except legacy records', () => {
-    mem.set(KEY, JSON.stringify({ [W1]: ['offer-1'], legacy: ['old-offer'] }));
+  test('nothing is mine — not even another bucket\'s records', () => {
+    mem.set(KEY, JSON.stringify({ [W1]: ['offer-1'] }));
     setActiveScope(null);
     expect(isMyOffer('offer-1')).toBe(false);
-    expect(isMyOffer('old-offer')).toBe(true);
   });
 });
 
-describe('legacy read-through (Q-1 option 1)', () => {
-  test('a pre-scoping flat array migrates and still matches for every wallet', () => {
+// Q-1, resolved by Eddie: pre-scoping records are DISCARDED, not migrated.
+describe('pre-scoping records (no compatibility)', () => {
+  test('a pre-scoping flat array is not mine for any wallet', () => {
     mem.set(KEY, JSON.stringify(['old-offer']));
     setActiveScope(W1);
-    expect(isMyOffer('old-offer')).toBe(true);
+    expect(isMyOffer('old-offer')).toBe(false);
     setActiveScope(W2);
-    expect(isMyOffer('old-offer')).toBe(true);
+    expect(isMyOffer('old-offer')).toBe(false);
   });
 
-  test('writing after a migration keeps the legacy bucket', () => {
+  test('the next write replaces the flat array with a bucket store', () => {
     mem.set(KEY, JSON.stringify(['old-offer']));
     setActiveScope(W1);
     addMyOffer('offer-1');
-    expect(stored()).toEqual({ legacy: ['old-offer'], [W1]: ['offer-1'] });
+    expect(stored()).toEqual({ [W1]: ['offer-1'] });
   });
 
-  test('legacy blob keys (pre-offerId builds) keep matching', () => {
+  test('a blob key is a valid key like any other', () => {
     const blob = 'swapoffer1' + 'q'.repeat(64);
-    mem.set(KEY, JSON.stringify([blob]));
     setActiveScope(W1);
+    addMyOffer(blob);
     expect(isMyOffer(blob)).toBe(true);
   });
 });
@@ -123,9 +123,9 @@ describe('isMyOfferIn', () => {
     expect(isMyOfferIn('offer-1', W2)).toBe(false);
   });
 
-  test('null scope still sees legacy', () => {
-    mem.set(KEY, JSON.stringify({ legacy: ['old-offer'] }));
+  test('null scope owns nothing, whatever the active scope is', () => {
+    mem.set(KEY, JSON.stringify({ [W1]: ['offer-1'] }));
     setActiveScope(W1);
-    expect(isMyOfferIn('old-offer', null)).toBe(true);
+    expect(isMyOfferIn('offer-1', null)).toBe(false);
   });
 });

--- a/templates/zswap-da/src/state/myOffers.test.ts
+++ b/templates/zswap-da/src/state/myOffers.test.ts
@@ -1,0 +1,131 @@
+// The "is this offer mine?" record, now bucketed per wallet. These cases are
+// the regression net for issue 00003: with two wallets in one browser, wallet B
+// must NOT inherit wallet A's offers as its own.
+import { beforeEach, describe, expect, test } from 'bun:test';
+import { addMyOffer, isMyOffer, isMyOfferIn, setActiveScope } from './myOffers';
+
+// Minimal localStorage stand-in — bun's test runtime has no DOM.
+const mem = new Map<string, string>();
+(globalThis as any).localStorage = {
+  getItem: (k: string) => (mem.has(k) ? mem.get(k)! : null),
+  setItem: (k: string, v: string) => { mem.set(k, String(v)); },
+  removeItem: (k: string) => { mem.delete(k); },
+  clear: () => mem.clear(),
+};
+
+const KEY = 'zswap-da:my-offers';
+const W1 = 'preprod::mn_shield-addr_test1aaa';
+const W2 = 'preprod::mn_shield-addr_test1bbb';
+const stored = () => JSON.parse(mem.get(KEY) ?? '{}');
+
+beforeEach(() => {
+  mem.clear();
+  // Also drops the module cache, so each test starts from the storage it seeds.
+  setActiveScope(null);
+});
+
+describe('addMyOffer / isMyOffer', () => {
+  test('records into the active wallet bucket', () => {
+    setActiveScope(W1);
+    addMyOffer('offer-1');
+    expect(stored()).toEqual({ [W1]: ['offer-1'] });
+    expect(isMyOffer('offer-1')).toBe(true);
+  });
+
+  test('another wallet in the same browser does not inherit it (issue 00003)', () => {
+    setActiveScope(W1);
+    addMyOffer('offer-1');
+    setActiveScope(W2);
+    expect(isMyOffer('offer-1')).toBe(false);
+  });
+
+  test('switching back restores ownership', () => {
+    setActiveScope(W1);
+    addMyOffer('offer-1');
+    setActiveScope(W2);
+    addMyOffer('offer-2');
+    setActiveScope(W1);
+    expect(isMyOffer('offer-1')).toBe(true);
+    expect(isMyOffer('offer-2')).toBe(false);
+    // Neither wallet's records were clobbered by the other's write.
+    expect(stored()).toEqual({ [W1]: ['offer-1'], [W2]: ['offer-2'] });
+  });
+
+  test('the same wallet on another network is a different bucket', () => {
+    setActiveScope('preprod::w');
+    addMyOffer('offer-1');
+    setActiveScope('undeployed::w');
+    expect(isMyOffer('offer-1')).toBe(false);
+  });
+
+  test('duplicate keys are not appended twice', () => {
+    setActiveScope(W1);
+    addMyOffer('offer-1');
+    addMyOffer('offer-1');
+    expect(stored()[W1]).toEqual(['offer-1']);
+  });
+
+  test('empty/null keys are ignored', () => {
+    setActiveScope(W1);
+    addMyOffer(null);
+    addMyOffer(undefined);
+    addMyOffer('');
+    expect(isMyOffer(null)).toBe(false);
+    expect(isMyOffer('')).toBe(false);
+    expect(mem.has(KEY)).toBe(false);
+  });
+});
+
+describe('no wallet connected (null scope)', () => {
+  test('writes are refused rather than landing in someone else\'s bucket', () => {
+    setActiveScope(null);
+    addMyOffer('offer-1');
+    expect(mem.has(KEY)).toBe(false);
+  });
+
+  test('nothing is mine except legacy records', () => {
+    mem.set(KEY, JSON.stringify({ [W1]: ['offer-1'], legacy: ['old-offer'] }));
+    setActiveScope(null);
+    expect(isMyOffer('offer-1')).toBe(false);
+    expect(isMyOffer('old-offer')).toBe(true);
+  });
+});
+
+describe('legacy read-through (Q-1 option 1)', () => {
+  test('a pre-scoping flat array migrates and still matches for every wallet', () => {
+    mem.set(KEY, JSON.stringify(['old-offer']));
+    setActiveScope(W1);
+    expect(isMyOffer('old-offer')).toBe(true);
+    setActiveScope(W2);
+    expect(isMyOffer('old-offer')).toBe(true);
+  });
+
+  test('writing after a migration keeps the legacy bucket', () => {
+    mem.set(KEY, JSON.stringify(['old-offer']));
+    setActiveScope(W1);
+    addMyOffer('offer-1');
+    expect(stored()).toEqual({ legacy: ['old-offer'], [W1]: ['offer-1'] });
+  });
+
+  test('legacy blob keys (pre-offerId builds) keep matching', () => {
+    const blob = 'swapoffer1' + 'q'.repeat(64);
+    mem.set(KEY, JSON.stringify([blob]));
+    setActiveScope(W1);
+    expect(isMyOffer(blob)).toBe(true);
+  });
+});
+
+describe('isMyOfferIn', () => {
+  test('answers for a scope other than the active one (render-time lookup)', () => {
+    mem.set(KEY, JSON.stringify({ [W1]: ['offer-1'], [W2]: ['offer-2'] }));
+    setActiveScope(W1);
+    expect(isMyOfferIn('offer-2', W2)).toBe(true);
+    expect(isMyOfferIn('offer-1', W2)).toBe(false);
+  });
+
+  test('null scope still sees legacy', () => {
+    mem.set(KEY, JSON.stringify({ legacy: ['old-offer'] }));
+    setActiveScope(W1);
+    expect(isMyOfferIn('old-offer', null)).toBe(true);
+  });
+});

--- a/templates/zswap-da/src/state/myOffers.ts
+++ b/templates/zswap-da/src/state/myOffers.ts
@@ -3,16 +3,15 @@
 // anonymous on-chain, so the only reliable "mine" signal for them is what we
 // created locally.
 //
-// Keyed by `offerId` (hex sha256 of the raw MIP-0005 transaction bytes),
-// which is what the blob-free order book now carries. Entries written by older
-// builds were keyed by the full bech32m blob; those are kept and still match, so
-// trades made before that migration don't lose their "mine" marking.
+// Keyed by `offerId` (hex sha256 of the raw MIP-0005 transaction bytes), which
+// is what the blob-free order book now carries. A full bech32m blob is also
+// accepted as a key, so a caller that only holds the blob still matches.
 //
 // Records are bucketed per `<networkId>::<shieldedAddress>` (see scope.ts): one
 // browser can hold several wallets, and before scoping every wallet inherited
 // every other wallet's offers — the dead end reported as issue 00003.
 
-import { LEGACY_SCOPE, bucketOf, readBuckets, writeBuckets, type Buckets } from './scope';
+import { bucketOf, readBuckets, writeBuckets, type Buckets } from './scope';
 
 const KEY = 'zswap-da:my-offers';
 
@@ -41,8 +40,7 @@ export function getActiveScope(): string | null {
 
 /**
  * Record an offer this wallet created. Pass the `offerId` returned by
- * `POST /v1/offers`; the blob is also accepted so legacy callers and
- * pre-migration records keep working.
+ * `POST /v1/offers`; the blob is also accepted as a key.
  *
  * With no wallet connected there is no bucket to write to. Every caller reaches
  * here only after a successful transaction, so that combination means the wallet
@@ -63,9 +61,8 @@ export function addMyOffer(key: string | null | undefined): void {
 }
 
 /**
- * True when this offer hash (or legacy blob) was created by `scope`'s wallet —
- * or by a pre-scoping build in this browser, which we cannot attribute to a
- * wallet and therefore keep showing to everyone (Q-1 option 1).
+ * True when this offer hash (or blob) was created by `scope`'s wallet. With no
+ * wallet — `scope === null` — nothing is mine.
  *
  * Takes the scope explicitly because the order book computes ownership during
  * RENDER, while the active scope is installed from an effect: reading the module
@@ -74,8 +71,7 @@ export function addMyOffer(key: string | null | undefined): void {
  */
 export function isMyOfferIn(key: string | null | undefined, scope: string | null): boolean {
   if (!key) return false;
-  const buckets = all();
-  return bucketOf(buckets, scope).includes(key) || bucketOf(buckets, LEGACY_SCOPE).includes(key);
+  return bucketOf(all(), scope).includes(key);
 }
 
 /** {@link isMyOfferIn} against the active scope. */

--- a/templates/zswap-da/src/state/myOffers.ts
+++ b/templates/zswap-da/src/state/myOffers.ts
@@ -1,47 +1,84 @@
-// Local record of offers THIS browser created — so the order book can mark them
-// (you can't take your own offer). Shielded offers are anonymous on-chain, so
-// the only reliable "mine" signal for them is what we created locally.
+// Local record of offers THIS WALLET created — so the order book can mark them
+// (taking your own offer is a decision, not a silent block). Shielded offers are
+// anonymous on-chain, so the only reliable "mine" signal for them is what we
+// created locally.
 //
 // Keyed by `offerId` (hex sha256 of the raw MIP-0005 transaction bytes),
 // which is what the blob-free order book now carries. Entries written by older
 // builds were keyed by the full bech32m blob; those are kept and still match, so
-// trades made before this migration don't lose their "mine" marking.
+// trades made before that migration don't lose their "mine" marking.
+//
+// Records are bucketed per `<networkId>::<shieldedAddress>` (see scope.ts): one
+// browser can hold several wallets, and before scoping every wallet inherited
+// every other wallet's offers — the dead end reported as issue 00003.
+
+import { LEGACY_SCOPE, bucketOf, readBuckets, writeBuckets, type Buckets } from './scope';
 
 const KEY = 'zswap-da:my-offers';
 
-function load(): Set<string> {
-  try {
-    return new Set(JSON.parse(localStorage.getItem(KEY) || '[]'));
-  } catch {
-    return new Set();
-  }
-}
+let activeScope: string | null = null;
+let cache: Buckets<string> | null = null;
 
-let cache: Set<string> | null = null;
-function get(): Set<string> {
-  if (!cache) cache = load();
+function all(): Buckets<string> {
+  if (!cache) cache = readBuckets<string>(KEY);
   return cache;
 }
 
-function persist(s: Set<string>): void {
-  try {
-    localStorage.setItem(KEY, JSON.stringify([...s]));
-  } catch { /* ignore quota */ }
+/**
+ * Point the store at the connected wallet's bucket (`null` = no wallet).
+ * Always drops the cache: another tab — or this tab under a different wallet —
+ * may have written since, and a stale bucket would mis-mark ownership.
+ */
+export function setActiveScope(scope: string | null): void {
+  activeScope = scope;
+  cache = null;
+}
+
+/** The scope writes currently go to; exported for the sibling stores' tests. */
+export function getActiveScope(): string | null {
+  return activeScope;
 }
 
 /**
- * Record an offer this browser created. Pass the `offerId` returned by
+ * Record an offer this wallet created. Pass the `offerId` returned by
  * `POST /v1/offers`; the blob is also accepted so legacy callers and
  * pre-migration records keep working.
+ *
+ * With no wallet connected there is no bucket to write to. Every caller reaches
+ * here only after a successful transaction, so that combination means the wallet
+ * dropped mid-flow — loud enough to warn about, not worth throwing over.
  */
 export function addMyOffer(key: string | null | undefined): void {
   if (!key) return;
-  const s = get();
-  s.add(key);
-  persist(s);
+  if (!activeScope) {
+    console.warn('[my-offers] no wallet connected — not recording offer', key.slice(0, 16));
+    return;
+  }
+  const buckets = all();
+  const list = bucketOf(buckets, activeScope);
+  if (list.includes(key)) return;
+  const next = { ...buckets, [activeScope]: [...list, key] };
+  cache = next;
+  writeBuckets(KEY, next);
 }
 
-/** True when this offer hash (or legacy blob) was created by this browser. */
+/**
+ * True when this offer hash (or legacy blob) was created by `scope`'s wallet —
+ * or by a pre-scoping build in this browser, which we cannot attribute to a
+ * wallet and therefore keep showing to everyone (Q-1 option 1).
+ *
+ * Takes the scope explicitly because the order book computes ownership during
+ * RENDER, while the active scope is installed from an effect: reading the module
+ * state there would mark a freshly connected wallet's rows against the previous
+ * wallet's bucket for one render, and a memo would then cache that answer.
+ */
+export function isMyOfferIn(key: string | null | undefined, scope: string | null): boolean {
+  if (!key) return false;
+  const buckets = all();
+  return bucketOf(buckets, scope).includes(key) || bucketOf(buckets, LEGACY_SCOPE).includes(key);
+}
+
+/** {@link isMyOfferIn} against the active scope. */
 export function isMyOffer(key: string | null | undefined): boolean {
-  return !!key && get().has(key);
+  return isMyOfferIn(key, activeScope);
 }

--- a/templates/zswap-da/src/state/myTrades.test.ts
+++ b/templates/zswap-da/src/state/myTrades.test.ts
@@ -1,0 +1,175 @@
+// The on-device trade log, bucketed per wallet. The "bottom section" of the app
+// used to show wallet A's history to wallet B; these cases pin the isolation,
+// the legacy read-through, and the fact that mutations find whichever bucket
+// holds the record (a legacy row must still be updatable and clearable).
+import { beforeEach, describe, expect, test } from 'bun:test';
+import {
+  addTrade,
+  clearTrades,
+  listTrades,
+  removeTrade,
+  setActiveScope,
+  subscribeTrades,
+  updateTradeStatus,
+  type MyTrade,
+} from './myTrades';
+
+// Minimal localStorage stand-in — bun's test runtime has no DOM.
+const mem = new Map<string, string>();
+(globalThis as any).localStorage = {
+  getItem: (k: string) => (mem.has(k) ? mem.get(k)! : null),
+  setItem: (k: string, v: string) => { mem.set(k, String(v)); },
+  removeItem: (k: string) => { mem.delete(k); },
+  clear: () => mem.clear(),
+};
+
+const KEY = 'zswap-da:my-trades';
+const W1 = 'preprod::mn_shield-addr_test1aaa';
+const W2 = 'preprod::mn_shield-addr_test1bbb';
+const stored = () => JSON.parse(mem.get(KEY) ?? '{}');
+
+const trade = (id: string, status: MyTrade['status'] = 'live'): MyTrade => ({
+  id,
+  kind: 'create',
+  give: { sym: 'WETH', amt: 3 },
+  get: { sym: 'WBTC', amt: 15 },
+  at: 1_700_000_000_000,
+  status,
+  shielded: true,
+});
+
+beforeEach(() => {
+  mem.clear();
+  // Also drops the module cache, so each test starts from the storage it seeds.
+  setActiveScope(null);
+});
+
+describe('per-wallet isolation', () => {
+  test('a trade is recorded in the active wallet bucket only', () => {
+    setActiveScope(W1);
+    addTrade(trade('t1'));
+    expect(Object.keys(stored())).toEqual([W1]);
+    expect(listTrades().map((t) => t.id)).toEqual(['t1']);
+  });
+
+  test('the other wallet sees none of it', () => {
+    setActiveScope(W1);
+    addTrade(trade('t1'));
+    setActiveScope(W2);
+    expect(listTrades()).toEqual([]);
+    addTrade(trade('t2'));
+    expect(listTrades().map((t) => t.id)).toEqual(['t2']);
+    setActiveScope(W1);
+    expect(listTrades().map((t) => t.id)).toEqual(['t1']);
+  });
+
+  test('newest first within a bucket', () => {
+    setActiveScope(W1);
+    addTrade(trade('older'));
+    addTrade(trade('newer'));
+    expect(listTrades().map((t) => t.id)).toEqual(['newer', 'older']);
+  });
+});
+
+describe('legacy records (Q-1 option 1)', () => {
+  test('a pre-scoping flat array is shown to every wallet, tagged', () => {
+    mem.set(KEY, JSON.stringify([trade('old')]));
+    setActiveScope(W1);
+    const [row] = listTrades();
+    expect(row.id).toBe('old');
+    expect(row.legacy).toBe(true);
+    setActiveScope(W2);
+    expect(listTrades()[0].legacy).toBe(true);
+  });
+
+  test('the wallet\'s own trades come first, legacy after', () => {
+    mem.set(KEY, JSON.stringify([trade('old')]));
+    setActiveScope(W1);
+    addTrade(trade('mine'));
+    expect(listTrades().map((t) => [t.id, !!t.legacy])).toEqual([['mine', false], ['old', true]]);
+  });
+
+  test('no wallet connected → legacy only', () => {
+    mem.set(KEY, JSON.stringify({ [W1]: [trade('t1')], legacy: [trade('old')] }));
+    setActiveScope(null);
+    expect(listTrades().map((t) => t.id)).toEqual(['old']);
+  });
+
+  test('with no wallet, a trade is not recorded into someone else\'s bucket', () => {
+    setActiveScope(null);
+    addTrade(trade('t1'));
+    expect(mem.has(KEY)).toBe(false);
+  });
+
+  test('old status vocabulary is mapped on read', () => {
+    mem.set(KEY, JSON.stringify([{ ...trade('old'), status: 'completed' }]));
+    setActiveScope(W1);
+    expect(listTrades()[0].status).toBe('consumed');
+  });
+
+  test('pre-/v1 offerHash is read as offerId', () => {
+    mem.set(KEY, JSON.stringify([{ ...trade('old'), offerHash: 'abc123' }]));
+    setActiveScope(W1);
+    expect(listTrades()[0].offerId).toBe('abc123');
+  });
+});
+
+describe('mutations find the bucket holding the record', () => {
+  test('updateTradeStatus works on the active bucket', () => {
+    setActiveScope(W1);
+    addTrade(trade('t1', 'not_public'));
+    updateTradeStatus('t1', 'live');
+    expect(listTrades()[0].status).toBe('live');
+  });
+
+  test('updateTradeStatus works on a legacy record', () => {
+    mem.set(KEY, JSON.stringify([trade('old', 'live')]));
+    setActiveScope(W1);
+    updateTradeStatus('old', 'consumed');
+    expect(stored().legacy[0].status).toBe('consumed');
+  });
+
+  test('an unknown id is a no-op', () => {
+    setActiveScope(W1);
+    addTrade(trade('t1'));
+    updateTradeStatus('nope', 'consumed');
+    removeTrade('nope');
+    expect(listTrades().map((t) => t.id)).toEqual(['t1']);
+  });
+
+  test('removeTrade never touches another wallet\'s bucket', () => {
+    mem.set(KEY, JSON.stringify({ [W1]: [trade('t1')], [W2]: [trade('t2')] }));
+    setActiveScope(W1);
+    removeTrade('t1');
+    expect(stored()).toEqual({ [W1]: [], [W2]: [trade('t2')] });
+  });
+});
+
+describe('clearTrades', () => {
+  test('clears what the user can see — active + legacy — and nothing else', () => {
+    mem.set(KEY, JSON.stringify({ [W1]: [trade('t1')], [W2]: [trade('t2')], legacy: [trade('old')] }));
+    setActiveScope(W1);
+    clearTrades();
+    expect(stored()).toEqual({ [W2]: [trade('t2')] });
+    expect(listTrades()).toEqual([]);
+  });
+});
+
+describe('subscribers', () => {
+  test('fire on write and on a wallet switch', () => {
+    let calls = 0;
+    const off = subscribeTrades(() => { calls++; });
+    setActiveScope(W1);
+    expect(calls).toBe(1);
+    addTrade(trade('t1'));
+    expect(calls).toBe(2);
+    // Re-installing the SAME scope is not a change and must not churn the UI.
+    setActiveScope(W1);
+    expect(calls).toBe(2);
+    setActiveScope(W2);
+    expect(calls).toBe(3);
+    off();
+    setActiveScope(W1);
+    expect(calls).toBe(3);
+  });
+});

--- a/templates/zswap-da/src/state/myTrades.test.ts
+++ b/templates/zswap-da/src/state/myTrades.test.ts
@@ -1,7 +1,7 @@
 // The on-device trade log, bucketed per wallet. The "bottom section" of the app
 // used to show wallet A's history to wallet B; these cases pin the isolation,
-// the legacy read-through, and the fact that mutations find whichever bucket
-// holds the record (a legacy row must still be updatable and clearable).
+// the fact that pre-scoping records are discarded rather than migrated (Q-1),
+// and that every mutation stays inside the active wallet's bucket.
 import { beforeEach, describe, expect, test } from 'bun:test';
 import {
   addTrade,
@@ -71,28 +71,27 @@ describe('per-wallet isolation', () => {
   });
 });
 
-describe('legacy records (Q-1 option 1)', () => {
-  test('a pre-scoping flat array is shown to every wallet, tagged', () => {
+// Q-1, resolved by Eddie: no compatibility with the pre-scoping shape.
+describe('pre-scoping records are discarded', () => {
+  test('a pre-scoping flat array is invisible to every wallet', () => {
     mem.set(KEY, JSON.stringify([trade('old')]));
     setActiveScope(W1);
-    const [row] = listTrades();
-    expect(row.id).toBe('old');
-    expect(row.legacy).toBe(true);
+    expect(listTrades()).toEqual([]);
     setActiveScope(W2);
-    expect(listTrades()[0].legacy).toBe(true);
+    expect(listTrades()).toEqual([]);
   });
 
-  test('the wallet\'s own trades come first, legacy after', () => {
+  test('the next write replaces the flat array with a bucket store', () => {
     mem.set(KEY, JSON.stringify([trade('old')]));
     setActiveScope(W1);
     addTrade(trade('mine'));
-    expect(listTrades().map((t) => [t.id, !!t.legacy])).toEqual([['mine', false], ['old', true]]);
+    expect(stored()).toEqual({ [W1]: [trade('mine')] });
   });
 
-  test('no wallet connected → legacy only', () => {
-    mem.set(KEY, JSON.stringify({ [W1]: [trade('t1')], legacy: [trade('old')] }));
+  test('no wallet connected → an empty log, not another bucket\'s', () => {
+    mem.set(KEY, JSON.stringify({ [W1]: [trade('t1')] }));
     setActiveScope(null);
-    expect(listTrades().map((t) => t.id)).toEqual(['old']);
+    expect(listTrades()).toEqual([]);
   });
 
   test('with no wallet, a trade is not recorded into someone else\'s bucket', () => {
@@ -101,20 +100,14 @@ describe('legacy records (Q-1 option 1)', () => {
     expect(mem.has(KEY)).toBe(false);
   });
 
-  test('old status vocabulary is mapped on read', () => {
-    mem.set(KEY, JSON.stringify([{ ...trade('old'), status: 'completed' }]));
+  test('a malformed store degrades to an empty log', () => {
+    mem.set(KEY, '{not json');
     setActiveScope(W1);
-    expect(listTrades()[0].status).toBe('consumed');
-  });
-
-  test('pre-/v1 offerHash is read as offerId', () => {
-    mem.set(KEY, JSON.stringify([{ ...trade('old'), offerHash: 'abc123' }]));
-    setActiveScope(W1);
-    expect(listTrades()[0].offerId).toBe('abc123');
+    expect(listTrades()).toEqual([]);
   });
 });
 
-describe('mutations find the bucket holding the record', () => {
+describe('mutations stay inside the active bucket', () => {
   test('updateTradeStatus works on the active bucket', () => {
     setActiveScope(W1);
     addTrade(trade('t1', 'not_public'));
@@ -122,11 +115,20 @@ describe('mutations find the bucket holding the record', () => {
     expect(listTrades()[0].status).toBe('live');
   });
 
-  test('updateTradeStatus works on a legacy record', () => {
-    mem.set(KEY, JSON.stringify([trade('old', 'live')]));
+  test('updateTradeStatus never reaches another wallet\'s record', () => {
+    mem.set(KEY, JSON.stringify({ [W1]: [trade('t1')], [W2]: [trade('t2', 'live')] }));
     setActiveScope(W1);
-    updateTradeStatus('old', 'consumed');
-    expect(stored().legacy[0].status).toBe('consumed');
+    updateTradeStatus('t2', 'consumed');
+    expect(stored()[W2][0].status).toBe('live');
+  });
+
+  test('with no wallet, mutations are no-ops', () => {
+    mem.set(KEY, JSON.stringify({ [W1]: [trade('t1', 'live')] }));
+    setActiveScope(null);
+    updateTradeStatus('t1', 'consumed');
+    removeTrade('t1');
+    clearTrades();
+    expect(stored()).toEqual({ [W1]: [trade('t1', 'live')] });
   });
 
   test('an unknown id is a no-op', () => {
@@ -146,8 +148,8 @@ describe('mutations find the bucket holding the record', () => {
 });
 
 describe('clearTrades', () => {
-  test('clears what the user can see — active + legacy — and nothing else', () => {
-    mem.set(KEY, JSON.stringify({ [W1]: [trade('t1')], [W2]: [trade('t2')], legacy: [trade('old')] }));
+  test('clears what the user can see — this wallet — and nothing else', () => {
+    mem.set(KEY, JSON.stringify({ [W1]: [trade('t1')], [W2]: [trade('t2')] }));
     setActiveScope(W1);
     clearTrades();
     expect(stored()).toEqual({ [W2]: [trade('t2')] });

--- a/templates/zswap-da/src/state/myTrades.ts
+++ b/templates/zswap-da/src/state/myTrades.ts
@@ -5,22 +5,11 @@
 //
 // Bucketed per `<networkId>::<shieldedAddress>` (see scope.ts) — one browser can
 // hold several wallets, and an unscoped log showed wallet A's history to wallet
-// B. Records written before scoping live in the `legacy` bucket: they can't be
-// attributed to a wallet, so they are shown to every wallet, tagged (Q-1).
+// B. Records written before scoping are discarded, not migrated (Q-1).
 
-import { LEGACY_SCOPE, bucketOf, readBuckets, writeBuckets, type Buckets } from './scope';
+import { bucketOf, readBuckets, writeBuckets, type Buckets } from './scope';
 
 export type MyTradeStatus = 'not_public' | 'live' | 'consumed' | 'cancelled' | 'expired';
-
-/** Pre-/v1 records used the old vocabulary; map them on read. */
-const LEGACY_STATUS: Record<string, MyTradeStatus> = {
-  open: 'live',
-  completed: 'consumed',
-  // The old 'cancelled' was a local "user abandoned this" marker that was never
-  // actually written by any code path. The name now means something specific
-  // and server-authoritative, so any stray value maps onto the closest state.
-  cancelled: 'cancelled',
-};
 
 export interface TradeLeg { sym: string; amt: number }
 export interface MyTrade {
@@ -43,9 +32,6 @@ export interface MyTrade {
    *  the key for all subsequent status polling. Absent on records created before
    *  content addressing, which fall back to blob-based status lookup. */
   offerId?: string;
-  /** DERIVED on read, never stored: this record predates wallet scoping, so it
-   *  belongs to "some wallet in this browser" and is shown to all of them. */
-  legacy?: boolean;
 }
 
 const KEY = 'zswap-da:my-trades';
@@ -54,22 +40,12 @@ let activeScope: string | null = null;
 let cache: Buckets<MyTrade> | null = null;
 const subs = new Set<() => void>();
 
-function normalize(t: MyTrade & { offerHash?: string }): MyTrade {
-  return {
-    ...t,
-    status: LEGACY_STATUS[t.status as string] ?? t.status,
-    // Pre-/v1 records stored the content hash as `offerHash`; it is the same
-    // value, renamed to match the wire.
-    offerId: t.offerId ?? t.offerHash,
-  };
-}
-
+// No read-time normalization: the bucketed shape is only ever written by this
+// build, so the old status vocabulary (`open`/`completed`) and the old
+// `offerHash` field can no longer appear in a bucket. Both lived in the flat
+// pre-scoping arrays, which are now discarded on read (see scope.ts).
 function all(): Buckets<MyTrade> {
-  if (cache) return cache;
-  const raw = readBuckets<MyTrade & { offerHash?: string }>(KEY);
-  const out: Buckets<MyTrade> = {};
-  for (const [scope, list] of Object.entries(raw)) out[scope] = list.map(normalize);
-  cache = out;
+  if (!cache) cache = readBuckets<MyTrade>(KEY);
   return cache;
 }
 
@@ -80,9 +56,9 @@ function persist(next: Buckets<MyTrade>): void {
 }
 
 /**
- * Point the log at the connected wallet's bucket (`null` = no wallet, so only
- * legacy records are visible). Drops the cache and notifies subscribers, because
- * switching wallets changes what `listTrades()` returns just as much as a write.
+ * Point the log at the connected wallet's bucket (`null` = no wallet, so the log
+ * is empty). Drops the cache and notifies subscribers, because switching wallets
+ * changes what `listTrades()` returns just as much as a write.
  */
 export function setActiveScope(scope: string | null): void {
   const changed = scope !== activeScope;
@@ -91,15 +67,9 @@ export function setActiveScope(scope: string | null): void {
   if (changed) subs.forEach((f) => f());
 }
 
-/**
- * The connected wallet's trades, newest first, followed by the unattributable
- * pre-scoping records tagged `legacy` so the UI can say where they came from.
- */
+/** The connected wallet's trades, newest first. Empty with no wallet. */
 export function listTrades(): MyTrade[] {
-  const buckets = all();
-  const mine = activeScope && activeScope !== LEGACY_SCOPE ? bucketOf(buckets, activeScope) : [];
-  const legacy = bucketOf(buckets, LEGACY_SCOPE).map((t) => ({ ...t, legacy: true }));
-  return [...mine, ...legacy];
+  return [...bucketOf(all(), activeScope)];
 }
 
 export function addTrade(t: Omit<MyTrade, 'id' | 'at'> & { id?: string; at?: number }): MyTrade {
@@ -116,8 +86,7 @@ export function addTrade(t: Omit<MyTrade, 'id' | 'at'> & { id?: string; at?: num
   };
   // No wallet ⇒ no bucket. Callers only get here after a transaction the wallet
   // signed, so this means the wallet went away mid-flow: warn, hand back the
-  // record (so the caller's flow completes) and drop it rather than polluting
-  // the legacy bucket, which is reserved for genuinely pre-scoping data.
+  // record (so the caller's flow completes) and drop it.
   if (!activeScope) {
     console.warn('[my-trades] no wallet connected — not recording trade', rec.id);
     return rec;
@@ -127,42 +96,39 @@ export function addTrade(t: Omit<MyTrade, 'id' | 'at'> & { id?: string; at?: num
   return rec;
 }
 
-/** Find the bucket holding `id` — a record can be in the active OR legacy one. */
-function scopeHolding(buckets: Buckets<MyTrade>, id: string): string | null {
-  for (const [scope, list] of Object.entries(buckets)) {
-    if (list.some((t) => t.id === id)) return scope;
-  }
-  return null;
-}
+// Mutations only ever touch the ACTIVE bucket: `listTrades()` is the only way a
+// record reaches the UI, so an id the user can act on is always this wallet's.
+// Searching every bucket would let one wallet rewrite another's history.
 
 export function updateTradeStatus(id: string, status: MyTrade['status']): void {
+  if (!activeScope) return;
   const buckets = all();
-  const scope = scopeHolding(buckets, id);
-  if (!scope) return;
+  const list = bucketOf(buckets, activeScope);
   let changed = false;
-  const next = buckets[scope].map((t) => {
+  const next = list.map((t) => {
     if (t.id === id && t.status !== status) { changed = true; return { ...t, status }; }
     return t;
   });
-  if (changed) persist({ ...buckets, [scope]: next });
+  if (changed) persist({ ...buckets, [activeScope]: next });
 }
 
 export function removeTrade(id: string): void {
+  if (!activeScope) return;
   const buckets = all();
-  const scope = scopeHolding(buckets, id);
-  if (!scope) return;
-  persist({ ...buckets, [scope]: buckets[scope].filter((t) => t.id !== id) });
+  const list = bucketOf(buckets, activeScope);
+  if (!list.some((t) => t.id === id)) return;
+  persist({ ...buckets, [activeScope]: list.filter((t) => t.id !== id) });
 }
 
 /**
- * "Clear all" clears what the user can SEE: this wallet's records and the legacy
- * ones. Other wallets' buckets are left alone — clearing them from here would be
- * destroying history the user isn't looking at.
+ * "Clear all" clears what the user can SEE: this wallet's records. Other
+ * wallets' buckets are left alone — clearing them from here would be destroying
+ * history the user isn't looking at.
  */
 export function clearTrades(): void {
+  if (!activeScope) return;
   const next = { ...all() };
-  if (activeScope) delete next[activeScope];
-  delete next[LEGACY_SCOPE];
+  delete next[activeScope];
   persist(next);
 }
 

--- a/templates/zswap-da/src/state/myTrades.ts
+++ b/templates/zswap-da/src/state/myTrades.ts
@@ -1,7 +1,14 @@
-// Local trade log — every offer this browser CREATES or TAKES, kept on-device.
+// Local trade log — every offer this WALLET creates or takes, kept on-device.
 // Shielded ZSwaps are secret on-chain, so this client-side record is the only
 // durable history of them (cleared = unrecoverable, surfaced in the UI). Keyed
 // by a local id; the `blob` is the real bech32m offer for export/re-share.
+//
+// Bucketed per `<networkId>::<shieldedAddress>` (see scope.ts) — one browser can
+// hold several wallets, and an unscoped log showed wallet A's history to wallet
+// B. Records written before scoping live in the `legacy` bucket: they can't be
+// attributed to a wallet, so they are shown to every wallet, tagged (Q-1).
+
+import { LEGACY_SCOPE, bucketOf, readBuckets, writeBuckets, type Buckets } from './scope';
 
 export type MyTradeStatus = 'not_public' | 'live' | 'consumed' | 'cancelled' | 'expired';
 
@@ -36,38 +43,63 @@ export interface MyTrade {
    *  the key for all subsequent status polling. Absent on records created before
    *  content addressing, which fall back to blob-based status lookup. */
   offerId?: string;
+  /** DERIVED on read, never stored: this record predates wallet scoping, so it
+   *  belongs to "some wallet in this browser" and is shown to all of them. */
+  legacy?: boolean;
 }
 
 const KEY = 'zswap-da:my-trades';
-let cache: MyTrade[] | null = null;
+
+let activeScope: string | null = null;
+let cache: Buckets<MyTrade> | null = null;
 const subs = new Set<() => void>();
 
-function read(): MyTrade[] {
-  if (cache) return cache;
-  try {
-    const raw = JSON.parse(localStorage.getItem(KEY) || '[]') as (MyTrade & { offerHash?: string })[];
-    cache = raw.map((t) => ({
-      ...t,
-      status: LEGACY_STATUS[t.status as string] ?? t.status,
-      // Pre-/v1 records stored the content hash as `offerHash`; it is the same
-      // value, renamed to match the wire.
-      offerId: t.offerId ?? t.offerHash,
-    }));
-  } catch {
-    cache = [];
-  }
-  return cache!;
+function normalize(t: MyTrade & { offerHash?: string }): MyTrade {
+  return {
+    ...t,
+    status: LEGACY_STATUS[t.status as string] ?? t.status,
+    // Pre-/v1 records stored the content hash as `offerHash`; it is the same
+    // value, renamed to match the wire.
+    offerId: t.offerId ?? t.offerHash,
+  };
 }
-function write(list: MyTrade[]): void {
-  cache = list;
-  try {
-    localStorage.setItem(KEY, JSON.stringify(list));
-  } catch { /* ignore quota */ }
+
+function all(): Buckets<MyTrade> {
+  if (cache) return cache;
+  const raw = readBuckets<MyTrade & { offerHash?: string }>(KEY);
+  const out: Buckets<MyTrade> = {};
+  for (const [scope, list] of Object.entries(raw)) out[scope] = list.map(normalize);
+  cache = out;
+  return cache;
+}
+
+function persist(next: Buckets<MyTrade>): void {
+  cache = next;
+  writeBuckets(KEY, next);
   subs.forEach((f) => f());
 }
 
+/**
+ * Point the log at the connected wallet's bucket (`null` = no wallet, so only
+ * legacy records are visible). Drops the cache and notifies subscribers, because
+ * switching wallets changes what `listTrades()` returns just as much as a write.
+ */
+export function setActiveScope(scope: string | null): void {
+  const changed = scope !== activeScope;
+  activeScope = scope;
+  cache = null;
+  if (changed) subs.forEach((f) => f());
+}
+
+/**
+ * The connected wallet's trades, newest first, followed by the unattributable
+ * pre-scoping records tagged `legacy` so the UI can say where they came from.
+ */
 export function listTrades(): MyTrade[] {
-  return read();
+  const buckets = all();
+  const mine = activeScope && activeScope !== LEGACY_SCOPE ? bucketOf(buckets, activeScope) : [];
+  const legacy = bucketOf(buckets, LEGACY_SCOPE).map((t) => ({ ...t, legacy: true }));
+  return [...mine, ...legacy];
 }
 
 export function addTrade(t: Omit<MyTrade, 'id' | 'at'> & { id?: string; at?: number }): MyTrade {
@@ -82,26 +114,56 @@ export function addTrade(t: Omit<MyTrade, 'id' | 'at'> & { id?: string; at?: num
     blob: t.blob,
     offerId: t.offerId,
   };
-  write([rec, ...read()]);
+  // No wallet ⇒ no bucket. Callers only get here after a transaction the wallet
+  // signed, so this means the wallet went away mid-flow: warn, hand back the
+  // record (so the caller's flow completes) and drop it rather than polluting
+  // the legacy bucket, which is reserved for genuinely pre-scoping data.
+  if (!activeScope) {
+    console.warn('[my-trades] no wallet connected — not recording trade', rec.id);
+    return rec;
+  }
+  const buckets = all();
+  persist({ ...buckets, [activeScope]: [rec, ...bucketOf(buckets, activeScope)] });
   return rec;
 }
 
+/** Find the bucket holding `id` — a record can be in the active OR legacy one. */
+function scopeHolding(buckets: Buckets<MyTrade>, id: string): string | null {
+  for (const [scope, list] of Object.entries(buckets)) {
+    if (list.some((t) => t.id === id)) return scope;
+  }
+  return null;
+}
+
 export function updateTradeStatus(id: string, status: MyTrade['status']): void {
-  const list = read();
+  const buckets = all();
+  const scope = scopeHolding(buckets, id);
+  if (!scope) return;
   let changed = false;
-  const next = list.map((t) => {
+  const next = buckets[scope].map((t) => {
     if (t.id === id && t.status !== status) { changed = true; return { ...t, status }; }
     return t;
   });
-  if (changed) write(next);
+  if (changed) persist({ ...buckets, [scope]: next });
 }
 
 export function removeTrade(id: string): void {
-  write(read().filter((t) => t.id !== id));
+  const buckets = all();
+  const scope = scopeHolding(buckets, id);
+  if (!scope) return;
+  persist({ ...buckets, [scope]: buckets[scope].filter((t) => t.id !== id) });
 }
 
+/**
+ * "Clear all" clears what the user can SEE: this wallet's records and the legacy
+ * ones. Other wallets' buckets are left alone — clearing them from here would be
+ * destroying history the user isn't looking at.
+ */
 export function clearTrades(): void {
-  write([]);
+  const next = { ...all() };
+  if (activeScope) delete next[activeScope];
+  delete next[LEGACY_SCOPE];
+  persist(next);
 }
 
 export function subscribeTrades(fn: () => void): () => void {

--- a/templates/zswap-da/src/state/scope.test.ts
+++ b/templates/zswap-da/src/state/scope.test.ts
@@ -1,0 +1,101 @@
+// Scoped-storage primitives: key format, the one-time migration of pre-scoping
+// flat arrays, and the "never throw on junk" contract the callers rely on.
+import { beforeEach, describe, expect, test } from 'bun:test';
+import { LEGACY_SCOPE, bucketOf, buildScope, readBuckets, writeBuckets } from './scope';
+
+// Minimal localStorage stand-in — bun's test runtime has no DOM.
+const mem = new Map<string, string>();
+(globalThis as any).localStorage = {
+  getItem: (k: string) => (mem.has(k) ? mem.get(k)! : null),
+  setItem: (k: string, v: string) => { mem.set(k, String(v)); },
+  removeItem: (k: string) => { mem.delete(k); },
+  clear: () => mem.clear(),
+};
+
+const KEY = 'test:store';
+beforeEach(() => mem.clear());
+
+describe('buildScope', () => {
+  test('joins network and shielded address with ::', () => {
+    expect(buildScope('preprod', 'mn_shield-addr_test1abc')).toBe('preprod::mn_shield-addr_test1abc');
+  });
+
+  test('the same wallet on two networks gets two scopes', () => {
+    const addr = 'mn_shield-addr_test1abc';
+    expect(buildScope('preprod', addr)).not.toBe(buildScope('undeployed', addr));
+  });
+
+  test('the local JS wallet (raw hex coin key) scopes like any other', () => {
+    expect(buildScope('undeployed', 'ab'.repeat(32))).toBe(`undeployed::${'ab'.repeat(32)}`);
+  });
+
+  test('no wallet → null (nothing is mine, writes are refused)', () => {
+    expect(buildScope('preprod', null)).toBeNull();
+    expect(buildScope('preprod', undefined)).toBeNull();
+    expect(buildScope('preprod', '')).toBeNull();
+    expect(buildScope(null, 'mn_shield-addr_test1abc')).toBeNull();
+  });
+});
+
+describe('readBuckets', () => {
+  test('absent key → empty store', () => {
+    expect(readBuckets(KEY)).toEqual({});
+  });
+
+  test('pre-scoping flat array migrates into the legacy bucket', () => {
+    mem.set(KEY, JSON.stringify(['offer-a', 'offer-b']));
+    expect(readBuckets<string>(KEY)).toEqual({ [LEGACY_SCOPE]: ['offer-a', 'offer-b'] });
+  });
+
+  test('migration is idempotent once written back', () => {
+    mem.set(KEY, JSON.stringify(['offer-a']));
+    const migrated = readBuckets<string>(KEY);
+    writeBuckets(KEY, migrated);
+    expect(readBuckets<string>(KEY)).toEqual(migrated);
+  });
+
+  test('already-scoped object is read as-is', () => {
+    const stored = { 'preprod::w1': ['a'], 'preprod::w2': ['b'], legacy: ['c'] };
+    mem.set(KEY, JSON.stringify(stored));
+    expect(readBuckets<string>(KEY)).toEqual(stored);
+  });
+
+  test('non-array bucket values are dropped, not returned as junk', () => {
+    mem.set(KEY, JSON.stringify({ 'preprod::w1': ['a'], broken: 'not-a-list' }));
+    expect(readBuckets<string>(KEY)).toEqual({ 'preprod::w1': ['a'] });
+  });
+
+  test('malformed JSON degrades to empty — a convenience log never throws', () => {
+    mem.set(KEY, '{not json');
+    expect(readBuckets(KEY)).toEqual({});
+  });
+
+  test('a scalar value degrades to empty', () => {
+    mem.set(KEY, JSON.stringify(42));
+    expect(readBuckets(KEY)).toEqual({});
+  });
+});
+
+describe('bucketOf', () => {
+  const buckets = { 'preprod::w1': ['a'] };
+
+  test('returns the scope bucket', () => {
+    expect(bucketOf(buckets, 'preprod::w1')).toEqual(['a']);
+  });
+
+  test('unknown scope → empty, not undefined', () => {
+    expect(bucketOf(buckets, 'preprod::w2')).toEqual([]);
+  });
+
+  test('null scope (no wallet) → empty', () => {
+    expect(bucketOf(buckets, null)).toEqual([]);
+  });
+});
+
+describe('writeBuckets round-trip', () => {
+  test('stores the scoped shape and reads it back', () => {
+    writeBuckets(KEY, { 'preprod::w1': ['a', 'b'], legacy: ['c'] });
+    expect(JSON.parse(mem.get(KEY)!)).toEqual({ 'preprod::w1': ['a', 'b'], legacy: ['c'] });
+    expect(readBuckets<string>(KEY)).toEqual({ 'preprod::w1': ['a', 'b'], legacy: ['c'] });
+  });
+});

--- a/templates/zswap-da/src/state/scope.test.ts
+++ b/templates/zswap-da/src/state/scope.test.ts
@@ -1,7 +1,8 @@
-// Scoped-storage primitives: key format, the one-time migration of pre-scoping
-// flat arrays, and the "never throw on junk" contract the callers rely on.
+// Scoped-storage primitives: key format, the "anything that isn't a bucket
+// object reads as empty" rule that discards the pre-scoping flat arrays, and the
+// "never throw on junk" contract the callers rely on.
 import { beforeEach, describe, expect, test } from 'bun:test';
-import { LEGACY_SCOPE, bucketOf, buildScope, readBuckets, writeBuckets } from './scope';
+import { bucketOf, buildScope, readBuckets, writeBuckets } from './scope';
 
 // Minimal localStorage stand-in — bun's test runtime has no DOM.
 const mem = new Map<string, string>();
@@ -42,20 +43,21 @@ describe('readBuckets', () => {
     expect(readBuckets(KEY)).toEqual({});
   });
 
-  test('pre-scoping flat array migrates into the legacy bucket', () => {
+  // The pre-scoping shape. It is DISCARDED, not migrated: an unscoped record
+  // cannot be attributed to a wallet without guessing, and the app is alpha.
+  test('a pre-scoping flat array reads as empty and is not migrated', () => {
     mem.set(KEY, JSON.stringify(['offer-a', 'offer-b']));
-    expect(readBuckets<string>(KEY)).toEqual({ [LEGACY_SCOPE]: ['offer-a', 'offer-b'] });
+    expect(readBuckets<string>(KEY)).toEqual({});
   });
 
-  test('migration is idempotent once written back', () => {
+  test('the discarded array is simply overwritten by the next write', () => {
     mem.set(KEY, JSON.stringify(['offer-a']));
-    const migrated = readBuckets<string>(KEY);
-    writeBuckets(KEY, migrated);
-    expect(readBuckets<string>(KEY)).toEqual(migrated);
+    writeBuckets(KEY, { ...readBuckets<string>(KEY), 'preprod::w1': ['new'] });
+    expect(readBuckets<string>(KEY)).toEqual({ 'preprod::w1': ['new'] });
   });
 
   test('already-scoped object is read as-is', () => {
-    const stored = { 'preprod::w1': ['a'], 'preprod::w2': ['b'], legacy: ['c'] };
+    const stored = { 'preprod::w1': ['a'], 'preprod::w2': ['b'] };
     mem.set(KEY, JSON.stringify(stored));
     expect(readBuckets<string>(KEY)).toEqual(stored);
   });
@@ -94,8 +96,8 @@ describe('bucketOf', () => {
 
 describe('writeBuckets round-trip', () => {
   test('stores the scoped shape and reads it back', () => {
-    writeBuckets(KEY, { 'preprod::w1': ['a', 'b'], legacy: ['c'] });
-    expect(JSON.parse(mem.get(KEY)!)).toEqual({ 'preprod::w1': ['a', 'b'], legacy: ['c'] });
-    expect(readBuckets<string>(KEY)).toEqual({ 'preprod::w1': ['a', 'b'], legacy: ['c'] });
+    writeBuckets(KEY, { 'preprod::w1': ['a', 'b'], 'preprod::w2': ['c'] });
+    expect(JSON.parse(mem.get(KEY)!)).toEqual({ 'preprod::w1': ['a', 'b'], 'preprod::w2': ['c'] });
+    expect(readBuckets<string>(KEY)).toEqual({ 'preprod::w1': ['a', 'b'], 'preprod::w2': ['c'] });
   });
 });

--- a/templates/zswap-da/src/state/scope.ts
+++ b/templates/zswap-da/src/state/scope.ts
@@ -1,0 +1,76 @@
+// Wallet scoping for the on-device records (`my-offers`, `my-trades`).
+//
+// Both stores used to be flat, per-BROWSER lists. That is wrong as soon as two
+// wallets share one browser: an offer posted with Lace stayed "mine" after
+// connecting 1am, so the order book refused to let the second wallet take it
+// (issue 00003) and My Trades showed the other wallet's history as your own.
+//
+// The fix is a scope level in the stored JSON:
+//
+//   { "preprod::mn_shield-addr_…": [...], "undeployed::a1b2…": [...], "legacy": [...] }
+//
+// The scope is `<networkId>::<shieldedAddress>` — the network matters because the
+// same wallet on preprod and undeployed holds different coins and different
+// offers. Records written before scoping cannot be attributed to any wallet, so
+// they migrate once into the `legacy` bucket, which every wallet still reads
+// (Q-1 option 1: no data loss; the own-offer decision dialog of (B) turns a
+// misattributed legacy record into a confirmable choice, not a dead end).
+
+/** Bucket for records written before wallet scoping existed. Read by everyone. */
+export const LEGACY_SCOPE = 'legacy';
+
+/**
+ * The storage scope for a connected wallet, or `null` when no wallet is
+ * connected (no wallet ⇒ nothing is "mine", and writes have nowhere to go).
+ */
+export function buildScope(
+  networkId: string | null | undefined,
+  shieldedAddress: string | null | undefined,
+): string | null {
+  if (!networkId || !shieldedAddress) return null;
+  return `${networkId}::${shieldedAddress}`;
+}
+
+/** The on-disk shape after migration: one bucket per scope. */
+export type Buckets<T> = Record<string, T[]>;
+
+/**
+ * Read a scoped store from localStorage, migrating the pre-scoping shape.
+ *
+ * A flat array is what every build before this one wrote; it becomes the
+ * `legacy` bucket. Anything unreadable (absent, malformed, wrong type) degrades
+ * to an empty store rather than throwing — these records are a convenience log,
+ * never a correctness input.
+ */
+export function readBuckets<T>(key: string): Buckets<T> {
+  let raw: unknown;
+  try {
+    const s = localStorage.getItem(key);
+    if (!s) return {};
+    raw = JSON.parse(s);
+  } catch {
+    return {};
+  }
+  // Pre-scoping flat array → the legacy bucket. Migration is lazy (on first
+  // read) and idempotent: once written back, the value is already an object.
+  if (Array.isArray(raw)) return { [LEGACY_SCOPE]: raw as T[] };
+  if (!raw || typeof raw !== 'object') return {};
+  const out: Buckets<T> = {};
+  for (const [scope, value] of Object.entries(raw as Record<string, unknown>)) {
+    if (Array.isArray(value)) out[scope] = value as T[];
+  }
+  return out;
+}
+
+/** Persist a scoped store. Quota failures are ignored — see readBuckets. */
+export function writeBuckets<T>(key: string, buckets: Buckets<T>): void {
+  try {
+    localStorage.setItem(key, JSON.stringify(buckets));
+  } catch { /* ignore quota */ }
+}
+
+/** The records of one bucket, or `[]` when the bucket (or scope) is absent. */
+export function bucketOf<T>(buckets: Buckets<T>, scope: string | null): T[] {
+  if (!scope) return [];
+  return buckets[scope] ?? [];
+}

--- a/templates/zswap-da/src/state/scope.ts
+++ b/templates/zswap-da/src/state/scope.ts
@@ -7,17 +7,17 @@
 //
 // The fix is a scope level in the stored JSON:
 //
-//   { "preprod::mn_shield-addr_…": [...], "undeployed::a1b2…": [...], "legacy": [...] }
+//   { "preprod::mn_shield-addr_…": [...], "undeployed::a1b2…": [...] }
 //
 // The scope is `<networkId>::<shieldedAddress>` — the network matters because the
 // same wallet on preprod and undeployed holds different coins and different
-// offers. Records written before scoping cannot be attributed to any wallet, so
-// they migrate once into the `legacy` bucket, which every wallet still reads
-// (Q-1 option 1: no data loss; the own-offer decision dialog of (B) turns a
-// misattributed legacy record into a confirmable choice, not a dead end).
-
-/** Bucket for records written before wallet scoping existed. Read by everyone. */
-export const LEGACY_SCOPE = 'legacy';
+// offers.
+//
+// There is no compatibility path for the pre-scoping flat arrays: the app is
+// alpha, and a wallet-less record cannot be attributed to a wallet without
+// guessing. A stored value that is not a bucket object is read as an empty store
+// and overwritten by the next write (Q-1, resolved by Eddie: breaking change
+// accepted).
 
 /**
  * The storage scope for a connected wallet, or `null` when no wallet is
@@ -31,16 +31,15 @@ export function buildScope(
   return `${networkId}::${shieldedAddress}`;
 }
 
-/** The on-disk shape after migration: one bucket per scope. */
+/** The on-disk shape: one bucket per scope. */
 export type Buckets<T> = Record<string, T[]>;
 
 /**
- * Read a scoped store from localStorage, migrating the pre-scoping shape.
+ * Read a scoped store from localStorage.
  *
- * A flat array is what every build before this one wrote; it becomes the
- * `legacy` bucket. Anything unreadable (absent, malformed, wrong type) degrades
- * to an empty store rather than throwing — these records are a convenience log,
- * never a correctness input.
+ * Anything that is not a bucket object — absent, malformed, or the flat array
+ * older builds wrote — degrades to an empty store rather than throwing. These
+ * records are a convenience log, never a correctness input.
  */
 export function readBuckets<T>(key: string): Buckets<T> {
   let raw: unknown;
@@ -51,10 +50,8 @@ export function readBuckets<T>(key: string): Buckets<T> {
   } catch {
     return {};
   }
-  // Pre-scoping flat array → the legacy bucket. Migration is lazy (on first
-  // read) and idempotent: once written back, the value is already an object.
-  if (Array.isArray(raw)) return { [LEGACY_SCOPE]: raw as T[] };
-  if (!raw || typeof raw !== 'object') return {};
+  // An array is the pre-scoping shape. It is discarded, not migrated.
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return {};
   const out: Buckets<T> = {};
   for (const [scope, value] of Object.entries(raw as Record<string, unknown>)) {
     if (Array.isArray(value)) out[scope] = value as T[];

--- a/templates/zswap-da/src/state/useZSwapApp.ts
+++ b/templates/zswap-da/src/state/useZSwapApp.ts
@@ -50,7 +50,14 @@ import { isOwnOffer, parseOfferSender, unshieldedAddressToHex } from '../service
 import { findTokenName, shortToken } from '../utils';
 import { log } from '../lib/log';
 import { dlog, timed } from '../debug';
-import { takerShortfalls, shortfallsFromLegs, shortfallMessage, batchTakerShortfalls, affordableIndices } from '../services/takerBalance';
+import { takerShortfalls, shortfallsFromLegs, shortfallMessage, batchTakerShortfalls } from '../services/takerBalance';
+import {
+  affordableSelection,
+  defaultSelection,
+  summarize,
+  type SelectableOffer,
+  type TakeSummary,
+} from '../services/takeSelection';
 import type { KnownToken, OfferStatus, ZSwapOffer } from '../types';
 
 const NETWORK_ID = (import.meta.env.VITE_MIDNIGHT_NETWORK_ID as string) || 'undeployed';
@@ -699,19 +706,48 @@ export function useZSwapApp(): ZSwapApp {
     (takeable: (Order & { blob: string })[]) => {
       const n = takeable.length;
       if (n === 0) return;
-      const payAmt = takeable.reduce((s, o) => s + o.amtTo, 0);
-      const recvAmt = takeable.reduce((s, o) => s + o.amtFrom, 0);
-      // Settle the whole selection as ONE transaction. This used to loop
-      // `takeOffer` per offer, which re-spent the taker's coin from wallet state
-      // that hadn't seen the previous take, so the node rejected every offer
-      // after the first with `Zswap(NullifierAlreadyPresent)`.
+      const balances = { shielded: wstate?.shieldedBalances, unshielded: wstate?.unshieldedBalances };
+      // One selectable row per offer: display amounts come from the book, the
+      // exact legs from the blob — the balance maths must never run on the
+      // display floats.
+      const items: SelectableOffer[] = takeable.map((o) => ({
+        id: o.offerId ?? o.blob,
+        pay: { sym: o.to, amt: o.amtTo },
+        receive: { sym: o.from, amt: o.amtFrom },
+        pays: parseTakerLegs(o.blob, NETWORK_ID as any)?.pays ?? [],
+        // The user may have chosen to include their own offers a dialog ago;
+        // keep saying which ones they are.
+        mine: ownsOffer(o, o.blob),
+      }));
+      const orderById = new Map(items.map((it, i) => [it.id, takeable[i]]));
+      // Affordability is an AGGREGATE property: each offer can look affordable
+      // on its own while the batch overspends, so this is the best-price-first
+      // prefix that fits, not a per-row test.
+      const affordable = new Set(affordableSelection(items, balances));
+      const checkedByDefault = new Set(defaultSelection(items, balances));
+      const initial = summarize(items, checkedByDefault, balances, knownTokens);
+      const toView = (s: TakeSummary) => ({
+        pay: { sym: s.pay.sym, amt: fmtAmt(s.pay.amt) },
+        receive: { sym: s.receive.sym, amt: fmtAmt(s.receive.amt) },
+        blocked: s.blocked ?? undefined,
+        cta: s.cta,
+      });
+
+      // Settle exactly what the dialog had checked, as ONE transaction. Taking
+      // them one at a time re-spent the taker's coin from wallet state that
+      // hadn't seen the previous take, so the node rejected every offer after
+      // the first with `Zswap(NullifierAlreadyPresent)`.
       //
       // History stays per offer — the UI's unit is the offer even though the
       // chain's unit is now a single settlement — and nothing is recorded unless
       // that settlement succeeded, so a failed batch leaves no phantom trades.
-      const settle = (orders: (Order & { blob: string })[]) => async () => {
-        await takeOffers(orders.map((o) => o.blob));
-        for (const o of orders) {
+      const settle = async (ids: string[]) => {
+        const chosen = ids.length > 0
+          ? ids.map((id) => orderById.get(id)).filter((o): o is Order & { blob: string } => !!o)
+          : takeable;
+        if (chosen.length === 0) return;
+        await takeOffers(chosen.map((o) => o.blob));
+        for (const o of chosen) {
           addTrade({
             kind: 'take',
             give: { sym: o.to, amt: o.amtTo },
@@ -723,51 +759,26 @@ export function useZSwapApp(): ZSwapApp {
           });
         }
       };
-      // Block on the AGGREGATE cost — checking each offer against the full
-      // balance would pass a batch that only overspends in sum. When the whole
-      // batch is short, compute the affordable prefix (best-priced first) so the
-      // user can take part instead of nothing.
-      const blocked = shortfallMessage(
-        batchTakerShortfalls(
-          takeable.map((o) => o.blob),
-          wstate?.shieldedBalances,
-          wstate?.unshieldedBalances,
-          NETWORK_ID as any,
-          knownTokens,
-        ),
-      ) ?? undefined;
-      const okIdx = blocked
-        ? new Set(
-            affordableIndices(
-              takeable.map((o) => parseTakerLegs(o.blob, NETWORK_ID as any)?.pays ?? []),
-              wstate?.shieldedBalances,
-              wstate?.unshieldedBalances,
-            ),
-          )
-        : null;
-      const affordable = okIdx ? takeable.filter((_, i) => okIdx.has(i)) : takeable;
+
       setPendingConfirm({
+        // The title states what was selected; the CTA below tracks what is
+        // currently checked.
         title: n > 1 ? `Take ${n} offers` : 'Take offer',
-        pay: { sym: takeable[0].to, amt: fmtAmt(payAmt) },
-        receive: { sym: takeable[0].from, amt: fmtAmt(recvAmt) },
-        cta: n > 1 ? `Take ${n} offers` : 'Take offer',
-        blocked,
-        items: n > 1
-          ? takeable.map((o, i) => ({
-              pay: `${fmtAmt(o.amtTo)} ${o.to}`,
-              receive: `${fmtAmt(o.amtFrom)} ${o.from}`,
-              ok: okIdx ? okIdx.has(i) : true,
-            }))
-          : undefined,
-        partial: blocked && affordable.length > 0
-          ? { cta: `Take affordable ${affordable.length} of ${n}`, onConfirm: settle(affordable) }
-          : undefined,
-        onConfirm: settle(takeable),
+        ...toView(initial),
+        items: items.map((it) => ({
+          id: it.id,
+          pay: `${fmtAmt(it.pay.amt)} ${it.pay.sym}`,
+          receive: `${fmtAmt(it.receive.amt)} ${it.receive.sym}`,
+          ok: affordable.has(it.id),
+          mine: it.mine,
+          checked: checkedByDefault.has(it.id),
+        })),
+        assess: (ids) => toView(summarize(items, ids, balances, knownTokens)),
+        onConfirm: settle,
       });
     },
-    [takeOffers, wstate, knownTokens],
+    [takeOffers, wstate, knownTokens, ownsOffer],
   );
-
   const requestTake = useCallback(
     async (o: Order) => {
       if (!o.offerId) {

--- a/templates/zswap-da/src/state/useZSwapApp.ts
+++ b/templates/zswap-da/src/state/useZSwapApp.ts
@@ -223,7 +223,7 @@ export interface ZSwapApp {
   // my trades — local, on-device log of created/taken offers
   myTrades: MyTrade[];
   /** Storage scope of the connected wallet (`<networkId>::<shieldedAddress>`),
-   *  or null with no wallet — the records shown are then legacy-only. */
+   *  or null with no wallet — nothing is then "mine" and the trade log is empty. */
   walletScope: string | null;
   clearTrade: (id: string) => void;
   clearAllTrades: () => void;

--- a/templates/zswap-da/src/state/useZSwapApp.ts
+++ b/templates/zswap-da/src/state/useZSwapApp.ts
@@ -24,6 +24,15 @@ import { injectedContractWallet, localContractWallet, type ContractWallet } from
 import { api } from '../services/api';
 import { addMyOffer, isMyOfferIn, setActiveScope as setMyOffersScope } from './myOffers';
 import type { ConfirmPayload } from '../ui/ConfirmModal';
+import type { DecisionOption, DecisionPayload } from '../ui/DecisionModal';
+import {
+  applyOwnOfferChoice,
+  decideOwnOffers,
+  ownOfferChoiceLabel,
+  partitionOwn,
+  type OwnOfferDecision,
+  type OwnOfferSplit,
+} from '../services/ownOffers';
 import { fmtAmt } from './format';
 import {
   addTrade,
@@ -190,6 +199,10 @@ export interface ZSwapApp {
   takeOffer: (blob: string) => Promise<void>;
   // shared take-confirm dialog (driven by any screen, rendered once in App)
   pendingConfirm: ConfirmPayload | null;
+  /** Shared question dialog (own offers). Rendered once in App, next to the
+   *  confirm dialog; answering it continues or abandons the take. */
+  pendingDecision: DecisionPayload | null;
+  closeDecision: () => void;
   /** Async: the offer's blob is fetched on selection (the book is blob-free). */
   requestTake: (o: Order) => Promise<void>;
   requestTakeMany: (orders: Order[]) => Promise<void>;
@@ -628,124 +641,64 @@ export function useZSwapApp(): ZSwapApp {
   );
 
   const [pendingConfirm, setPendingConfirm] = useState<ConfirmPayload | null>(null);
+  const [pendingDecision, setPendingDecision] = useState<DecisionPayload | null>(null);
+  const closeDecision = useCallback(() => setPendingDecision(null), []);
   // Selecting an offer now costs a GET /v1/offers/:offerId per offer. Expose that
   // as a pending flag so the screens can disable their take controls instead of
   // appearing frozen between click and confirm dialog.
   const [takePreparing, setTakePreparing] = useState(false);
-  const requestTake = useCallback(
-    async (o: Order) => {
-      if (!o.offerId) {
-        // Legacy row indexed before content addressing — the node can't serve
-        // its blob by hash, so there's nothing to settle from.
-        toast('This offer predates content addressing and can no longer be taken.');
-        return;
+
+  /**
+   * Ask about the own offers in a selection, then continue with whatever the
+   * user picked. Taking your own offer is legal on-chain, so this is the whole
+   * of the enforcement: a question, never a block — and never the connect modal,
+   * which is what this used to do (issue 00003).
+   *
+   * Cancel — and dismissing the dialog — settle nothing.
+   */
+  const askOwnOffers = useCallback(
+    <T,>(split: OwnOfferSplit<T>, decision: OwnOfferDecision, proceed: (chosen: T[]) => void) => {
+      // Cancel first, mirroring the confirm dialog's button order; the
+      // continue-with-everything option is the accented one on the right.
+      const options: DecisionOption[] = [{ label: 'Cancel', onPick: () => {} }];
+      for (const choice of decision.choices) {
+        if (choice === 'cancel') continue;
+        options.push({
+          label: ownOfferChoiceLabel(choice, decision),
+          kind: choice === 'take-all' ? 'primary' : 'plain',
+          onPick: () => {
+            const chosen = applyOwnOfferChoice(split, choice);
+            if (chosen) proceed(chosen);
+          },
+        });
       }
-      // Selection is where the blob gets fetched — the order book itself is
-      // blob-free, so nothing was prefetched for the rest of the page.
-      setTakePreparing(true);
-      let blob: string | null;
-      try {
-        blob = await loadOfferBlob(o.offerId);
-      } finally {
-        setTakePreparing(false);
-      }
-      if (!blob) {
-        toast('This offer is no longer available — it may have just been taken.');
-        zapi.fetchOffers();
-        return;
-      }
-      // The list can't tell whether an unshielded offer is ours (that needs the
-      // blob). Now that we have it, check before letting the user take it.
-      if (selfUnshieldedHex && isOwnOffer(parseOfferSender(blob, NETWORK_ID as any), selfUnshieldedHex)) {
-        toast("That's your own offer — you can't take it.");
-        return;
-      }
-      // Taker pays what the order WANTS (o.to / amtTo) and receives what it
-      // GIVES (o.from / amtFrom).
-      setPendingConfirm({
-        title: 'Take offer',
-        pay: { sym: o.to, amt: fmtAmt(o.amtTo) },
-        receive: { sym: o.from, amt: fmtAmt(o.amtFrom) },
-        cta: 'Take offer',
-        blocked: takerShortfall(blob) ?? undefined,
-        onConfirm: async () => {
-          await takeOffer(blob);
-          addTrade({
-            kind: 'take',
-            give: { sym: o.to, amt: o.amtTo },
-            get: { sym: o.from, amt: o.amtFrom },
-            status: 'consumed',
-            shielded: false,
-            blob,
-            offerId: o.offerId ?? undefined,
-          });
-        },
+      setPendingDecision({
+        title: decision.kind === 'mixed' ? 'Some offers are yours' : 'Your own offer',
+        body: decision.message ?? '',
+        options,
       });
     },
-    [toast, takeOffer, takerShortfall, loadOfferBlob, selfUnshieldedHex, zapi],
+    [],
   );
 
-  // Take one or more order-book offers in a single confirm dialog. Filters out
-  // your own offers (you can't take them) and blobs we can't settle; aggregates
-  // the pay/receive across the selection; settles the whole selection as one
-  // transaction via the batcher.
-  const requestTakeMany = useCallback(
-    async (orders: Order[]) => {
-      if (!tradeWallet?.canTrade) {
-        toast('Use the browser wallet (Lace) to take offers.');
-        return;
-      }
-      const candidates = orders.filter((o) => !o.isMine && o.offerId);
-      if (candidates.length === 0) {
-        if (orders.some((o) => o.isMine)) {
-          setConnectOpen(true);
-          return;
-        }
-        toast(
-          orders.some((o) => !o.offerId)
-            ? 'These offers predate content addressing and can no longer be taken.'
-            : 'No live offer to take here.',
-        );
-        return;
-      }
+  /** True when this offer belongs to the connected wallet: the on-device record
+   *  (the only signal a shielded offer has) or the blob's unshielded sender. */
+  const ownsOffer = useCallback(
+    (o: Order, blob: string): boolean =>
+      o.isMine ||
+      (!!selfUnshieldedHex && isOwnOffer(parseOfferSender(blob, NETWORK_ID as any), selfUnshieldedHex)),
+    [selfUnshieldedHex],
+  );
 
-      // Fetch the blobs for the SELECTION only — bounded by what the user
-      // picked, never the whole book. Offers that 404 here were consumed
-      // between render and click.
-      setTakePreparing(true);
-      let resolved: { o: Order; blob: string | null }[];
-      try {
-        resolved = await Promise.all(
-          candidates.map(async (o) => ({ o, blob: await loadOfferBlob(o.offerId) })),
-        );
-      } finally {
-        setTakePreparing(false);
-      }
-      // Only real bech32m offers (swapoffer1…) can be settled. Seeded demo
-      // liquidity carries a placeholder blob and must be skipped with a clear
-      // message rather than a cryptic decode error.
-      const isReal = (b: string | null) => !!b && /^swapoffer1/i.test(b);
-      const takeable = resolved
-        .filter((r): r is { o: Order; blob: string } => isReal(r.blob))
-        // The list can't detect unshielded ownership without the blob; now that
-        // we have it, drop anything that turns out to be ours.
-        .filter(({ blob }) =>
-          !selfUnshieldedHex || !isOwnOffer(parseOfferSender(blob, NETWORK_ID as any), selfUnshieldedHex))
-        .map(({ o, blob }) => ({ ...o, blob }));
-
-      if (takeable.length === 0) {
-        const vanished = resolved.some((r) => r.blob === null);
-        toast(
-          vanished
-            ? 'Those offers are no longer available — they may have just been taken.'
-            : resolved.some((r) => r.blob && !isReal(r.blob))
-              ? "Seeded demo liquidity — these offers aren't settle-able. Use a real (swapoffer1…) offer to test taking."
-              : 'No live offer to take here.',
-        );
-        if (vanished) zapi.fetchOffers();
-        return;
-      }
+  /**
+   * Open the take-confirm dialog for a resolved selection. Split out of
+   * `requestTakeMany` because the own-offer question sits in front of it: the
+   * dialog is opened from the question's answer, not from the click.
+   */
+  const openTakeConfirm = useCallback(
+    (takeable: (Order & { blob: string })[]) => {
       const n = takeable.length;
+      if (n === 0) return;
       const payAmt = takeable.reduce((s, o) => s + o.amtTo, 0);
       const recvAmt = takeable.reduce((s, o) => s + o.amtFrom, 0);
       // Settle the whole selection as ONE transaction. This used to loop
@@ -812,7 +765,126 @@ export function useZSwapApp(): ZSwapApp {
         onConfirm: settle(takeable),
       });
     },
-    [toast, takeOffers, tradeWallet, wstate, knownTokens, loadOfferBlob, selfUnshieldedHex, zapi],
+    [takeOffers, wstate, knownTokens],
+  );
+
+  const requestTake = useCallback(
+    async (o: Order) => {
+      if (!o.offerId) {
+        // Legacy row indexed before content addressing — the node can't serve
+        // its blob by hash, so there's nothing to settle from.
+        toast('This offer predates content addressing and can no longer be taken.');
+        return;
+      }
+      // Selection is where the blob gets fetched — the order book itself is
+      // blob-free, so nothing was prefetched for the rest of the page.
+      setTakePreparing(true);
+      let blob: string | null;
+      try {
+        blob = await loadOfferBlob(o.offerId);
+      } finally {
+        setTakePreparing(false);
+      }
+      if (!blob) {
+        toast('This offer is no longer available — it may have just been taken.');
+        zapi.fetchOffers();
+        return;
+      }
+      // Taker pays what the order WANTS (o.to / amtTo) and receives what it
+      // GIVES (o.from / amtFrom).
+      const b = blob;
+      const open = () =>
+        setPendingConfirm({
+          title: 'Take offer',
+          pay: { sym: o.to, amt: fmtAmt(o.amtTo) },
+          receive: { sym: o.from, amt: fmtAmt(o.amtFrom) },
+          cta: 'Take offer',
+          blocked: takerShortfall(b) ?? undefined,
+          onConfirm: async () => {
+            await takeOffer(b);
+            addTrade({
+              kind: 'take',
+              give: { sym: o.to, amt: o.amtTo },
+              get: { sym: o.from, amt: o.amtFrom },
+              status: 'consumed',
+              shielded: false,
+              blob: b,
+              offerId: o.offerId ?? undefined,
+            });
+          },
+        });
+      // Own offer? The list can't tell for an unshielded offer (that needs the
+      // blob) — now that we have it, ask instead of refusing with a toast.
+      const split = partitionOwn([o], () => ownsOffer(o, b));
+      const decision = decideOwnOffers(split);
+      if (decision.kind === 'none') { open(); return; }
+      askOwnOffers(split, decision, open);
+    },
+    [toast, takeOffer, takerShortfall, loadOfferBlob, ownsOffer, askOwnOffers, zapi],
+  );
+
+  // Take one or more order-book offers in a single confirm dialog. Drops blobs
+  // we can't settle, asks about the ones that are yours, aggregates the
+  // pay/receive across what's left and settles it as one transaction.
+  const requestTakeMany = useCallback(
+    async (orders: Order[]) => {
+      if (!tradeWallet?.canTrade) {
+        toast('Use the browser wallet (Lace) to take offers.');
+        return;
+      }
+      // Own offers deliberately stay IN the candidate set: they are a question
+      // for the user further down, not a reason to redirect to the connect
+      // modal — which is exactly what this used to do, silently (issue 00003).
+      const candidates = orders.filter((o) => o.offerId);
+      if (candidates.length === 0) {
+        toast(
+          orders.some((o) => !o.offerId)
+            ? 'These offers predate content addressing and can no longer be taken.'
+            : 'No live offer to take here.',
+        );
+        return;
+      }
+
+      // Fetch the blobs for the SELECTION only — bounded by what the user
+      // picked, never the whole book. Offers that 404 here were consumed
+      // between render and click.
+      setTakePreparing(true);
+      let resolved: { o: Order; blob: string | null }[];
+      try {
+        resolved = await Promise.all(
+          candidates.map(async (o) => ({ o, blob: await loadOfferBlob(o.offerId) })),
+        );
+      } finally {
+        setTakePreparing(false);
+      }
+      // Only real bech32m offers (swapoffer1…) can be settled. Seeded demo
+      // liquidity carries a placeholder blob and must be skipped with a clear
+      // message rather than a cryptic decode error.
+      const isReal = (b: string | null) => !!b && /^swapoffer1/i.test(b);
+      const takeable = resolved
+        .filter((r): r is { o: Order; blob: string } => isReal(r.blob))
+        .map(({ o, blob }) => ({ ...o, blob }));
+
+      if (takeable.length === 0) {
+        const vanished = resolved.some((r) => r.blob === null);
+        toast(
+          vanished
+            ? 'Those offers are no longer available — they may have just been taken.'
+            : resolved.some((r) => r.blob && !isReal(r.blob))
+              ? "Seeded demo liquidity — these offers aren't settle-able. Use a real (swapoffer1…) offer to test taking."
+              : 'No live offer to take here.',
+        );
+        if (vanished) zapi.fetchOffers();
+        return;
+      }
+      // Ownership is only fully knowable now: the local record covers shielded
+      // offers, the unshielded-sender match needs the blob we just fetched.
+      const split = partitionOwn(takeable, (o) => ownsOffer(o, o.blob));
+      const decision = decideOwnOffers(split);
+      if (decision.kind === 'none') { openTakeConfirm(takeable); return; }
+      askOwnOffers(split, decision, openTakeConfirm);
+    },
+    [toast, tradeWallet, loadOfferBlob, ownsOffer, askOwnOffers, openTakeConfirm, zapi],
   );
   const closeConfirm = useCallback(() => setPendingConfirm(null), []);
 
@@ -981,6 +1053,8 @@ export function useZSwapApp(): ZSwapApp {
     createOffer,
     takeOffer,
     pendingConfirm,
+    pendingDecision,
+    closeDecision,
     requestTake,
     requestTakeMany,
     takePreparing,

--- a/templates/zswap-da/src/state/useZSwapApp.ts
+++ b/templates/zswap-da/src/state/useZSwapApp.ts
@@ -650,6 +650,27 @@ export function useZSwapApp(): ZSwapApp {
   const [pendingConfirm, setPendingConfirm] = useState<ConfirmPayload | null>(null);
   const [pendingDecision, setPendingDecision] = useState<DecisionPayload | null>(null);
   const closeDecision = useCallback(() => setPendingDecision(null), []);
+
+  // A wallet disconnect must not leave a take dialog behind. Settlement already
+  // refuses without a wallet (`requireWallet` throws and the error lands in the
+  // dialog), so nothing could ever settle after a disconnect — this is the
+  // visible half of the same guarantee: the stale question closes instead of
+  // waiting to fail.
+  //
+  // Deliberately edge-triggered on connected → disconnected: a level-triggered
+  // "close whenever there is no wallet" would also shut a dialog that was opened
+  // while disconnected, and would fire during the connect handshake (`connected`
+  // is set before `readState` fills `wstate`).
+  const hadWallet = useRef(false);
+  useEffect(() => {
+    const has = !!connected && !!wstate;
+    if (hadWallet.current && !has) {
+      setPendingConfirm(null);
+      setPendingDecision(null);
+    }
+    hadWallet.current = has;
+  }, [connected, wstate]);
+
   // Selecting an offer now costs a GET /v1/offers/:offerId per offer. Expose that
   // as a pending flag so the screens can disable their take controls instead of
   // appearing frozen between click and confirm dialog.
@@ -741,10 +762,13 @@ export function useZSwapApp(): ZSwapApp {
       // History stays per offer — the UI's unit is the offer even though the
       // chain's unit is now a single settlement — and nothing is recorded unless
       // that settlement succeeded, so a failed batch leaves no phantom trades.
+      // No "all" fallback for an empty id list: the ids ARE the user's answer,
+      // and an empty answer settles nothing. Falling back to the whole selection
+      // would put offers on chain that the dialog showed as unchecked.
       const settle = async (ids: string[]) => {
-        const chosen = ids.length > 0
-          ? ids.map((id) => orderById.get(id)).filter((o): o is Order & { blob: string } => !!o)
-          : takeable;
+        const chosen = ids
+          .map((id) => orderById.get(id))
+          .filter((o): o is Order & { blob: string } => !!o);
         if (chosen.length === 0) return;
         await takeOffers(chosen.map((o) => o.blob));
         for (const o of chosen) {

--- a/templates/zswap-da/src/state/useZSwapApp.ts
+++ b/templates/zswap-da/src/state/useZSwapApp.ts
@@ -22,13 +22,22 @@ import { type OfferLeg } from '../services/makerOffer';
 import { makeInjectedTradeWallet, makeLocalTradeWallet, type TradeWallet } from './tradeWallet';
 import { injectedContractWallet, localContractWallet, type ContractWallet } from '../services/contractWallet';
 import { api } from '../services/api';
-import { addMyOffer } from './myOffers';
+import { addMyOffer, isMyOfferIn, setActiveScope as setMyOffersScope } from './myOffers';
 import type { ConfirmPayload } from '../ui/ConfirmModal';
 import { fmtAmt } from './format';
-import { addTrade, clearTrades, listTrades, removeTrade, subscribeTrades, updateTradeStatus, type MyTrade } from './myTrades';
+import {
+  addTrade,
+  clearTrades,
+  listTrades,
+  removeTrade,
+  setActiveScope as setMyTradesScope,
+  subscribeTrades,
+  updateTradeStatus,
+  type MyTrade,
+} from './myTrades';
+import { buildScope } from './scope';
 import { parseTakerLegs } from '../services/offerParse';
 import { isOwnOffer, parseOfferSender, unshieldedAddressToHex } from '../services/offerSender';
-import { isMyOffer } from './myOffers';
 import { findTokenName, shortToken } from '../utils';
 import { log } from '../lib/log';
 import { dlog, timed } from '../debug';
@@ -193,6 +202,9 @@ export interface ZSwapApp {
   closeConfirm: () => void;
   // my trades — local, on-device log of created/taken offers
   myTrades: MyTrade[];
+  /** Storage scope of the connected wallet (`<networkId>::<shieldedAddress>`),
+   *  or null with no wallet — the records shown are then legacy-only. */
+  walletScope: string | null;
   clearTrade: (id: string) => void;
   clearAllTrades: () => void;
   importOffer: (blob: string) => Promise<void>;
@@ -225,6 +237,20 @@ export function useZSwapApp(): ZSwapApp {
   const [mintTick, setMintTick] = useState(0);
   const [myTrades, setMyTrades] = useState<MyTrade[]>(() => listTrades());
   useEffect(() => subscribeTrades(() => setMyTrades([...listTrades()])), []);
+
+  // The on-device records belong to a WALLET on a NETWORK, not to the browser:
+  // two wallets in one browser used to share one bucket, so wallet B inherited
+  // wallet A's offers as "mine" and could never take them (issue 00003).
+  // `null` = no wallet ⇒ nothing is mine and writes are refused (see scope.ts).
+  //
+  // Declared AFTER the subscription above so that on mount the subscriber is
+  // already registered when the scope is installed and fires it.
+  const walletScope = useMemo(() => buildScope(NETWORK_ID, wstate?.shieldedAddress), [wstate?.shieldedAddress]);
+  useEffect(() => {
+    setMyOffersScope(walletScope);
+    // Notifies subscribeTrades, which re-reads the log for the new wallet.
+    setMyTradesScope(walletScope);
+  }, [walletScope]);
 
   // The active wallet's transaction capability (mint/create/take). Injected
   // (Lace) goes through the dapp-connector; local (JS facade) through the
@@ -314,8 +340,9 @@ export function useZSwapApp(): ZSwapApp {
   // keep them non-takeable.
   //
   // Ownership: shielded offers are anonymous on-chain, so the primary signal is
-  // a local record of what this browser created — now keyed by offerId, which
-  // is what the blob-free list carries. The unshielded-sender match needs the
+  // a local record of what the CONNECTED WALLET created (plus the unattributable
+  // pre-scoping records) — keyed by offerId, which is what the blob-free list
+  // carries. The unshielded-sender match needs the
   // blob, so it can only run for offers whose blob we've already fetched; the
   // authoritative check happens at selection time in requestTake(), where the
   // blob is always loaded.
@@ -325,14 +352,15 @@ export function useZSwapApp(): ZSwapApp {
         const order = toOrder(o, knownTokens);
         if (!order) return null;
         const blob = order.offerId ? blobById[order.offerId] : undefined;
-        let mine = isMyOffer(order.offerId) || isMyOffer(blob);
+        let mine = isMyOfferIn(order.offerId, walletScope) || isMyOfferIn(blob, walletScope);
         if (!mine && selfUnshieldedHex && blob) {
           mine = isOwnOffer(parseOfferSender(blob, NETWORK_ID as any), selfUnshieldedHex);
         }
         return { ...order, blob, isMine: mine };
       })
       .filter((o): o is Order => o !== null);
-  }, [zapi.offers, knownTokens, selfUnshieldedHex, blobById]);
+    // `walletScope` is a real input here: switching wallets changes who owns what.
+  }, [zapi.offers, knownTokens, selfUnshieldedHex, blobById, walletScope]);
 
   const toast = useCallback((msg: string, kind?: 'ok' | string) => {
     const id = Math.random().toString(36).slice(2);
@@ -959,6 +987,7 @@ export function useZSwapApp(): ZSwapApp {
     takerShortfall,
     closeConfirm,
     myTrades,
+    walletScope,
     clearTrade,
     clearAllTrades,
     importOffer,

--- a/templates/zswap-da/src/ui/ConfirmModal.tsx
+++ b/templates/zswap-da/src/ui/ConfirmModal.tsx
@@ -1,47 +1,92 @@
 // Generic confirm dialog used before settling a take (and other irreversible
 // actions). Shows a pay→receive summary and runs an async action with a busy
 // state + inline error.
+//
+// For a multi-offer take every row carries a checkbox: a price level aggregates
+// all offers at that price and used to be all-or-nothing. The dialog keeps the
+// checked set, and re-derives the totals, the affordability verdict and the CTA
+// from it through the payload's `assess` — so the numbers on screen always
+// describe what pressing the button will actually settle.
 
-import { useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Modal, ModalHead } from './Modal';
 import { Coin, Icon } from './icons';
 import { dlog } from '../debug';
 
-export interface ConfirmPayload {
-  title: string;
+/** What the dialog shows for the current selection. */
+export interface ConfirmView {
   pay: { sym: string; amt: string };
   receive: { sym: string; amt: string };
-  shielded?: boolean;
-  cta: string;
-  /** When set, the offer can't be funded by the wallet — reason is shown and the
-   *  confirm CTA is disabled (never start a settle the wallet can't complete). */
+  /** When set, the selection can't be funded by the wallet — reason is shown and
+   *  the confirm CTA is disabled (never start a settle the wallet can't
+   *  complete). */
   blocked?: string;
-  /** Per-offer breakdown for a batch take. `ok:false` rows are unaffordable and
-   *  render muted, so the user can see the batch composition before confirming. */
-  items?: { pay: string; receive: string; ok: boolean }[];
-  /** When the full batch is blocked but a subset is affordable, offer to take
-   *  just that subset via a secondary CTA. */
-  partial?: { cta: string; onConfirm: () => Promise<void> };
-  onConfirm: () => Promise<void>;
+  cta: string;
+}
+
+export interface ConfirmItem {
+  /** Stable identity of the offer — what `onConfirm` receives. */
+  id: string;
+  pay: string;
+  receive: string;
+  /** The wallet can cover this row within the affordable set; `false` rows are
+   *  muted and marked "can't afford". */
+  ok: boolean;
+  /** This offer is your own (you chose to include it). */
+  mine?: boolean;
+  /** Whether the row starts checked. */
+  checked: boolean;
+}
+
+export interface ConfirmPayload extends ConfirmView {
+  title: string;
+  shielded?: boolean;
+  /** Per-offer breakdown for a batch take. Rendered as a checkbox list when
+   *  there is more than one — a single offer keeps the plain dialog. */
+  items?: ConfirmItem[];
+  /** Recompute the header/CTA for a checked subset. Absent for payloads with no
+   *  items, where the static `pay`/`receive`/`blocked`/`cta` stand. */
+  assess?: (selectedIds: string[]) => ConfirmView;
+  /** Receives the checked ids, in item order (empty when there are no items). */
+  onConfirm: (selectedIds: string[]) => Promise<void>;
 }
 
 export function ConfirmModal({ payload, onClose }: { payload: ConfirmPayload | null; onClose: () => void }) {
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState<string | null>(null);
+  const [checked, setChecked] = useState<Set<string>>(new Set());
 
-  const run = async (label: string, handler: () => Promise<void>) => {
+  // Re-seed for each dialog. Keyed on the payload object: a new take builds a
+  // new payload, and nothing mutates one in place.
+  useEffect(() => {
+    setChecked(new Set((payload?.items ?? []).filter((i) => i.checked).map((i) => i.id)));
+    setErr(null);
+  }, [payload]);
+
+  const items = payload?.items ?? [];
+  // Item order, not click order — the ids travel to the settlement, which pays
+  // the offers in the book's best-price-first order.
+  const selectedIds = useMemo(() => items.filter((i) => checked.has(i.id)).map((i) => i.id), [items, checked]);
+  const view: ConfirmView | null = payload
+    ? (payload.assess ? payload.assess(selectedIds) : payload)
+    : null;
+  const selectable = items.length > 1;
+  const nothingChecked = items.length > 0 && selectedIds.length === 0;
+
+  const run = async (label: string) => {
     if (!payload) return;
     const t0 = performance.now();
     dlog(`━━━ CONFIRM PRESSED: "${label}" ━━━`, {
       title: payload.title,
-      pay: `${payload.pay.amt} ${payload.pay.sym}`,
-      receive: `${payload.receive.amt} ${payload.receive.sym}`,
+      pay: `${view?.pay.amt} ${view?.pay.sym}`,
+      receive: `${view?.receive.amt} ${view?.receive.sym}`,
       shielded: payload.shielded,
+      selected: selectedIds.length || undefined,
     });
     setBusy(true);
     setErr(null);
     try {
-      await handler();
+      await payload.onConfirm(selectedIds);
       dlog(`✓✓✓ CONFIRM DONE: "${label}" (${(performance.now() - t0).toFixed(0)}ms) ✓✓✓`);
       onClose();
     } catch (e: any) {
@@ -57,55 +102,78 @@ export function ConfirmModal({ payload, onClose }: { payload: ConfirmPayload | n
     }
   };
 
+  const toggle = (id: string) => {
+    if (busy) return;
+    setChecked((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id); else next.add(id);
+      return next;
+    });
+  };
+
   return (
     <Modal open={!!payload} onClose={busy ? () => {} : onClose} width={440}>
-      {payload && (
+      {payload && view && (
         <>
           <ModalHead title={payload.title} onClose={busy ? () => {} : onClose} />
           <div style={{ padding: 16 }}>
             <div style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '14px 16px', borderRadius: 'var(--r-field)', background: 'var(--surface-2)', marginBottom: 8 }}>
-              <Coin sym={payload.pay.sym} size="sm" />
+              <Coin sym={view.pay.sym} size="sm" />
               <span style={{ display: 'flex', flexDirection: 'column' }}>
                 <span style={{ fontSize: 11.5, color: 'var(--ink-3)' }}>You pay</span>
-                <span className="zs-num" style={{ fontWeight: 700, fontSize: 15 }}>{payload.pay.amt} {payload.pay.sym}</span>
+                <span className="zs-num" style={{ fontWeight: 700, fontSize: 15 }}>{view.pay.amt} {view.pay.sym}</span>
               </span>
             </div>
             <div style={{ display: 'flex', justifyContent: 'center', margin: '-2px 0' }}><Icon.arrow style={{ color: 'var(--ink-3)', transform: 'rotate(90deg)' }} /></div>
             <div style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '14px 16px', borderRadius: 'var(--r-field)', background: 'var(--accent-soft)', border: '1px solid var(--accent-line)' }}>
-              <Coin sym={payload.receive.sym} size="sm" />
+              <Coin sym={view.receive.sym} size="sm" />
               <span style={{ display: 'flex', flexDirection: 'column' }}>
                 <span style={{ fontSize: 11.5, color: 'var(--ink-3)' }}>You receive</span>
-                <span className="zs-num" style={{ fontWeight: 700, fontSize: 15, color: 'var(--accent)' }}>{payload.receive.amt} {payload.receive.sym}</span>
+                <span className="zs-num" style={{ fontWeight: 700, fontSize: 15, color: 'var(--accent)' }}>{view.receive.amt} {view.receive.sym}</span>
               </span>
               {payload.shielded && <span className="zs-badge-shield" style={{ marginLeft: 'auto' }}><Icon.shield /> Shielded</span>}
             </div>
 
-            {payload.items && payload.items.length > 1 && (
-              <div style={{ marginTop: 12, border: '1px solid var(--line)', borderRadius: 'var(--r-field)', maxHeight: 168, overflowY: 'auto' }}>
-                {payload.items.map((it, i) => (
-                  <div key={i} style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '7px 12px', fontSize: 12.5, borderTop: i ? '1px solid var(--line)' : undefined, opacity: it.ok ? 1 : 0.5 }}>
-                    <span className="zs-num" style={{ color: 'var(--ink)' }}>{it.pay}</span>
-                    <Icon.arrow style={{ color: 'var(--ink-3)', width: 12, height: 12 }} />
-                    <span className="zs-num" style={{ color: 'var(--accent)' }}>{it.receive}</span>
-                    {!it.ok && <span style={{ marginLeft: 'auto', fontSize: 11, color: 'var(--neg)', fontWeight: 600 }}>can't afford</span>}
-                  </div>
-                ))}
-              </div>
+            {selectable && (
+              <>
+                <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginTop: 12, marginBottom: 6 }}>
+                  <span className="zs-tag">Offers in this take</span>
+                  <span style={{ fontSize: 11.5, color: 'var(--ink-3)' }}>{selectedIds.length} of {items.length} selected</span>
+                </div>
+                <div style={{ border: '1px solid var(--line)', borderRadius: 'var(--r-field)', maxHeight: 168, overflowY: 'auto' }}>
+                  {items.map((it, i) => {
+                    const on = checked.has(it.id);
+                    return (
+                      <label key={it.id} title={it.ok ? undefined : "The wallet can't cover this offer on top of the ones above it."}
+                        style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '7px 12px', fontSize: 12.5, borderTop: i ? '1px solid var(--line)' : undefined, opacity: on ? 1 : 0.55, cursor: busy ? 'default' : 'pointer' }}>
+                        <input type="checkbox" checked={on} disabled={busy} onChange={() => toggle(it.id)}
+                          style={{ accentColor: 'var(--accent)', width: 14, height: 14, flex: '0 0 auto', cursor: busy ? 'default' : 'pointer' }} />
+                        <span className="zs-num" style={{ color: 'var(--ink)' }}>{it.pay}</span>
+                        <Icon.arrow style={{ color: 'var(--ink-3)', width: 12, height: 12 }} />
+                        <span className="zs-num" style={{ color: 'var(--accent)' }}>{it.receive}</span>
+                        <span style={{ marginLeft: 'auto', display: 'inline-flex', alignItems: 'center', gap: 6 }}>
+                          {it.mine && <span className="zs-pill" style={{ padding: '1px 6px', fontSize: 9.5, fontWeight: 700, color: 'var(--accent)', background: 'var(--accent-soft)', borderColor: 'var(--accent-line)' }}>Yours</span>}
+                          {!it.ok && <span style={{ fontSize: 11, color: 'var(--neg)', fontWeight: 600 }}>can't afford</span>}
+                        </span>
+                      </label>
+                    );
+                  })}
+                </div>
+              </>
             )}
 
-            {(err ?? payload.blocked) && <div style={{ marginTop: 12, fontSize: 12.5, color: 'var(--neg)', lineHeight: 1.45, wordBreak: 'break-word' }}>{err ?? payload.blocked}</div>}
+            {(err ?? view.blocked) && <div style={{ marginTop: 12, fontSize: 12.5, color: 'var(--neg)', lineHeight: 1.45, wordBreak: 'break-word' }}>{err ?? view.blocked}</div>}
 
             <div style={{ display: 'flex', gap: 8, marginTop: 16 }}>
               <button className="zs-btn" style={{ flex: '0 0 auto', padding: '12px 16px' }} disabled={busy} onClick={onClose}>Cancel</button>
-              {payload.blocked && payload.partial ? (
-                <button className="zs-btn zs-btn--primary" style={{ flex: 1, justifyContent: 'center', padding: 12 }} disabled={busy} onClick={() => run(payload.partial!.cta, payload.partial!.onConfirm)}>
-                  {busy ? 'Settling…' : <><Icon.bolt /> {payload.partial.cta}</>}
-                </button>
-              ) : (
-                <button className="zs-btn zs-btn--primary" style={{ flex: 1, justifyContent: 'center', padding: 12, opacity: payload.blocked ? 0.5 : 1, cursor: payload.blocked ? 'not-allowed' : 'pointer' }} disabled={busy || !!payload.blocked} onClick={() => run(payload.cta, payload.onConfirm)}>
-                  {busy ? 'Settling…' : <><Icon.bolt /> {payload.cta}</>}
-                </button>
-              )}
+              {(() => {
+                const stop = !!view.blocked || nothingChecked;
+                return (
+                  <button className="zs-btn zs-btn--primary" style={{ flex: 1, justifyContent: 'center', padding: 12, opacity: stop ? 0.5 : 1, cursor: stop ? 'not-allowed' : 'pointer' }} disabled={busy || stop} onClick={() => run(view.cta)}>
+                    {busy ? 'Settling…' : <><Icon.bolt /> {view.cta}</>}
+                  </button>
+                );
+              })()}
             </div>
           </div>
         </>

--- a/templates/zswap-da/src/ui/DecisionModal.tsx
+++ b/templates/zswap-da/src/ui/DecisionModal.tsx
@@ -1,0 +1,54 @@
+// Generic "which of these do you want?" dialog. Unlike ConfirmModal it runs no
+// async action and reports no error: it only asks, hands the answer back and
+// closes — the flow that opened it decides what happens next.
+//
+// It exists because the take path had nowhere to ask. When the selection turned
+// out to contain your own offers the only reachable branch was the connect
+// modal, which explained nothing and settled nothing (issue 00003).
+
+import { Modal, ModalHead } from './Modal';
+
+export interface DecisionOption {
+  label: string;
+  /** `primary` is the accented CTA, `plain` the neutral button. At most one
+   *  primary — the dialog does not enforce it, the callers just don't. */
+  kind?: 'primary' | 'plain';
+  onPick: () => void;
+}
+
+export interface DecisionPayload {
+  title: string;
+  body: string;
+  options: DecisionOption[];
+}
+
+export function DecisionModal({ payload, onClose }: { payload: DecisionPayload | null; onClose: () => void }) {
+  return (
+    <Modal open={!!payload} onClose={onClose} width={420}>
+      {payload && (
+        <>
+          <ModalHead title={payload.title} onClose={onClose} />
+          <div style={{ padding: 16 }}>
+            <p style={{ fontSize: 13.5, color: 'var(--ink-2)', lineHeight: 1.55, margin: 0 }}>{payload.body}</p>
+            <div style={{ display: 'flex', gap: 8, marginTop: 16, flexWrap: 'wrap' }}>
+              {payload.options.map((opt, i) => (
+                <button
+                  key={i}
+                  className={opt.kind === 'primary' ? 'zs-btn zs-btn--primary' : 'zs-btn'}
+                  style={opt.kind === 'primary'
+                    ? { flex: 1, minWidth: 120, justifyContent: 'center', padding: 12 }
+                    : { flex: '0 0 auto', padding: '12px 16px' }}
+                  // Close first: every option ends this question, and the
+                  // handler may open the next dialog on top of it.
+                  onClick={() => { onClose(); opt.onPick(); }}
+                >
+                  {opt.label}
+                </button>
+              ))}
+            </div>
+          </div>
+        </>
+      )}
+    </Modal>
+  );
+}


### PR DESCRIPTION
Three fixes to `templates/zswap-da` that all fall out of the same root cause: the app's "is this offer mine?" record is per **browser**, not per **wallet**.

The reported symptom: with two wallets in one browser, clicking Take on a level containing an offer you made under the *other* wallet opened a blank "Connect a wallet" modal — a dead end, with a wallet already connected.

> **Breaking for existing browsers (accepted).** The old flat `zswap-da:my-offers` / `zswap-da:my-trades` values are **discarded** — see (A). No user-facing API or data outside `localStorage` is affected.

## (A) Local records are scoped by network + wallet

`zswap-da:my-offers` and `zswap-da:my-trades` were flat arrays shared by every wallet on the machine. They are now buckets keyed by `"<networkId>::<shieldedAddress>"`:

- New `src/state/scope.ts` — `buildScope(networkId, shieldedAddress)` plus the bucketed read/write helper.
- `myOffers.ts` / `myTrades.ts` gained `setActiveScope(scope)`, driven from `useZSwapApp` by the connected wallet. With no wallet the active scope is `null`: reads return nothing, writes are no-ops with a console warning.
- `isMine` is computed from the active scope only — never from another wallet's records. The order-book `orders` memo takes `walletScope` as an explicit input, because it computes `isMine` during render while the scope is installed from an effect; without that, one render would attribute rows to the previous wallet and `useMemo` would cache it.
- `MyTrades` shows a "Trades are kept per wallet — connect a wallet to see its trades." hint when nothing is connected.

### The localStorage change — breaking, and deliberately so

There is **no compatibility path for the pre-scoping flat arrays**. A record written before scoping carries no wallet, and attributing it to one means guessing; the app is alpha, so the stored values are simply dropped rather than carrying a `legacy` bucket, a migration, and a "which wallet was this?" caveat through the UI forever.

Concretely: `readBuckets` treats any stored value that is not a bucket object — the old flat array, or anything malformed — as an empty store, which the next write overwrites. Existing browsers therefore lose their `zswap-da:my-offers` and `zswap-da:my-trades` history on upgrade. Nothing on-chain or server-side is affected; these stores are a local convenience log. With no wallet connected, `isMine` is always false and My Trades is empty apart from the hint.

Mutations (`updateTradeStatus`, `removeTrade`, `clearTrades`) now stay strictly inside the active wallet's bucket — `listTrades()` is the only way a record reaches the UI, so an id the user can act on is always this wallet's, and searching every bucket would let one wallet rewrite another's history.

## (B) Taking your own offer is a question, not a dead end

`requestTakeMany`'s `if (orders.some(o => o.isMine)) { setConnectOpen(true); return; }` is gone — the take path no longer opens the connect modal at all. Own offers stay in the candidate set and the split happens after the blobs load, when ownership is actually knowable (the local record covers shielded offers; unshielded ones need the blob's sender):

- all yours → "This is your own offer. Take it anyway?" — **Cancel** / **Take anyway**
- mixed → "K of N selected offers are yours." — **Cancel** / **Skip mine** / **Include mine**

The chosen set continues into the normal confirm dialog. Cancel, ✕, Escape and backdrop all settle nothing. The single-offer path (`requestTake`) uses the same dialog instead of the old "you can't take your own offer" toast, and now honours the local record too, not just the sender match. Order-book levels containing your own offers carry a **Yours** pill.

New: `src/ui/DecisionModal.tsx` (generic title/body/buttons dialog) and `src/services/ownOffers.ts` (the pure partition/decision logic).

## (C) Per-offer checkboxes in the take dialog

A price level aggregates every offer at that price and used to be all-or-nothing. Every row in a multi-offer take now has a checkbox, and the totals, the affordability verdict and the CTA are recomputed from the checked set on each toggle. Only the checked offers are settled — still as **one merged transaction**, and history is still recorded per offer.

- Rows start checked except those the balance cannot cover. Affordability is an *aggregate* property (each offer can look affordable alone while the batch overspends), so the default is the best-price-first prefix that fits. When the wallet can afford nothing, everything starts checked instead — an empty dialog with a disabled CTA and no shortfall message explains nothing, and that is the same class of bug as the one this PR fixes.
- The old "Take affordable K of N" secondary button (`payload.partial`) is gone; the affordable prefix is now just the default checked set.
- CTA reads "Take K offers", or "Select an offer" (disabled) with nothing checked.
- Single-offer selections keep today's dialog — no checkbox list.

New pure helper `src/services/takeSelection.ts` (`summarize`, `affordableSelection`, `defaultSelection`). `takerBalance.ts` gained `sumLegs(perOffer)` so the leg-summing fold has one implementation instead of two; behaviour is unchanged.

### Internal API change: `ConfirmPayload`

`ConfirmPayload` (`src/ui/ConfirmModal.tsx`) changed shape: `items[]` are now `{ id, pay, receive, ok, mine?, checked }`, there is a new `assess(selectedIds)`, `onConfirm` takes the checked ids, and `partial` is removed. **This type is internal to `templates/zswap-da`** — no other template or package imports it, so nothing outside this directory is affected.

## Also in this PR

- Disconnecting the wallet while a decision or confirm dialog is open now closes both. Nothing could ever settle after a disconnect (`requireWallet()` throws and the error lands in the dialog), so this is the visible half of a guarantee that already held.
- `settle(ids)` lost its "if nothing is checked, take everything" fallback. An empty selection settles nothing — an unchecked offer must never be the thing that reaches the chain.

## Commits

| | |
|---|---|
| `3882920e` | fix(zswap-da): scope my-offers/my-trades by network::wallet |
| `49a7be9c` | fix(zswap-da): ask before taking your own offer instead of opening the connect modal |
| `e7ce2aa0` | feat(zswap-da): choose which offers of a ladder to take |
| `fd54a626` | fix(zswap-da): close take dialogs on wallet disconnect; never settle on an empty selection |
| `f42b1ca4` | refactor(zswap-da): drop pre-scoping localStorage compatibility (alpha, breaking) |

## Testing

- `bun test` in `templates/zswap-da`: **141 pass / 0 fail / 248 `expect()` calls across 9 files** (baseline before this work: 64 / 0 / 115 across 4 files). Five new files: `state/scope.test.ts`, `state/myOffers.test.ts`, `state/myTrades.test.ts`, `services/ownOffers.test.ts`, `services/takeSelection.test.ts` — covering scope key building, per-wallet isolation, the null-scope contract, malformed and pre-scoping stored values reading as empty, the own-offer partition/decision/labels, and the checked-subset arithmetic (totals, aggregate shortfall, CTA, default seeding, unknown ids, undecodable blobs).
- `bunx tsc -b`: exit 0. `bun run build` (including the `prebuild` Compact contract compile): green, ~10 s.
- Dev-server smoke against `https://preprod.api-zswap.zkdojo.com` with `VITE_MIDNIGHT_NETWORK_ID=preprod`, no wallet connected: the app loads, the pair list and the WBTC/WETH order book render, trade history loads, **zero console errors**, and My Trades shows the per-wallet hint.
- `git diff --stat` is 17 files, all under `templates/zswap-da/src/` — no dependency changes, no build artifacts, nothing outside the template.

**Pending:** the wallet-connected verification (two wallets in one browser; settling a 2-of-3 subset) needs live offers in the book, which preprod did not have during this work. It will be done in the browser on preprod once this and the companion `midnight-1` port PR are deployed.
