### PR TITLE
feat(zswap-da): show reference rate, offset and sponsorship threshold from /v1/quote and /v1/prices

### DIFF
--- a/templates/zswap-da/src/screens/Market.tsx
+++ b/templates/zswap-da/src/screens/Market.tsx
@@ -200,12 +200,16 @@ export function Market({ st, onStartOrder }: { st: ZSwapApp; onStartOrder?: () =
   const change24 = stats?.change24 ?? 0;
   const lastUp = change24 >= 0;
 
-  // —— reference price (GET /v1/prices) ——
+  // —— reference price (GET /v1/prices?tokens=…) ——
   // "1 base = r quote" at the node's reference prices, plus how far the book's
   // own mid sits from it. Null whenever either token has no market-backed price
   // (test tokens), in which case the header says "no reference" rather than
   // dressing up the demo price as a market.
-  const prices = usePrices(nonce);
+  //
+  // Only the selected pair's two colours are asked for (master plan §3a): the
+  // node never dumps its price table, and with no pair selected nothing is
+  // fetched at all.
+  const prices = usePrices([baseColor, quoteColor], nonce);
   const reference = useMemo(
     () => referenceRate(prices, baseColor, quoteColor),
     [prices, baseColor, quoteColor],

--- a/templates/zswap-da/src/screens/Market.tsx
+++ b/templates/zswap-da/src/screens/Market.tsx
@@ -12,6 +12,9 @@ import { Coin, Icon, isShielded } from '../ui/icons';
 import { api, type ChartHistoryRow, type ChartStats, type PairInfo } from '../services/api';
 import { shortToken } from '../utils';
 import { TokenChip } from '../ui/TokenChip';
+import { fmtAge, fmtOffsetPct } from '../state/format';
+import { referenceRate } from '../state/reference';
+import { usePrices } from '../state/usePrices';
 import type { Order, ZSwapApp } from '../state/useZSwapApp';
 
 type Side = 'ask' | 'bid';
@@ -34,9 +37,9 @@ function fmtQty(q: number): string {
   return parseFloat(q.toPrecision(3)).toString();
 }
 
-function Stat({ label, children, sub }: { label: string; children: React.ReactNode; sub?: string }) {
+function Stat({ label, children, sub, title }: { label: string; children: React.ReactNode; sub?: string; title?: string }) {
   return (
-    <div style={{ minWidth: 0 }}>
+    <div style={{ minWidth: 0 }} title={title}>
       <div className="zs-tag" style={{ marginBottom: 5 }}>{label}</div>
       <div className="zs-num" style={{ fontSize: 16, fontWeight: 700, letterSpacing: '-.02em', whiteSpace: 'nowrap' }}>{children}</div>
       {sub && <div className="zs-num" style={{ fontSize: 12, color: 'var(--ink-3)', whiteSpace: 'nowrap', marginTop: 2 }}>{sub}</div>}
@@ -197,6 +200,21 @@ export function Market({ st, onStartOrder }: { st: ZSwapApp; onStartOrder?: () =
   const change24 = stats?.change24 ?? 0;
   const lastUp = change24 >= 0;
 
+  // —— reference price (GET /v1/prices) ——
+  // "1 base = r quote" at the node's reference prices, plus how far the book's
+  // own mid sits from it. Null whenever either token has no market-backed price
+  // (test tokens), in which case the header says "no reference" rather than
+  // dressing up the demo price as a market.
+  const prices = usePrices(nonce);
+  const reference = useMemo(
+    () => referenceRate(prices, baseColor, quoteColor),
+    [prices, baseColor, quoteColor],
+  );
+  const referenceSub = reference
+    ? [reference.label, fmtAge(reference.updatedAt)].filter(Boolean).join(' · ')
+    : null;
+  const midVsReference = reference && mid > 0 ? fmtOffsetPct(mid, reference.rate) : null;
+
   // —— row selection: hover previews a cumulative range, click commits ——
   const [active, setActive] = useState<Record<string, boolean>>({});
   const [hover, setHover] = useState<{ side: Side; idx: number } | null>(null);
@@ -334,13 +352,31 @@ export function Market({ st, onStartOrder }: { st: ZSwapApp; onStartOrder?: () =
           </div>
         </div>
 
-        {pair && stats && (
+        {pair && (stats || reference) && (
           <div style={{ display: 'flex', gap: 30, flexWrap: 'wrap', alignItems: 'flex-start' }}>
-            <Stat label="Last price">{fmtPrice(stats.last)} <span style={{ fontSize: 12, color: 'var(--ink-3)', fontWeight: 600 }}>{quote}</span></Stat>
-            <Stat label="24h"><span style={{ color: lastUp ? 'var(--pos)' : 'var(--neg)' }}>{lastUp ? '+' : ''}{change24.toFixed(2)}%</span></Stat>
-            <Stat label="High">{fmtPrice(stats.high)}</Stat>
-            <Stat label="Low">{fmtPrice(stats.low)}</Stat>
-            <Stat label="Volume" sub={fmtQty(stats.volume_quote) + ' ' + quote}>{fmtQty(stats.volume_base)} <span style={{ fontSize: 12, color: 'var(--ink-3)', fontWeight: 600 }}>{base}</span></Stat>
+            {stats && <>
+              <Stat label="Last price">{fmtPrice(stats.last)} <span style={{ fontSize: 12, color: 'var(--ink-3)', fontWeight: 600 }}>{quote}</span></Stat>
+              <Stat label="24h"><span style={{ color: lastUp ? 'var(--pos)' : 'var(--neg)' }}>{lastUp ? '+' : ''}{change24.toFixed(2)}%</span></Stat>
+              <Stat label="High">{fmtPrice(stats.high)}</Stat>
+              <Stat label="Low">{fmtPrice(stats.low)}</Stat>
+              <Stat label="Volume" sub={fmtQty(stats.volume_quote) + ' ' + quote}>{fmtQty(stats.volume_base)} <span style={{ fontSize: 12, color: 'var(--ink-3)', fontWeight: 600 }}>{base}</span></Stat>
+            </>}
+            <Stat
+              label="Reference"
+              sub={referenceSub ?? undefined}
+              title={reference
+                ? `Reference price from GET /v1/prices (${reference.label})`
+                : `No market reference for this pair - at least one token is priced by the demo fallback`}
+            >
+              {reference
+                ? <>1 {base} = {fmtPrice(reference.rate)} <span style={{ fontSize: 12, color: 'var(--ink-3)', fontWeight: 600 }}>{quote}</span></>
+                : <span style={{ color: 'var(--ink-3)', fontWeight: 600 }}>no reference</span>}
+            </Stat>
+            <Stat label="Mid vs reference" title="How far the order book's mid price sits from the reference price">
+              {midVsReference
+                ? <span style={{ color: mid <= (reference?.rate ?? 0) ? 'var(--pos)' : 'var(--neg)' }}>{midVsReference}</span>
+                : <span style={{ color: 'var(--ink-3)', fontWeight: 600 }}>{reference ? 'no book' : 'no reference'}</span>}
+            </Stat>
             <Stat label="Asset ID"><TokenChip color={baseColor} knownTokens={st.knownTokens} size="sm" /></Stat>
           </div>
         )}

--- a/templates/zswap-da/src/screens/Swap.tsx
+++ b/templates/zswap-da/src/screens/Swap.tsx
@@ -17,6 +17,7 @@ import { TokenPicker } from '../ui/TokenPicker';
 import { api, type Quote } from '../services/api';
 import { log } from '../lib/log';
 import { fmtUsd, rateDisplay } from '../state/format';
+import { describeQuote } from '../state/reference';
 import type { KnownToken } from '../types';
 import type { OfferLeg } from '../services/makerOffer';
 import type { ZSwapApp } from '../state/useZSwapApp';
@@ -98,6 +99,10 @@ export function PlaceOrderForm({ st, compact, requestPayPicker, onPayPickerHandl
   const [posting, setPosting] = useState(false);
   const [postStatus, setPostStatus] = useState('');
   const [error, setError] = useState<string | null>(null);
+  // The node's machine code for the last failure. NOT_SPONSORED (422) is the
+  // one the maker can act on from here, so it gets the same "Apply best price"
+  // escape hatch as the pre-submit warning.
+  const [errorCode, setErrorCode] = useState<string | null>(null);
 
   // External "start the order flow" trigger → open the Pay-with picker once.
   useEffect(() => {
@@ -148,6 +153,7 @@ export function PlaceOrderForm({ st, compact, requestPayPicker, onPayPickerHandl
 
   const post = async () => {
     setError(null);
+    setErrorCode(null);
     if (!from || !to) return;
     if (!sameKind) { setError('Both tokens must be the same privacy kind (all shielded or all unshielded).'); return; }
     if (payAmt.trim() !== '' && payBig === null) { setError('Amounts are whole base units — no decimals or separators.'); return; }
@@ -174,7 +180,11 @@ export function PlaceOrderForm({ st, compact, requestPayPicker, onPayPickerHandl
     } catch (e: any) {
       const msg = e?.message ?? String(e);
       log.error('[create-offer] failed during', phase, e);
+      // ApiError.message IS the node's `reason` (see services/api.ts), so a
+      // 422 NOT_SPONSORED explains itself here verbatim - numbers included -
+      // instead of reading "Failed to submit offer".
       setError(msg);
+      setErrorCode(typeof e?.code === 'string' ? e.code : null);
     } finally {
       setPosting(false);
       setPostStatus('');
@@ -207,7 +217,10 @@ export function PlaceOrderForm({ st, compact, requestPayPicker, onPayPickerHandl
     else { label = bothShielded ? 'Create shielded order' : 'Create order'; action = post; }
   }
 
-  const dPct = quote?.discount != null ? quote.discount * 100 : null;
+  // Everything the reference price lets us say: the rate itself, the maker's
+  // offset from it, the sponsorship threshold, and where the price came from.
+  // Pure and unit-tested in state/reference.test.ts.
+  const ref = quote ? describeQuote(quote, from?.name ?? '', to?.name ?? '') : null;
 
   return (
     <>
@@ -232,23 +245,35 @@ export function PlaceOrderForm({ st, compact, requestPayPicker, onPayPickerHandl
               <>
                 <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', justifyContent: 'space-between', gap: '4px 14px', fontSize: 13 }}>
                   <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6, color: 'var(--ink-2)', whiteSpace: 'nowrap' }}><Icon.shield style={{ color: 'var(--accent)', flex: '0 0 auto' }} /> Your rate · 1 {from!.name} = <RateInline value={quote.implied_rate ?? 0} /> {to!.name}</span>
-                  {dPct != null && <span className="zs-num" style={{ color: dPct >= 0 ? 'var(--pos)' : 'var(--neg)', whiteSpace: 'nowrap', fontWeight: 600 }}>{dPct >= 0 ? '−' : '+'}{Math.abs(dPct).toFixed(1)}% vs market</span>}
+                  {ref?.offset && <span className="zs-num" style={{ color: ref.offsetBelow ? 'var(--pos)' : 'var(--neg)', whiteSpace: 'nowrap', fontWeight: 600 }}>{ref.offset} vs reference</span>}
                 </div>
-                {!autoPrice && <div style={{ fontSize: 11.5, color: 'var(--ink-3)', whiteSpace: 'nowrap' }}>Market · 1 {from!.name} = <RateInline value={quote.market_rate} /> {to!.name}</div>}
+                {/* The reference rate is shown in BOTH price modes now: in auto
+                    mode the maker still has to see what the price is anchored to
+                    and how far below it the sponsorship threshold sits. */}
+                {ref?.referenceRate != null && (
+                  <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: '2px 12px', fontSize: 11.5, color: 'var(--ink-3)' }}>
+                    <span style={{ whiteSpace: 'nowrap' }}>Reference · 1 {from!.name} = <RateInline value={ref.referenceRate} /> {to!.name}</span>
+                    {ref.thresholdText && <span style={{ whiteSpace: 'nowrap' }}>{ref.thresholdText}</span>}
+                  </div>
+                )}
+                {ref?.sourceText && <div style={{ fontSize: 11.5, color: 'var(--ink-3)', lineHeight: 1.4 }}>{ref.sourceText}</div>}
 
                 {quote.sponsored ? (
                   <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '9px 11px', borderRadius: 11, background: 'var(--pos-soft)', border: '1px solid color-mix(in srgb, var(--pos) 25%, transparent)' }}>
                     <Icon.shield style={{ color: 'var(--pos)', flex: '0 0 auto' }} />
                     <span style={{ fontSize: 12, color: 'var(--ink-2)', lineHeight: 1.4 }}><b style={{ color: 'var(--pos)' }}>Celestia fee sponsored.</b> Good trades get filled fast.</span>
                   </div>
-                ) : (
+                ) : ref?.showNotSponsored ? (
+                  // Suppressed for demo-priced pairs: the batcher sponsors
+                  // unpriced tokens (BATCHER_SPONSOR_UNPRICED=allow), so
+                  // warning about a test-token trade would be a lie.
                   <div style={{ display: 'flex', alignItems: 'flex-start', gap: 8, padding: '9px 11px', borderRadius: 11, background: 'var(--warn-soft)', border: '1px solid color-mix(in srgb, var(--warn) 22%, transparent)' }}>
                     <span style={{ color: 'var(--warn)', fontWeight: 800, flex: '0 0 auto', lineHeight: 1.3 }}>!</span>
-                    <div style={{ fontSize: 12, color: 'var(--ink-2)', lineHeight: 1.45 }}>This price won't be sponsored to Celestia.
+                    <div style={{ fontSize: 12, color: 'var(--ink-2)', lineHeight: 1.45 }}>{ref.notSponsoredText ?? "This price won't be sponsored to Celestia."}
                       <button onClick={() => setAutoPrice(true)} style={{ marginLeft: 6, border: 'none', background: 'transparent', color: 'var(--accent)', fontWeight: 700, fontSize: 12, cursor: 'pointer', padding: 0, textDecoration: 'underline' }}>Apply best price</button>
                     </div>
                   </div>
-                )}
+                ) : null}
               </>
             )}
           </div>
@@ -259,7 +284,13 @@ export function PlaceOrderForm({ st, compact, requestPayPicker, onPayPickerHandl
           {st.wallet && bothShielded && payBig !== null && payBig > 0n && recvBig !== null && recvBig > 0n && <Icon.shield />} {label}
         </button>
 
-        {error && <div style={{ fontSize: 12.5, color: 'var(--neg)', lineHeight: 1.45, wordBreak: 'break-word', marginTop: 4 }}>{error}</div>}
+        {error && (
+          <div style={{ fontSize: 12.5, color: 'var(--neg)', lineHeight: 1.45, wordBreak: 'break-word', marginTop: 4 }}>{error}
+            {errorCode === 'NOT_SPONSORED' && (
+              <button onClick={() => { setAutoPrice(true); setError(null); setErrorCode(null); }} style={{ marginLeft: 6, border: 'none', background: 'transparent', color: 'var(--accent)', fontWeight: 700, fontSize: 12.5, cursor: 'pointer', padding: 0, textDecoration: 'underline' }}>Apply best price</button>
+            )}
+          </div>
+        )}
 
         {bothSel && (
           <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 7, marginTop: compact ? 8 : 12, fontSize: 12, color: 'var(--ink-3)' }}>

--- a/templates/zswap-da/src/services/api.test.ts
+++ b/templates/zswap-da/src/services/api.test.ts
@@ -71,10 +71,15 @@ const QUOTE_FIXTURE = {
 };
 
 describe('getPrices', () => {
-  test('parses the §3 body and hits /v1/prices', async () => {
+  const WBTC = 'e7'.repeat(32);
+  const WETH = 'fd'.repeat(32);
+
+  test('parses the §3 body and asks /v1/prices for exactly the colours given', async () => {
     const calls = serve(200, PRICES_FIXTURE);
-    const p: PricesResponse = await api.getPrices();
-    expect(calls[0]).toContain('/v1/prices');
+    const p: PricesResponse = await api.getPrices([WBTC, WETH]);
+    const url = new URL(calls[0]);
+    expect(url.pathname.endsWith('/v1/prices')).toBe(true);
+    expect(url.searchParams.get('tokens')).toBe(`${WBTC},${WETH}`);
     expect(p.sponsor_discount).toBe(0.025);
     expect(p.feed?.provider).toBe('coingecko');
     expect(p.assets).toHaveLength(2);
@@ -82,9 +87,41 @@ describe('getPrices', () => {
     expect(p.tokens[1].source).toBe('fallback');
   });
 
+  test('colours are lower-cased and de-duplicated in the query', async () => {
+    const calls = serve(200, PRICES_FIXTURE);
+    await api.getPrices([WBTC.toUpperCase(), ` ${WBTC} `, WETH]);
+    expect(new URL(calls[0]).searchParams.get('tokens')).toBe(`${WBTC},${WETH}`);
+  });
+
+  // §3a: `tokens` is REQUIRED and the node answers 400 without it. Never send
+  // the unfiltered form — refuse it here, with a message that says why.
+  test('an empty list is refused client-side, with no request', async () => {
+    const calls = serve(200, PRICES_FIXTURE);
+    await expect(api.getPrices([])).rejects.toThrow('at least one token color');
+    await expect(api.getPrices(['', '  '])).rejects.toThrow('at least one token color');
+    expect(calls).toHaveLength(0);
+  });
+
+  test('more than 50 colours is refused client-side, with no request', async () => {
+    const calls = serve(200, PRICES_FIXTURE);
+    const many = Array.from({ length: 51 }, (_, i) => i.toString(16).padStart(64, '0'));
+    expect(many).toHaveLength(51);
+    await expect(api.getPrices(many)).rejects.toThrow('at most 50 token colors');
+    expect(calls).toHaveLength(0);
+  });
+
   test('a node without the route throws ApiError 404, not a parse crash', async () => {
     serve(404, { error: 'NOT_FOUND', reason: 'Route GET /v1/prices not found' });
-    await expect(api.getPrices()).rejects.toThrow('Route GET /v1/prices not found');
+    await expect(api.getPrices([WBTC])).rejects.toThrow('Route GET /v1/prices not found');
+  });
+
+  test('a rejected query throws ApiError 400 with the node reason', async () => {
+    serve(400, { error: 'VALIDATION', reason: 'tokens must be 1-50 64-hex colors' });
+    const err = await api.getPrices([WBTC]).catch((e) => e);
+    expect(err).toBeInstanceOf(ApiError);
+    expect(err.status).toBe(400);
+    expect(err.code).toBe('VALIDATION');
+    expect(err.message).toBe('tokens must be 1-50 64-hex colors');
   });
 });
 

--- a/templates/zswap-da/src/services/api.test.ts
+++ b/templates/zswap-da/src/services/api.test.ts
@@ -1,0 +1,162 @@
+// api.ts against the master-plan §3 fixtures (project 00005).
+//
+// What is actually being pinned here is the ERROR path: a 422 NOT_SPONSORED
+// must reach the Swap screen as the node's own `reason` (with the numbers on
+// `.data`), not as a generic "Failed to submit offer". The happy paths double
+// as a parse check for the new /v1/prices and /v1/quote fields.
+//
+// api.ts imports ../config, which reads `window` and `location` at module load,
+// so the browser globals are stubbed before the dynamic import below. Bun's
+// test runtime has no DOM.
+import { afterEach, describe, expect, test } from 'bun:test';
+
+(globalThis as any).window ??= {};
+(globalThis as any).location ??= { hostname: 'localhost' };
+
+const { api, ApiError } = await import('./api');
+import type { PricesResponse, Quote } from './api';
+
+const realFetch = globalThis.fetch;
+afterEach(() => { globalThis.fetch = realFetch; });
+
+/** Serve one JSON body for every request, and record the URL that was asked for. */
+function serve(status: number, body: unknown) {
+  const calls: string[] = [];
+  globalThis.fetch = (async (input: any) => {
+    calls.push(String(input));
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }) as typeof fetch;
+  return calls;
+}
+
+// Master plan §3, verbatim shapes.
+const PRICES_FIXTURE = {
+  sponsor_discount: 0.025,
+  feed: {
+    provider: 'coingecko',
+    last_run_at: '2026-09-03T00:00:00.000Z',
+    last_ok_at: '2026-09-03T00:00:04.000Z',
+    last_error: null,
+  },
+  assets: [
+    { asset_id: 'bitcoin', price_usd: '77387', source: 'feed', provider_updated_at: '2026-09-02T16:25:50.000Z', updated_at: '2026-09-03T00:00:04.000Z' },
+    { asset_id: 'usdm', price_usd: '1', source: 'fixed', provider_updated_at: null, updated_at: '2026-09-03T00:00:04.000Z' },
+  ],
+  tokens: [
+    { token_color: 'e7'.repeat(32), name: 'WBTC', kind: 'shielded', decimals: 0, asset_id: 'bitcoin', price_usd: '77387', source: 'feed', updated_at: '2026-09-03T00:00:04.000Z' },
+    { token_color: 'aa'.repeat(32), name: 'TESTTOKENA', kind: 'shielded', decimals: 0, asset_id: null, price_usd: '13.02', source: 'fallback', updated_at: '2026-09-01T10:00:00.000Z' },
+  ],
+};
+
+const QUOTE_FIXTURE = {
+  from_token: 'e7'.repeat(32),
+  to_token: 'fd'.repeat(32),
+  from_amount: '1000',
+  market_rate: 32.336,
+  suggested_to_amount: '31527',
+  to_amount: '31527',
+  implied_rate: 31.527,
+  discount: 0.025,
+  sponsored: true,
+  from_usd: 77387000,
+  to_usd: 75452325,
+  source: 'token-prices',
+  sponsor_discount: 0.025,
+  from_source: 'feed',
+  to_source: 'feed',
+  prices_updated_at: '2026-09-03T00:00:04.000Z',
+};
+
+describe('getPrices', () => {
+  test('parses the §3 body and hits /v1/prices', async () => {
+    const calls = serve(200, PRICES_FIXTURE);
+    const p: PricesResponse = await api.getPrices();
+    expect(calls[0]).toContain('/v1/prices');
+    expect(p.sponsor_discount).toBe(0.025);
+    expect(p.feed?.provider).toBe('coingecko');
+    expect(p.assets).toHaveLength(2);
+    expect(p.tokens[0].price_usd).toBe('77387'); // stays a string
+    expect(p.tokens[1].source).toBe('fallback');
+  });
+
+  test('a node without the route throws ApiError 404, not a parse crash', async () => {
+    serve(404, { error: 'NOT_FOUND', reason: 'Route GET /v1/prices not found' });
+    await expect(api.getPrices()).rejects.toThrow('Route GET /v1/prices not found');
+  });
+});
+
+describe('getQuote', () => {
+  test('carries the new reference fields through', async () => {
+    const calls = serve(200, QUOTE_FIXTURE);
+    const q: Quote = await api.getQuote('e7'.repeat(32), 'fd'.repeat(32), '1000');
+    expect(calls[0]).toContain('/v1/quote?');
+    expect(q.sponsor_discount).toBe(0.025);
+    expect(q.from_source).toBe('feed');
+    expect(q.to_source).toBe('feed');
+    expect(q.prices_updated_at).toBe('2026-09-03T00:00:04.000Z');
+    expect(q.source).toBe('token-prices');
+  });
+
+  test('an older node without them still parses (fields undefined)', async () => {
+    const { sponsor_discount, from_source, to_source, prices_updated_at, ...legacy } = QUOTE_FIXTURE;
+    serve(200, legacy);
+    const q = await api.getQuote('e7'.repeat(32), 'fd'.repeat(32), '1000');
+    expect(q.market_rate).toBe(32.336);
+    expect(q.sponsor_discount).toBeUndefined();
+    expect(q.from_source).toBeUndefined();
+  });
+
+  test('422 surfaces the node reason and keeps the numbers', async () => {
+    serve(422, {
+      error: 'NOT_SPONSORED',
+      reason: 'wants 1.0% below reference, sponsorship needs ≥ 2.5%',
+      give_usd: 30656.1,
+      want_usd: 30349.5,
+      implied_discount: 0.01,
+      sponsor_discount: 0.025,
+    });
+    const err = await api.getQuote('e7'.repeat(32), 'fd'.repeat(32), '1000', '31000').catch((e) => e);
+    expect(err).toBeInstanceOf(ApiError);
+    expect(err.status).toBe(422);
+    expect(err.code).toBe('NOT_SPONSORED');
+    expect(err.message).toBe('wants 1.0% below reference, sponsorship needs ≥ 2.5%');
+    expect(err.data.implied_discount).toBe(0.01);
+  });
+
+  test('404 UNKNOWN_TOKEN keeps its actionable message', async () => {
+    serve(404, { error: 'UNKNOWN_TOKEN', reason: 'token not registered', token: 'aa' });
+    const err = await api.getQuote('e7'.repeat(32), 'aa', '1000').catch((e) => e);
+    expect(err.code).toBe('UNKNOWN_TOKEN');
+  });
+});
+
+describe('submitSwapOffer', () => {
+  test('422 NOT_SPONSORED reaches the caller as the node reason, not "Failed to submit offer"', async () => {
+    serve(422, {
+      error: 'NOT_SPONSORED',
+      reason: 'wants 1.0% below reference, sponsorship needs ≥ 2.5%',
+      give_usd: 30656.1,
+      want_usd: 30349.5,
+      implied_discount: 0.01,
+      sponsor_discount: 0.025,
+    });
+    const err = await api.submitSwapOffer('swapoffer1fixture').catch((e) => e);
+    expect(err).toBeInstanceOf(ApiError);
+    expect(err.code).toBe('NOT_SPONSORED');
+    // This is the string the Swap error area renders verbatim (createOffer
+    // rethrows anything that is not a duplicate / ROOT_UNKNOWN).
+    expect(err.message).toBe('wants 1.0% below reference, sponsorship needs ≥ 2.5%');
+    expect(err.data.sponsor_discount).toBe(0.025);
+    expect(err.status).toBe(422);
+  });
+
+  test('a body with no reason still falls back to a readable message', async () => {
+    serve(500, null);
+    const err = await api.submitSwapOffer('swapoffer1fixture').catch((e) => e);
+    expect(err.message).toBe('Failed to submit offer');
+    expect(err.code).toBe('HTTP_500');
+  });
+});

--- a/templates/zswap-da/src/services/api.ts
+++ b/templates/zswap-da/src/services/api.ts
@@ -7,6 +7,9 @@ import type {
 } from '../types';
 import { API_BASE, BATCHER_URL, BATCHER_TARGET } from '../config';
 import { dlog, timed } from '../debug';
+import type { PriceSource } from '../state/format';
+
+export type { PriceSource };
 
 /** Every offer route lives under /v1 with MIP-0006 vocabulary. */
 const V1 = `${API_BASE}/v1`;
@@ -85,6 +88,61 @@ export interface Quote {
   sponsored: boolean;
   from_usd: number;
   to_usd: number | null;
+  // ── reference-price fields (kernel 00005 part A) ──────────────────────────
+  // OPTIONAL ON PURPOSE: a node that predates the price service (preprod today,
+  // and every stack the midnight-1 port runs against until it is redeployed)
+  // answers without them. Typing them as required would compile a lie and the
+  // UI would read `undefined.toFixed()`. Every consumer must degrade to "no
+  // reference known" rather than invent a number.
+  /** Sponsorship threshold as a fraction, e.g. 0.025 = 2.5% below reference. */
+  sponsor_discount?: number;
+  /** Where the price of the token being paid came from. */
+  from_source?: PriceSource;
+  /** Where the price of the token being received came from. */
+  to_source?: PriceSource;
+  /** Older of the two token price timestamps; null when either side is demo. */
+  prices_updated_at?: string | null;
+  /** Pre-existing top-level field: 'token-prices' | 'demo-fallback'. */
+  source?: string;
+}
+
+/** One row of `GET /v1/prices.assets` — a USD price per coin of a market asset. */
+export interface AssetPrice {
+  asset_id: string;
+  /** Decimal STRING (NUMERIC on the wire) — never parse it for money maths. */
+  price_usd: string;
+  source: 'feed' | 'seed' | 'fixed';
+  provider_updated_at: string | null;
+  updated_at: string;
+}
+
+/** One row of `GET /v1/prices.tokens` — USD per BASE UNIT of a known token. */
+export interface TokenPrice {
+  token_color: string;
+  name: string;
+  kind: 'shielded' | 'unshielded';
+  decimals: number;
+  asset_id: string | null;
+  price_usd: string;
+  source: PriceSource;
+  updated_at: string;
+}
+
+/** `GET /v1/prices.feed` — the price-feed process's last run. All-null when it
+ *  has never run (a stack serving only the seeded prices). */
+export interface PriceFeedStatus {
+  provider: string;
+  last_run_at: string | null;
+  last_ok_at: string | null;
+  last_error: string | null;
+}
+
+/** `GET /v1/prices` (master plan §3). */
+export interface PricesResponse {
+  sponsor_discount: number;
+  feed: PriceFeedStatus | null;
+  assets: AssetPrice[];
+  tokens: TokenPrice[];
 }
 
 // NOTE: there is no /v1/chart/depth endpoint — the node serves only
@@ -169,7 +227,11 @@ export const api = {
    * The offer only appears in `GET /v1/offers` after the Celestia round-trip
    * (seconds to ~a minute), so poll status until it leaves `not_found`.
    *
-   * Throws ApiError. Notable codes: `DUPLICATE_OFFER` (409, carries the existing
+   * Throws ApiError. `NOT_SPONSORED` (422, kernel 00005 part B) carries the
+   * node's `reason` as the error message plus `give_usd` / `want_usd` /
+   * `implied_discount` / `sponsor_discount` on `.data`; createOffer rethrows it
+   * untouched so the Swap error area shows the reason verbatim.
+   * Other notable codes: `DUPLICATE_OFFER` (409, carries the existing
    * `offerId` + `status`) and `DUPLICATE_MARKERS` (409, carries `activeOfferId`
    * of the live offer that owns the same declared markers, plus `offerId` for this
    * attempt) — both are not failures from the user's point of view. Everything in
@@ -252,6 +314,12 @@ export const api = {
     // The node no longer fabricates a rate for tokens it doesn't know:
     // 404 UNKNOWN_TOKEN (not in /v1/known-tokens), 400 VALIDATION (malformed
     // color). Give both a message a user can act on.
+    //
+    // Everything else — including 422 NOT_SPONSORED — falls through to parse(),
+    // which builds an ApiError whose `.message` IS the server's `reason` and
+    // keeps the numbers (`give_usd`, `want_usd`, `implied_discount`,
+    // `sponsor_discount`) on `.data`. That is what the Swap error area renders,
+    // so a refusal explains itself instead of reading "Request failed".
     if (res.status === 404 || res.status === 400) {
       const body = await res.json().catch(() => null);
       if (body?.error === 'UNKNOWN_TOKEN') {
@@ -260,6 +328,19 @@ export const api = {
       throw new ApiError(res.status, body, 'That token pair is not quotable');
     }
     return parse(res, 'Failed to fetch quote');
+  },
+
+  /**
+   * Reference prices: the sponsorship threshold, the price-feed's last run,
+   * every market asset and every priced known token (master plan §3).
+   *
+   * Prices are decimal STRINGS per base unit. Throws ApiError — a node that
+   * predates the price service answers 404, which callers treat as "no
+   * reference available" rather than as an error to show.
+   */
+  getPrices: async (): Promise<PricesResponse> => {
+    const res = await fetch(`${V1}/prices`);
+    return parse(res, 'Failed to fetch prices');
   },
 
   getChartStats: async (base: string, quote: string): Promise<ChartStats> => {

--- a/templates/zswap-da/src/services/api.ts
+++ b/templates/zswap-da/src/services/api.ts
@@ -137,12 +137,31 @@ export interface PriceFeedStatus {
   last_error: string | null;
 }
 
-/** `GET /v1/prices` (master plan §3). */
+/** `GET /v1/prices?tokens=…` (master plan §3, filtered per §3a). Holds only the
+ *  requested colours that resolve to a price, and the assets they reference. */
 export interface PricesResponse {
   sponsor_discount: number;
   feed: PriceFeedStatus | null;
   assets: AssetPrice[];
   tokens: TokenPrice[];
+}
+
+/** The node's cap on `GET /v1/prices?tokens=` (master plan §3a: 1–50). */
+export const MAX_PRICE_TOKENS = 50;
+
+/**
+ * Colours as `/v1/prices` wants them: trimmed, lower-cased, de-duplicated,
+ * empties dropped, input order kept. Exported so a caller can build the same
+ * list it will be asked about (see state/usePrices.ts, which sorts it into a
+ * cache key).
+ */
+export function normalizeColors(tokens: readonly (string | null | undefined)[]): string[] {
+  const out: string[] = [];
+  for (const t of tokens) {
+    const c = (t ?? '').trim().toLowerCase();
+    if (c && !out.includes(c)) out.push(c);
+  }
+  return out;
 }
 
 // NOTE: there is no /v1/chart/depth endpoint — the node serves only
@@ -331,15 +350,36 @@ export const api = {
   },
 
   /**
-   * Reference prices: the sponsorship threshold, the price-feed's last run,
-   * every market asset and every priced known token (master plan §3).
+   * Reference prices for the colours asked for — a PER-PAIR lookup, never a
+   * dump of the price table (master plan §3a, Q-11).
+   *
+   * `tokens` is REQUIRED by the node: 1–50 lower-case 64-hex colours, comma
+   * separated; without it, or malformed, it answers `400 VALIDATION`. The list
+   * is lower-cased and deduplicated here, and an empty list is refused before
+   * any request goes out — an unfiltered call would only ever earn a 400 and
+   * would not tell the caller why.
+   *
+   * The response carries only the requested colours that resolve to a price
+   * (an unknown colour is silently absent, not an error) and the assets those
+   * tokens reference; `sponsor_discount` and `feed` are always present.
    *
    * Prices are decimal STRINGS per base unit. Throws ApiError — a node that
-   * predates the price service answers 404, which callers treat as "no
-   * reference available" rather than as an error to show.
+   * predates the price service answers 404, and a node that rejects the query
+   * answers 400; callers treat both as "no reference available" rather than as
+   * an error to show.
    */
-  getPrices: async (): Promise<PricesResponse> => {
-    const res = await fetch(`${V1}/prices`);
+  getPrices: async (tokens: readonly string[]): Promise<PricesResponse> => {
+    const wanted = normalizeColors(tokens);
+    if (wanted.length === 0) {
+      throw new Error('getPrices needs at least one token color');
+    }
+    if (wanted.length > MAX_PRICE_TOKENS) {
+      throw new Error(
+        `getPrices takes at most ${MAX_PRICE_TOKENS} token colors, got ${wanted.length}`,
+      );
+    }
+    const p = new URLSearchParams({ tokens: wanted.join(',') });
+    const res = await fetch(`${V1}/prices?${p.toString()}`);
     return parse(res, 'Failed to fetch prices');
   },
 

--- a/templates/zswap-da/src/state/format.test.ts
+++ b/templates/zswap-da/src/state/format.test.ts
@@ -1,0 +1,85 @@
+// Reference-price formatters (project 00005). Pure string maths — the point of
+// these tests is that the UI never prints a number it does not have, and that
+// the sign convention ("−" = below reference = the good side for a taker) is
+// the same one the rest of the Swap screen already uses.
+import { describe, expect, test } from 'bun:test';
+import { fmtAge, fmtOffsetPct, isMarketSource, pct1 } from './format';
+
+const MINUS = '−'; // U+2212, not an ASCII hyphen
+
+describe('fmtOffsetPct', () => {
+  test('below the reference reads as a negative percent', () => {
+    expect(fmtOffsetPct(0.975, 1)).toBe(`${MINUS}2.5%`);
+    expect(fmtOffsetPct(31.5, 32)).toBe(`${MINUS}1.6%`);
+  });
+
+  test('above the reference reads as a positive percent', () => {
+    expect(fmtOffsetPct(1.012, 1)).toBe('+1.2%');
+  });
+
+  test('exactly at the reference has no sign', () => {
+    expect(fmtOffsetPct(32, 32)).toBe('0.0%');
+    // −0 must not surface as "−0.0%"
+    expect(fmtOffsetPct(0.999999, 1)).toBe('0.0%');
+  });
+
+  test('rounds to one decimal', () => {
+    expect(fmtOffsetPct(0.98999, 1)).toBe(`${MINUS}1.0%`);
+    expect(fmtOffsetPct(1.0449, 1)).toBe('+4.5%');
+  });
+
+  test('returns null rather than inventing an offset', () => {
+    expect(fmtOffsetPct(null, 1)).toBeNull();
+    expect(fmtOffsetPct(1, null)).toBeNull();
+    expect(fmtOffsetPct(undefined, undefined)).toBeNull();
+    expect(fmtOffsetPct(1, 0)).toBeNull();
+    expect(fmtOffsetPct(NaN, 1)).toBeNull();
+    expect(fmtOffsetPct(1, Infinity)).toBeNull();
+  });
+});
+
+describe('fmtAge', () => {
+  const now = Date.parse('2026-09-02T12:00:00.000Z');
+  const ago = (ms: number) => new Date(now - ms).toISOString();
+
+  test('buckets', () => {
+    expect(fmtAge(ago(5_000), now)).toBe('just now');
+    expect(fmtAge(ago(59_000), now)).toBe('just now');
+    expect(fmtAge(ago(60_000), now)).toBe('1 min ago');
+    expect(fmtAge(ago(45 * 60_000), now)).toBe('45 min ago');
+    expect(fmtAge(ago(3 * 3_600_000), now)).toBe('3 h ago');
+    expect(fmtAge(ago(47 * 3_600_000), now)).toBe('47 h ago');
+    expect(fmtAge(ago(48 * 3_600_000), now)).toBe('2 d ago');
+    expect(fmtAge(ago(9 * 86_400_000), now)).toBe('9 d ago');
+  });
+
+  test('a future timestamp (clock skew) is not negative', () => {
+    expect(fmtAge(new Date(now + 60_000).toISOString(), now)).toBe('just now');
+  });
+
+  test('null for missing or unparseable input', () => {
+    expect(fmtAge(null, now)).toBeNull();
+    expect(fmtAge(undefined, now)).toBeNull();
+    expect(fmtAge('', now)).toBeNull();
+    expect(fmtAge('not a date', now)).toBeNull();
+  });
+});
+
+describe('isMarketSource', () => {
+  test('real reference prices', () => {
+    for (const s of ['feed', 'seed', 'fixed', 'manual']) expect(isMarketSource(s)).toBe(true);
+  });
+  test('the demo price is not a market', () => {
+    for (const s of ['fallback', 'demo-fallback', '', 'nonsense']) expect(isMarketSource(s)).toBe(false);
+    expect(isMarketSource(null)).toBe(false);
+    expect(isMarketSource(undefined)).toBe(false);
+  });
+});
+
+describe('pct1', () => {
+  test('fraction in, percent out', () => {
+    expect(pct1(0.025)).toBe('2.5');
+    expect(pct1(0.01)).toBe('1.0');
+    expect(pct1(0)).toBe('0.0');
+  });
+});

--- a/templates/zswap-da/src/state/format.ts
+++ b/templates/zswap-da/src/state/format.ts
@@ -47,3 +47,63 @@ export function fmtBalance(amount: string | number | null | undefined): string {
   if (!isFinite(n)) return String(amount);
   return fmt(n, n >= 1000 ? 2 : n === Math.floor(n) ? 0 : 4);
 }
+
+// ── Reference-price helpers (00005) ───────────────────────────────────────────
+// The node publishes a reference (market) rate, the source it came from and how
+// old it is; the UI has to say all three without ever inventing a number. These
+// stay pure so they can be unit-tested without React.
+
+/** Price sources the node reports for a token, in `/v1/quote` and `/v1/prices`.
+ *  `fallback`/`demo-fallback` are the deterministic demo price — not a market. */
+export type PriceSource = 'feed' | 'seed' | 'fixed' | 'manual' | 'fallback' | 'demo-fallback';
+
+/** True when a source is backed by a real reference price rather than the demo
+ *  hash price. `fixed` (a $1 peg) and `manual` (an operator override) count. */
+export function isMarketSource(s: string | null | undefined): boolean {
+  return s === 'feed' || s === 'seed' || s === 'fixed' || s === 'manual';
+}
+
+/** A percentage with one decimal, e.g. 0.025 → "2.5". Fractions in, percent out. */
+export function pct1(fraction: number): string {
+  return (fraction * 100).toFixed(1);
+}
+
+/**
+ * Signed offset of a price from the reference, `implied / market − 1`, as a
+ * display string: "−2.5%" (below reference — the good side for a taker) or
+ * "+1.2%". Uses U+2212 MINUS, matching the rest of the UI.
+ *
+ * Returns null when either side is missing or the reference is zero — the
+ * caller must then render nothing rather than a fabricated 0%.
+ */
+export function fmtOffsetPct(
+  implied: number | null | undefined,
+  market: number | null | undefined,
+): string | null {
+  if (implied == null || market == null) return null;
+  if (!isFinite(implied) || !isFinite(market) || market === 0) return null;
+  const pct = (implied / market - 1) * 100;
+  if (!isFinite(pct)) return null;
+  const rounded = Number(pct.toFixed(1));
+  if (rounded === 0) return '0.0%';
+  return (rounded < 0 ? '−' : '+') + Math.abs(rounded).toFixed(1) + '%';
+}
+
+/**
+ * How old a timestamp is, in the coarse buckets a price age needs:
+ * "just now" < 1 min, "12 min ago", "3 h ago" (< 48 h), then "5 d ago".
+ * Future timestamps (clock skew between node and browser) read "just now".
+ * Returns null for a missing or unparseable timestamp.
+ */
+export function fmtAge(iso: string | null | undefined, now: number = Date.now()): string | null {
+  if (!iso) return null;
+  const t = Date.parse(iso);
+  if (!isFinite(t)) return null;
+  const ms = now - t;
+  if (ms < 60_000) return 'just now';
+  const min = Math.floor(ms / 60_000);
+  if (min < 60) return `${min} min ago`;
+  const h = Math.floor(ms / 3_600_000);
+  if (h < 48) return `${h} h ago`;
+  return `${Math.floor(ms / 86_400_000)} d ago`;
+}

--- a/templates/zswap-da/src/state/reference.test.ts
+++ b/templates/zswap-da/src/state/reference.test.ts
@@ -1,0 +1,218 @@
+// The strings the Swap and Market screens show about the reference price
+// (project 00005, spec User Story 3 / SC-005). Rendering is trivial once these
+// are right, so this is where the behaviour is pinned:
+//   - a demo-priced pair is labelled as such and never warned about
+//   - a node that predates the price service degrades to "no reference known"
+//   - the threshold and the offset carry the node's own numbers, never guesses
+import { describe, expect, test } from 'bun:test';
+import type { PricesResponse, Quote, TokenPrice } from '../services/api';
+import { describeQuote, referenceRate, sourceLabel, tokenPriceOf } from './reference';
+
+const NOW = Date.parse('2026-09-02T12:00:00.000Z');
+const HOURS_AGO = (h: number) => new Date(NOW - h * 3_600_000).toISOString();
+const MINUS = '−';
+
+/** A WBTC→WETH quote at the seeded reference rate, 2.5% below it by default. */
+const quote = (over: Partial<Quote> = {}): Quote => ({
+  from_token: 'e7'.repeat(32),
+  to_token: 'fd'.repeat(32),
+  from_amount: '1000',
+  market_rate: 32.336,
+  suggested_to_amount: '31527',
+  to_amount: '31527',
+  implied_rate: 31.527,
+  discount: 0.025,
+  sponsored: true,
+  from_usd: 77387000,
+  to_usd: 75452325,
+  sponsor_discount: 0.025,
+  from_source: 'feed',
+  to_source: 'feed',
+  prices_updated_at: HOURS_AGO(3),
+  source: 'token-prices',
+  ...over,
+});
+
+describe('describeQuote — both legs market-backed', () => {
+  test('reference, offset, threshold and source line', () => {
+    const d = describeQuote(quote(), 'WBTC', 'WETH', NOW);
+    expect(d.marketBacked).toBe(true);
+    expect(d.referenceRate).toBe(32.336);
+    expect(d.offset).toBe(`${MINUS}2.5%`);
+    expect(d.offsetBelow).toBe(true);
+    expect(d.thresholdText).toBe('sponsored at ≥ 2.5% below reference');
+    expect(d.sourceText).toBe('Reference: CoinGecko · 3 h ago');
+    expect(d.showNotSponsored).toBe(false);
+  });
+
+  test('a seeded price says so, and a mixed pair names both sources', () => {
+    expect(describeQuote(quote({ from_source: 'seed', to_source: 'seed' }), 'WBTC', 'WETH', NOW).sourceText)
+      .toBe('Reference: CoinGecko snapshot · 3 h ago');
+    expect(describeQuote(quote({ from_source: 'feed', to_source: 'fixed' }), 'WBTC', 'USDM', NOW).sourceText)
+      .toBe('Reference: CoinGecko + pegged · 3 h ago');
+    expect(describeQuote(quote({ from_source: 'manual', to_source: 'manual' }), 'A', 'B', NOW).sourceText)
+      .toBe('Reference: operator · 3 h ago');
+  });
+
+  test('no timestamp → the source is still named, without an age', () => {
+    expect(describeQuote(quote({ prices_updated_at: null }), 'WBTC', 'WETH', NOW).sourceText)
+      .toBe('Reference: CoinGecko');
+  });
+
+  test('a price above the reference is warned about with the real numbers', () => {
+    const d = describeQuote(
+      quote({ sponsored: false, discount: 0.01, implied_rate: 32.0126 }),
+      'WBTC', 'WETH', NOW,
+    );
+    expect(d.showNotSponsored).toBe(true);
+    expect(d.notSponsoredText).toBe('This price is only 1.0% below reference; sponsorship needs ≥ 2.5%.');
+    expect(d.offset).toBe(`${MINUS}1.0%`);
+    expect(d.offsetBelow).toBe(true);
+  });
+
+  test('at and above the reference read differently', () => {
+    expect(describeQuote(quote({ sponsored: false, discount: 0 }), 'A', 'B', NOW).notSponsoredText)
+      .toBe('This price is at the reference; sponsorship needs ≥ 2.5% below.');
+    const above = describeQuote(
+      quote({ sponsored: false, discount: -0.03, implied_rate: 33.306 }),
+      'A', 'B', NOW,
+    );
+    expect(above.notSponsoredText).toBe('This price is 3.0% above reference; sponsorship needs ≥ 2.5% below.');
+    expect(above.offset).toBe('+3.0%');
+    expect(above.offsetBelow).toBe(false);
+  });
+
+  test('a node that omits the threshold gets no invented threshold', () => {
+    const d = describeQuote(
+      quote({ sponsored: false, discount: 0.01, sponsor_discount: undefined }),
+      'WBTC', 'WETH', NOW,
+    );
+    expect(d.thresholdText).toBeNull();
+    expect(d.notSponsoredText).toBeNull();   // caller falls back to the generic sentence
+    expect(d.showNotSponsored).toBe(true);
+  });
+});
+
+describe('describeQuote — demo (unpriced) pairs', () => {
+  test('names the unpriced token and suppresses the warning', () => {
+    const d = describeQuote(
+      quote({ from_source: 'feed', to_source: 'fallback', sponsored: false, source: 'demo-fallback' }),
+      'WBTC', 'TESTTOKENA', NOW,
+    );
+    expect(d.marketBacked).toBe(false);
+    expect(d.referenceRate).toBeNull();
+    expect(d.offset).toBeNull();
+    expect(d.thresholdText).toBeNull();
+    expect(d.showNotSponsored).toBe(false);
+    expect(d.sourceText).toBe(
+      'Demo rate — no market price for TESTTOKENA; test tokens are sponsored regardless',
+    );
+  });
+
+  test('both sides unpriced names both', () => {
+    const d = describeQuote(
+      quote({ from_source: 'fallback', to_source: 'demo-fallback', source: 'demo-fallback' }),
+      'TESTTOKENA', 'TESTTOKENB', NOW,
+    );
+    expect(d.sourceText).toBe(
+      'Demo rate — no market price for TESTTOKENA and TESTTOKENB; test tokens are sponsored regardless',
+    );
+  });
+});
+
+describe('describeQuote — node without the 00005 fields (preprod today)', () => {
+  const legacy = (over: Partial<Quote> = {}) =>
+    quote({ sponsor_discount: undefined, from_source: undefined, to_source: undefined, prices_updated_at: undefined, ...over });
+
+  test('token-prices: rate and offset still shown, no source line, no threshold', () => {
+    const d = describeQuote(legacy(), 'WBTC', 'WETH', NOW);
+    expect(d.marketBacked).toBe(true);
+    expect(d.referenceRate).toBe(32.336);
+    expect(d.offset).toBe(`${MINUS}2.5%`);
+    expect(d.sourceText).toBeNull();
+    expect(d.thresholdText).toBeNull();
+  });
+
+  test('demo-fallback: labelled as a demo rate for the pair', () => {
+    const d = describeQuote(legacy({ source: 'demo-fallback', sponsored: false }), 'WBTC', 'TESTTOKENA', NOW);
+    expect(d.marketBacked).toBe(false);
+    expect(d.showNotSponsored).toBe(false);
+    expect(d.sourceText).toBe(
+      'Demo rate — no market price for this pair; test tokens are sponsored regardless',
+    );
+  });
+});
+
+describe('sourceLabel', () => {
+  test('market sources are named, the demo price is not', () => {
+    expect(sourceLabel('feed')).toBe('CoinGecko');
+    expect(sourceLabel('seed')).toBe('CoinGecko snapshot');
+    expect(sourceLabel('fixed')).toBe('pegged');
+    expect(sourceLabel('manual')).toBe('operator');
+    expect(sourceLabel('fallback')).toBeNull();
+    expect(sourceLabel('demo-fallback')).toBeNull();
+    expect(sourceLabel(undefined)).toBeNull();
+  });
+});
+
+const token = (over: Partial<TokenPrice> & Pick<TokenPrice, 'token_color' | 'price_usd'>): TokenPrice => ({
+  name: 'T', kind: 'shielded', decimals: 0, asset_id: null, source: 'feed', updated_at: HOURS_AGO(1), ...over,
+});
+
+const WBTC = 'e7'.repeat(32);
+const WETH = 'fd'.repeat(32);
+const TESTA = 'aa'.repeat(32);
+
+const prices = (): PricesResponse => ({
+  sponsor_discount: 0.025,
+  feed: { provider: 'coingecko', last_run_at: HOURS_AGO(1), last_ok_at: HOURS_AGO(1), last_error: null },
+  assets: [
+    { asset_id: 'bitcoin', price_usd: '77387', source: 'feed', provider_updated_at: HOURS_AGO(1), updated_at: HOURS_AGO(1) },
+    { asset_id: 'ethereum', price_usd: '2393.28', source: 'feed', provider_updated_at: HOURS_AGO(1), updated_at: HOURS_AGO(1) },
+  ],
+  tokens: [
+    token({ token_color: WBTC, name: 'WBTC', price_usd: '77387', asset_id: 'bitcoin', updated_at: HOURS_AGO(2) }),
+    token({ token_color: WETH, name: 'WETH', price_usd: '2393.28', asset_id: 'ethereum', updated_at: HOURS_AGO(1) }),
+    token({ token_color: TESTA, name: 'TESTTOKENA', price_usd: '13.02', source: 'fallback' }),
+  ],
+});
+
+describe('referenceRate', () => {
+  test('1 base = price(base)/price(quote) quote, with the older timestamp', () => {
+    const r = referenceRate(prices(), WBTC, WETH)!;
+    expect(r.rate).toBeCloseTo(77387 / 2393.28, 9);
+    expect(r.label).toBe('CoinGecko');
+    expect(r.updatedAt).toBe(HOURS_AGO(2)); // older of the two rows
+  });
+
+  test('null when either side is the demo price or unknown', () => {
+    expect(referenceRate(prices(), WBTC, TESTA)).toBeNull();
+    expect(referenceRate(prices(), TESTA, WETH)).toBeNull();
+    expect(referenceRate(prices(), WBTC, 'ff'.repeat(32))).toBeNull();
+    expect(referenceRate(null, WBTC, WETH)).toBeNull();
+    expect(referenceRate(prices(), null, WETH)).toBeNull();
+  });
+
+  test('null on a zero or unparseable price rather than Infinity', () => {
+    const p = prices();
+    p.tokens[1] = token({ token_color: WETH, name: 'WETH', price_usd: '0' });
+    expect(referenceRate(p, WBTC, WETH)).toBeNull();
+    p.tokens[1] = token({ token_color: WETH, name: 'WETH', price_usd: 'n/a' });
+    expect(referenceRate(p, WBTC, WETH)).toBeNull();
+  });
+
+  test('mixed sources are both named', () => {
+    const p = prices();
+    p.tokens[1] = token({ token_color: WETH, name: 'USDM', price_usd: '0.000001', source: 'fixed' });
+    expect(referenceRate(p, WBTC, WETH)!.label).toBe('CoinGecko + pegged');
+  });
+});
+
+describe('tokenPriceOf', () => {
+  test('finds by colour, null otherwise', () => {
+    expect(tokenPriceOf(prices(), WBTC)?.name).toBe('WBTC');
+    expect(tokenPriceOf(prices(), 'ff'.repeat(32))).toBeNull();
+    expect(tokenPriceOf(null, WBTC)).toBeNull();
+    expect(tokenPriceOf(prices(), undefined)).toBeNull();
+  });
+});

--- a/templates/zswap-da/src/state/reference.test.ts
+++ b/templates/zswap-da/src/state/reference.test.ts
@@ -215,4 +215,11 @@ describe('tokenPriceOf', () => {
     expect(tokenPriceOf(null, WBTC)).toBeNull();
     expect(tokenPriceOf(prices(), undefined)).toBeNull();
   });
+
+  // The lookup query is lower-cased before it is sent (master plan §3a), so the
+  // rows that come back must still match a colour spelled any other way.
+  test('matches case-insensitively', () => {
+    expect(tokenPriceOf(prices(), WBTC.toUpperCase())?.name).toBe('WBTC');
+    expect(tokenPriceOf(prices(), ` ${WBTC} `)?.name).toBe('WBTC');
+  });
 });

--- a/templates/zswap-da/src/state/reference.ts
+++ b/templates/zswap-da/src/state/reference.ts
@@ -1,0 +1,188 @@
+// Reference-rate derivation for the Swap and Market screens (project 00005).
+//
+// The node publishes a reference (market) price per known token and says where
+// each one came from. Everything a screen needs to say about that — the rate,
+// the offset from it, the sponsorship threshold, the provider and the age — is
+// derived here, as pure functions over the API payloads, so the strings can be
+// unit-tested without rendering React.
+//
+// Two rules run through the whole file:
+//  1. Never invent a number. A node that predates the price service omits the
+//     source fields entirely; the honest answer is then "no reference known",
+//     not a zero or a guess.
+//  2. `fallback` / `demo-fallback` is the deterministic demo price, not a
+//     market. Pairs priced that way are labelled as demo rates and their
+//     "not sponsored" warning is suppressed — the batcher sponsors unpriced
+//     tokens (BATCHER_SPONSOR_UNPRICED=allow), so warning about them would lie.
+
+import type { PricesResponse, Quote, TokenPrice } from '../services/api';
+import { fmtAge, fmtOffsetPct, isMarketSource, pct1, type PriceSource } from './format';
+
+/** Human name for a price source. null for the demo price — it is not a market. */
+export function sourceLabel(s: PriceSource | string | null | undefined): string | null {
+  switch (s) {
+    case 'feed': return 'CoinGecko';
+    case 'seed': return 'CoinGecko snapshot';
+    case 'fixed': return 'pegged';
+    case 'manual': return 'operator';
+    default: return null;
+  }
+}
+
+/** "CoinGecko" for one source, "CoinGecko + pegged" when the two sides differ. */
+function joinLabels(a: string | null, b: string | null): string | null {
+  if (a && b) return a === b ? a : `${a} + ${b}`;
+  return a ?? b;
+}
+
+/** English list of one or two token names: "TESTTOKENA and TESTTOKENB". */
+function nameList(names: string[]): string {
+  const uniq = names.filter((n, i) => n && names.indexOf(n) === i);
+  if (uniq.length === 0) return 'this pair';
+  if (uniq.length === 1) return uniq[0];
+  return `${uniq.slice(0, -1).join(', ')} and ${uniq[uniq.length - 1]}`;
+}
+
+/** Everything the Swap screen says about a quote's reference price. */
+export interface QuoteReference {
+  /** Both legs carry a real reference price (feed/seed/fixed/manual). */
+  marketBacked: boolean;
+  /** The reference rate to display, or null when there is no reference. */
+  referenceRate: number | null;
+  /** The maker's offset from the reference, e.g. "−2.5%". */
+  offset: string | null;
+  /** true when the maker's rate is at or below the reference (good for a taker,
+   *  rendered in the positive colour, matching the pre-existing convention). */
+  offsetBelow: boolean | null;
+  /** "sponsored at ≥ 2.5% below reference", when the node publishes the threshold. */
+  thresholdText: string | null;
+  /** "Reference: CoinGecko · 3 h ago", or the demo-rate sentence. */
+  sourceText: string | null;
+  /** Warning text with the actual numbers; null when they are not known. */
+  notSponsoredText: string | null;
+  /** Whether to show the not-sponsored warning at all. */
+  showNotSponsored: boolean;
+}
+
+/**
+ * Describe a quote's reference price for display.
+ *
+ * `fromName`/`toName` are the token names shown to the user; `now` is injected
+ * so the age string is testable.
+ */
+export function describeQuote(
+  q: Quote,
+  fromName: string,
+  toName: string,
+  now: number = Date.now(),
+): QuoteReference {
+  const fromSrc = q.from_source;
+  const toSrc = q.to_source;
+  const haveSources = fromSrc != null && toSrc != null;
+
+  // Without per-leg sources (a node older than kernel 00005 part A) the only
+  // signal is the pre-existing top-level `source`, which says "demo-fallback"
+  // when the node had to fabricate a price for at least one side.
+  const marketBacked = haveSources
+    ? isMarketSource(fromSrc) && isMarketSource(toSrc)
+    : q.source !== 'demo-fallback';
+
+  const referenceRate =
+    marketBacked && typeof q.market_rate === 'number' && isFinite(q.market_rate) && q.market_rate > 0
+      ? q.market_rate
+      : null;
+
+  const offset = fmtOffsetPct(q.implied_rate, referenceRate);
+  const offsetBelow =
+    q.implied_rate != null && referenceRate != null ? q.implied_rate <= referenceRate : null;
+
+  const thresholdText =
+    marketBacked && q.sponsor_discount != null
+      ? `sponsored at ≥ ${pct1(q.sponsor_discount)}% below reference`
+      : null;
+
+  let sourceText: string | null = null;
+  if (!marketBacked) {
+    const unpriced = haveSources
+      ? [isMarketSource(fromSrc) ? '' : fromName, isMarketSource(toSrc) ? '' : toName].filter(Boolean)
+      : [];
+    sourceText =
+      `Demo rate — no market price for ${nameList(unpriced)}; ` +
+      'test tokens are sponsored regardless';
+  } else if (haveSources) {
+    const label = joinLabels(sourceLabel(fromSrc), sourceLabel(toSrc));
+    const age = fmtAge(q.prices_updated_at, now);
+    if (label) sourceText = age ? `Reference: ${label} · ${age}` : `Reference: ${label}`;
+  }
+
+  const showNotSponsored = !q.sponsored && marketBacked;
+  let notSponsoredText: string | null = null;
+  if (showNotSponsored && q.discount != null && q.sponsor_discount != null) {
+    const need = pct1(q.sponsor_discount);
+    const d = Number(pct1(q.discount));
+    notSponsoredText =
+      d > 0
+        ? `This price is only ${d.toFixed(1)}% below reference; sponsorship needs ≥ ${need}%.`
+        : d < 0
+          ? `This price is ${Math.abs(d).toFixed(1)}% above reference; sponsorship needs ≥ ${need}% below.`
+          : `This price is at the reference; sponsorship needs ≥ ${need}% below.`;
+  }
+
+  return {
+    marketBacked,
+    referenceRate,
+    offset,
+    offsetBelow,
+    thresholdText,
+    sourceText,
+    notSponsoredText,
+    showNotSponsored,
+  };
+}
+
+/** The `/v1/prices` row for one token colour, or null when it is not priced. */
+export function tokenPriceOf(
+  prices: PricesResponse | null | undefined,
+  color: string | null | undefined,
+): TokenPrice | null {
+  if (!prices || !color) return null;
+  return prices.tokens.find((t) => t.token_color === color) ?? null;
+}
+
+/** A pair's reference rate, derived from two token prices. */
+export interface PairReference {
+  /** How many quote units one base unit is worth at reference prices. */
+  rate: number;
+  /** "CoinGecko", "CoinGecko + pegged", … */
+  label: string;
+  /** Older of the two rows' timestamps — the age the pair can honestly claim. */
+  updatedAt: string | null;
+}
+
+/**
+ * Reference rate for a pair: price(base) / price(quote), both per base unit, so
+ * the result is directly "1 base = rate quote".
+ *
+ * Returns null unless BOTH tokens carry a market-backed price. `price_usd` is a
+ * decimal string; it is parsed to a double here because this is a display ratio
+ * and an offset threshold, never a settlement amount.
+ */
+export function referenceRate(
+  prices: PricesResponse | null | undefined,
+  baseColor: string | null | undefined,
+  quoteColor: string | null | undefined,
+): PairReference | null {
+  const b = tokenPriceOf(prices, baseColor);
+  const q = tokenPriceOf(prices, quoteColor);
+  if (!b || !q) return null;
+  if (!isMarketSource(b.source) || !isMarketSource(q.source)) return null;
+  const bp = Number(b.price_usd);
+  const qp = Number(q.price_usd);
+  if (!isFinite(bp) || !isFinite(qp) || qp <= 0 || bp <= 0) return null;
+  const label = joinLabels(sourceLabel(b.source), sourceLabel(q.source));
+  if (!label) return null;
+  const older = [b.updated_at, q.updated_at]
+    .filter((s): s is string => !!s)
+    .sort()[0] ?? null;
+  return { rate: bp / qp, label, updatedAt: older };
+}

--- a/templates/zswap-da/src/state/reference.ts
+++ b/templates/zswap-da/src/state/reference.ts
@@ -140,13 +140,17 @@ export function describeQuote(
   };
 }
 
-/** The `/v1/prices` row for one token colour, or null when it is not priced. */
+/** The `/v1/prices` row for one token colour, or null when it is not priced.
+ *  Matched case-insensitively: the lookup query is lower-cased on the way out
+ *  (master plan §3a), so the row that comes back need not be spelled the way
+ *  the caller spelled it. */
 export function tokenPriceOf(
   prices: PricesResponse | null | undefined,
   color: string | null | undefined,
 ): TokenPrice | null {
   if (!prices || !color) return null;
-  return prices.tokens.find((t) => t.token_color === color) ?? null;
+  const want = color.trim().toLowerCase();
+  return prices.tokens.find((t) => t.token_color?.toLowerCase() === want) ?? null;
 }
 
 /** A pair's reference rate, derived from two token prices. */

--- a/templates/zswap-da/src/state/usePrices.test.ts
+++ b/templates/zswap-da/src/state/usePrices.test.ts
@@ -1,0 +1,119 @@
+// The /v1/prices cache contract (master plan §3a, Q-11).
+//
+// The endpoint is a keyed lookup, so the cache must be keyed too: one entry per
+// SORTED COLOUR SET, one request per key per TTL, one shared request while a
+// key is in flight, and no request at all when there is nothing to ask about.
+// The hook itself is React; everything worth pinning is in the two pure
+// functions it is built on, so no renderer is needed here.
+//
+// api.ts imports ../config, which reads `window`/`location` at module load —
+// stub them before the dynamic import, as in services/api.test.ts.
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+
+(globalThis as any).window ??= {};
+(globalThis as any).location ??= { hostname: 'localhost' };
+
+const { invalidatePrices, loadPrices, pricesKey } = await import('./usePrices');
+
+const A = 'aa'.repeat(32);
+const B = 'bb'.repeat(32);
+
+const BODY = {
+  sponsor_discount: 0.025,
+  feed: { provider: 'coingecko', last_run_at: null, last_ok_at: null, last_error: null },
+  assets: [],
+  tokens: [
+    { token_color: A, name: 'WBTC', kind: 'shielded', decimals: 0, asset_id: 'bitcoin', price_usd: '77387', source: 'feed', updated_at: '2026-09-03T00:00:04.000Z' },
+  ],
+};
+
+const realFetch = globalThis.fetch;
+let calls: string[] = [];
+
+/** Answer every request with BODY after one macrotask, recording the URL. */
+function serve(status = 200, body: unknown = BODY) {
+  calls = [];
+  globalThis.fetch = (async (input: any) => {
+    calls.push(String(input));
+    await new Promise((r) => setTimeout(r, 5));
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }) as typeof fetch;
+}
+
+beforeEach(() => {
+  invalidatePrices();
+  serve();
+});
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+describe('pricesKey', () => {
+  test('is the sorted, lower-cased, de-duplicated colour set', () => {
+    expect(pricesKey([B, A])).toBe(`${A},${B}`);
+    expect(pricesKey([A, B])).toBe(pricesKey([B, A]));
+    expect(pricesKey([A.toUpperCase(), ` ${A} `])).toBe(A);
+  });
+
+  test('is empty when there is nothing to ask about', () => {
+    expect(pricesKey([])).toBe('');
+    expect(pricesKey(null)).toBe('');
+    expect(pricesKey(['', '   ', undefined])).toBe('');
+  });
+});
+
+describe('loadPrices', () => {
+  test('no colours, no request', async () => {
+    expect(await loadPrices('')).toBeNull();
+    expect(calls).toHaveLength(0);
+  });
+
+  test('asks the node for exactly the key, once, then serves the cache', async () => {
+    const key = pricesKey([B, A]);
+    const first = await loadPrices(key);
+    expect(first?.sponsor_discount).toBe(0.025);
+    expect(calls).toHaveLength(1);
+    expect(new URL(calls[0]).searchParams.get('tokens')).toBe(`${A},${B}`);
+
+    await loadPrices(key);
+    expect(calls).toHaveLength(1); // still inside the 60 s TTL
+  });
+
+  test('concurrent callers on one key share a single request', async () => {
+    const key = pricesKey([A, B]);
+    const [x, y, z] = await Promise.all([loadPrices(key), loadPrices(key), loadPrices(key)]);
+    expect(calls).toHaveLength(1);
+    expect(x).toBe(y);
+    expect(y).toBe(z);
+  });
+
+  test('a different pair is a different entry and does not evict the first', async () => {
+    const one = pricesKey([A, B]);
+    const two = pricesKey([A]);
+    await loadPrices(one);
+    await loadPrices(two);
+    expect(calls).toHaveLength(2);
+    expect(new URL(calls[1]).searchParams.get('tokens')).toBe(A);
+    await loadPrices(one);
+    expect(calls).toHaveLength(2); // the pair's entry survived the second key
+  });
+
+  test('a node that refuses the query resolves to null, and is retried', async () => {
+    serve(400, { error: 'VALIDATION', reason: 'tokens must be 1-50 64-hex colors' });
+    const key = pricesKey([A]);
+    expect(await loadPrices(key)).toBeNull();
+    expect(await loadPrices(key)).toBeNull();
+    expect(calls).toHaveLength(2); // a failure is never cached as "no reference"
+  });
+
+  test('invalidatePrices drops the cache', async () => {
+    const key = pricesKey([A]);
+    await loadPrices(key);
+    invalidatePrices();
+    await loadPrices(key);
+    expect(calls).toHaveLength(2);
+  });
+});

--- a/templates/zswap-da/src/state/usePrices.ts
+++ b/templates/zswap-da/src/state/usePrices.ts
@@ -1,0 +1,59 @@
+// Reference prices from GET /v1/prices, shared by every screen that needs one.
+//
+// The feed refreshes once a day, so a 60 s module-level cache is generous; it
+// exists so that opening a pair, flipping it and hitting Refresh do not each
+// re-fetch the whole token table. One in-flight request is shared by all
+// callers mounted at the same time.
+//
+// A node that predates the price service answers 404. That is "no reference
+// available", not an error to put in front of a user, so it resolves to null
+// and every consumer falls back to "no reference".
+
+import { useEffect, useState } from 'react';
+import { api, type PricesResponse } from '../services/api';
+
+const TTL_MS = 60_000;
+
+let cache: { at: number; data: PricesResponse } | null = null;
+let inflight: Promise<PricesResponse | null> | null = null;
+
+/** Drop the cache so the next read hits the node (used by tests). */
+export function invalidatePrices(): void {
+  cache = null;
+}
+
+function loadPrices(): Promise<PricesResponse | null> {
+  if (cache && Date.now() - cache.at < TTL_MS) return Promise.resolve(cache.data);
+  if (!inflight) {
+    inflight = api
+      .getPrices()
+      .then((data) => {
+        cache = { at: Date.now(), data };
+        return data;
+      })
+      .catch(() => null)
+      .finally(() => {
+        inflight = null;
+      });
+  }
+  return inflight;
+}
+
+/**
+ * The current reference prices, or null while loading / when the node has no
+ * `/v1/prices` route. `refreshKey` re-runs the read (still cache-bounded), so a
+ * screen's Refresh button can flow through here.
+ */
+export function usePrices(refreshKey?: unknown): PricesResponse | null {
+  const [prices, setPrices] = useState<PricesResponse | null>(cache?.data ?? null);
+  useEffect(() => {
+    let cancelled = false;
+    loadPrices().then((data) => {
+      if (!cancelled && data) setPrices(data);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [refreshKey]);
+  return prices;
+}

--- a/templates/zswap-da/src/state/usePrices.ts
+++ b/templates/zswap-da/src/state/usePrices.ts
@@ -1,59 +1,94 @@
 // Reference prices from GET /v1/prices, shared by every screen that needs one.
 //
-// The feed refreshes once a day, so a 60 s module-level cache is generous; it
-// exists so that opening a pair, flipping it and hitting Refresh do not each
-// re-fetch the whole token table. One in-flight request is shared by all
-// callers mounted at the same time.
+// The endpoint is a KEYED lookup, not a table dump (master plan §3a, Q-11): a
+// caller asks about the colours it is showing — the Market header asks about
+// the selected pair — and the node answers 400 if asked about nothing. So the
+// cache is keyed by the SORTED COLOUR SET: {WBTC,WETH} and {WETH,WBTC} are one
+// entry, and a different pair is a different entry that never evicts the first.
 //
-// A node that predates the price service answers 404. That is "no reference
-// available", not an error to put in front of a user, so it resolves to null
-// and every consumer falls back to "no reference".
+// The feed refreshes once a day, so a 60 s TTL per key is generous; it exists
+// so that opening a pair, flipping it and hitting Refresh do not each re-fetch.
+// One in-flight request is shared per key by all callers mounted at the time.
+//
+// A node that predates the price service answers 404, and one that dislikes the
+// query answers 400. Both are "no reference available", not an error to put in
+// front of a user, so they resolve to null and every consumer falls back to
+// "no reference". With no colours to ask about, nothing is fetched at all.
 
 import { useEffect, useState } from 'react';
-import { api, type PricesResponse } from '../services/api';
+import { api, normalizeColors, type PricesResponse } from '../services/api';
 
 const TTL_MS = 60_000;
 
-let cache: { at: number; data: PricesResponse } | null = null;
-let inflight: Promise<PricesResponse | null> | null = null;
+const cache = new Map<string, { at: number; data: PricesResponse }>();
+const inflight = new Map<string, Promise<PricesResponse | null>>();
 
-/** Drop the cache so the next read hits the node (used by tests). */
-export function invalidatePrices(): void {
-  cache = null;
+/** The cache key for a set of colours: normalized, sorted, comma-joined.
+ *  Empty (falsy) when there is nothing to ask about. */
+export function pricesKey(colors: readonly (string | null | undefined)[] | null | undefined): string {
+  return normalizeColors(colors ?? []).sort().join(',');
 }
 
-function loadPrices(): Promise<PricesResponse | null> {
-  if (cache && Date.now() - cache.at < TTL_MS) return Promise.resolve(cache.data);
-  if (!inflight) {
-    inflight = api
-      .getPrices()
+/** Drop every cached response so the next read hits the node (used by tests). */
+export function invalidatePrices(): void {
+  cache.clear();
+}
+
+/** The cached response for a key while it is fresh, else null. */
+function cachedFor(key: string): PricesResponse | null {
+  const hit = key ? cache.get(key) : undefined;
+  return hit && Date.now() - hit.at < TTL_MS ? hit.data : null;
+}
+
+/**
+ * Fetch (or reuse) the prices for one cache key. Exported for tests: it is the
+ * whole caching contract — one request per key per TTL, shared while in flight,
+ * and no request at all for an empty key.
+ */
+export function loadPrices(key: string): Promise<PricesResponse | null> {
+  if (!key) return Promise.resolve(null);
+  const fresh = cachedFor(key);
+  if (fresh) return Promise.resolve(fresh);
+  let p = inflight.get(key);
+  if (!p) {
+    p = api
+      .getPrices(key.split(','))
       .then((data) => {
-        cache = { at: Date.now(), data };
+        cache.set(key, { at: Date.now(), data });
         return data;
       })
       .catch(() => null)
       .finally(() => {
-        inflight = null;
+        inflight.delete(key);
       });
+    inflight.set(key, p);
   }
-  return inflight;
+  return p;
 }
 
 /**
- * The current reference prices, or null while loading / when the node has no
- * `/v1/prices` route. `refreshKey` re-runs the read (still cache-bounded), so a
- * screen's Refresh button can flow through here.
+ * The reference prices covering `colors`, or null while loading, when there is
+ * nothing selected, or when the node has no usable `/v1/prices`. `refreshKey`
+ * re-runs the read (still TTL-bounded), so a screen's Refresh button can flow
+ * through here.
  */
-export function usePrices(refreshKey?: unknown): PricesResponse | null {
-  const [prices, setPrices] = useState<PricesResponse | null>(cache?.data ?? null);
+export function usePrices(
+  colors: readonly (string | null | undefined)[] | null | undefined,
+  refreshKey?: unknown,
+): PricesResponse | null {
+  const key = pricesKey(colors);
+  const [prices, setPrices] = useState<PricesResponse | null>(() => cachedFor(key));
   useEffect(() => {
     let cancelled = false;
-    loadPrices().then((data) => {
+    // Never show one pair's prices under another pair's key.
+    setPrices(cachedFor(key));
+    if (!key) return;
+    loadPrices(key).then((data) => {
       if (!cancelled && data) setPrices(data);
     });
     return () => {
       cancelled = true;
     };
-  }, [refreshKey]);
+  }, [key, refreshKey]);
   return prices;
 }

--- a/templates/zswap-da/src/state/usePrices.ts
+++ b/templates/zswap-da/src/state/usePrices.ts
@@ -77,18 +77,21 @@ export function usePrices(
   refreshKey?: unknown,
 ): PricesResponse | null {
   const key = pricesKey(colors);
-  const [prices, setPrices] = useState<PricesResponse | null>(() => cachedFor(key));
+  // The response is held WITH the key it answers, so one pair's prices can
+  // never be read under another pair's key — and so a refresh keeps showing
+  // the prices it already has instead of blinking through "no reference".
+  const [held, setHeld] = useState<{ key: string; data: PricesResponse } | null>(null);
   useEffect(() => {
-    let cancelled = false;
-    // Never show one pair's prices under another pair's key.
-    setPrices(cachedFor(key));
     if (!key) return;
+    let cancelled = false;
     loadPrices(key).then((data) => {
-      if (!cancelled && data) setPrices(data);
+      if (!cancelled && data) setHeld({ key, data });
     });
     return () => {
       cancelled = true;
     };
   }, [key, refreshKey]);
-  return prices;
+  // On a pair change this falls back to that pair's cached body, or to null —
+  // "no reference" — until its own response lands.
+  return held && held.key === key ? held.data : cachedFor(key);
 }


### PR DESCRIPTION
## What

The Swap and Market screens now show the **reference conversion rate**, the maker's **offset from it**, the **sponsorship threshold**, and **where the reference came from and how old it is**. A batcher/node refusal is shown as its reason instead of a generic error.

Template-only (`templates/zswap-da`), additive, **no dependency changes** — it cherry-picks onto `midnight-1` unchanged.

Part C of project 00005 (token price service). Parts A and B add the kernel side in `zswap-offerfiles-kernel`: `GET /v1/prices`, source/threshold fields on `GET /v1/quote`, and a `422 NOT_SPONSORED` on `POST /v1/offers`.

## Why

A maker could not tell why an offer would or would not be sponsored to Celestia:

- the market rate was hidden whenever "Auto Market Price" was on
- "−x% vs market" carried no threshold, so 1% and 3% looked equally fine
- nothing said whether the "market" was a real price or the node's deterministic demo price
- a refusal from the batcher surfaced as an internal error

## Screens

**Swap** (both price modes now):

```
Your rate · 1 WBTC = 31.526 WETH                        −2.5% vs reference
Reference · 1 WBTC = 32.3351 WETH   sponsored at ≥ 2.5% below reference
Reference: CoinGecko · 3 h ago
[ Celestia fee sponsored. Good trades get filled fast. ]
```

At 1% below reference:

```
! This price is only 1.0% below reference; sponsorship needs ≥ 2.5%.  Apply best price
```

For a pair the node cannot price (test tokens), the warning is suppressed — the batcher sponsors unpriced tokens — and the line reads:

```
Demo rate — no market price for TESTTOKENA and TESTTOKENB; test tokens are sponsored regardless
```

**Market** header gains two stats: `Reference 1 WBTC = 32.335 WETH` (with the source and age underneath) and `Mid vs reference −3.5%`; both read `no reference` when either token is demo-priced.

## How

- `services/api.ts` — `getPrices(tokens)` (per-pair: builds `GET /v1/prices?tokens=a,b`, refuses an empty list or more than 50 colours before any request — the node requires `tokens` and has no unfiltered form) plus the `/v1/prices` types; `Quote` gains `sponsor_discount`, `from_source`, `to_source`, `prices_updated_at`.
  These four are **optional** on purpose: a node that predates the price service omits them, so this build stays correct against the current preprod API and shows "no reference known" rather than reading `undefined`.
- `state/format.ts` — `isMarketSource`, `pct1`, `fmtOffsetPct`, `fmtAge`.
- `state/reference.ts` (new) — `describeQuote()` and `referenceRate()`: every string the two screens render is derived here, pure and unit-tested, so the screens hold no formatting logic that can drift.
- `state/usePrices.ts` (new) — `/v1/prices?tokens=` behind a 60 s module cache keyed by the sorted colour set, one shared in-flight request per key; Market asks only for the selected pair and fetches nothing with no pair open; a 400/404 resolves to `null` ("no reference"). Per-pair lookups landed in `43f0ea36` + `689c326c` (Q-11: the price table is unbounded in principle, so no consumer pulls it whole).
- `screens/Swap.tsx`, `screens/Market.tsx` — rendering only.

The `422 NOT_SPONSORED` path needed no code change: `parse()` already builds an `ApiError` whose message is the node's `reason` with the numbers on `.data`, and `createOffer` rethrows it untouched. `services/api.test.ts` now pins that so it cannot regress, and the Swap error area gains the same "Apply best price" action for it.

## Testing

- `bun test` → **176 pass / 0 fail / 375 expect() across 12 files** (35 new: `format.test.ts`, `reference.test.ts`, `api.test.ts`)
- `bunx tsc -b` clean, `bun run build` green (including the compact contract prebuild)
- Manual walkthrough in the browser against a throwaway stub serving the frozen API fixtures (the kernel routes are not merged yet): auto mode, manual price 1% below, a test-token pair, and both Market cases render exactly the strings above. Posting an offer and seeing the 422 in the UI needs the Lace wallet and is verified on preprod once the kernel side is deployed.

## Not breaking

Additive. Against a node without the new fields the screens fall back to the pre-existing top-level `source` and show the rate and offset with no source line and no threshold — never a fabricated number.

