### PR TITLE
feat(zswap-da): amounts are whole coins — token decimals from the registry

### DIFF
--- a/templates/zswap-da/README.md
+++ b/templates/zswap-da/README.md
@@ -178,7 +178,8 @@ src/
                         takerBalance (+ its test), mintQueue
   shims/                crypto polyfill and loose .d.ts files for @effectstream/wallets
   state/                useZSwapApp orchestration, wallet + tradeWallet adapters,
-                        local myOffers / myTrades stores, formatting
+                        local myOffers / myTrades stores, amount (coins ⇄ base
+                        units) and swapAmounts, formatting
   styles/               Design tokens and global CSS
   types/                Shared types and the window.midnight declaration
   ui/                   Modals, toasts, wallet and network menus, console dock, icons
@@ -251,14 +252,39 @@ states the limit plainly: shielded-only offers stay anonymous by construction, b
 commitments hide the recipient's coin public key and only the holding wallet can decrypt the
 ciphertext. For those the function returns `undefined` and the caller falls back to a neutral label.
 
+### Amounts: whole coins on screen, base units everywhere else
+
+Every amount the chain, the wallet and the node API carry is an **integer of base units**. A token's
+`decimals` — served by `GET /v1/known-tokens` and carried on `KnownToken` — says how many base units
+make one whole coin: `1 coin = 10^decimals base units`. The UI reads and writes **whole coins**; the
+conversion lives in one place, `src/state/amount.ts`, and nothing below the screens ever sees a coin.
+
+- `parseWholeCoins('1.5', 6) === 1500000n` — string/bigint maths only. `Number(x) * 1e6` is banned:
+  the product is inexact for most inputs (`0.07 * 1e6 === 70000.00000000001`) and above 2^53 a double
+  rounds silently, which would post an offer for an amount nobody typed.
+- Over-precise input is **refused with a message naming the token's precision**, never rounded — the
+  amount is what settles on chain.
+- Rates the node publishes (`implied_rate`, `market_rate`, `/v1/chart` prices) are base-unit ratios;
+  `scaleRate(rate, dFrom, dTo)` turns them into the "1 WBTC = X WETH" a screen prints. That is the
+  identity while every token is 6 decimals, and correct the day one is not.
+- A token with no `decimals` — an older node, or a wallet-held colour in no registry — is read at
+  `DEFAULT_DECIMALS` (6), because every token this stack mints has 6.
+
+`src/state/swapAmounts.ts` is the Swap screen's half of that boundary (per-leg parsing, the
+auto-price suggestion, the affordability gate, the displayed rate), extracted so it is unit-tested
+without a DOM.
+
 ### Minting test tokens
 
 The Faucet screen (`src/screens/Faucet.tsx`) calls the `mint_shielded` and `mint_unshielded` circuits
 on the deployed OfferFiles contract through `src/services/browserContract.ts`, which assembles the
 standard midnight-js provider stack — `indexerPublicDataProvider`, `httpClientProofProvider`,
 `FetchZkConfigProvider`, `levelPrivateStateProvider` — and resolves the contract with
-`findDeployedContract`. Newly minted token names are held in `src/services/mintQueue.ts` and
-registered against their derived color once the mint lands, via `POST /v1/known-tokens`.
+`findDeployedContract`. The allotment is **1,000 whole coins**, so the circuit is called with
+`1_000_000_000` base units. Newly minted token names are held in `src/services/mintQueue.ts` and
+registered against their derived color once the mint lands, via `POST /v1/known-tokens` — carrying
+`decimals: 6` explicitly, so a node whose column still defaults to 0 does not record the token at a
+precision that would render every balance a million times too large.
 
 ### Browser build workarounds
 
@@ -294,17 +320,27 @@ both take precedence over the build-time values. The network is not user-selecta
 
 ## Testing
 
-The template ships one unit suite, `src/services/takerBalance.test.ts`, run with Bun's test runner:
+The template's unit suites run with Bun's test runner:
 
 ```sh
 bun test
 ```
 
-It covers the pure shortfall calculator: sufficient and exact balances producing no shortfall, a
-missing token counting as zero, shielded and unshielded legs reading from their own balance maps, and
-multi-leg offers reporting only the uncovered leg. That logic is deliberately separated from blob
-decoding inside `src/services/takerBalance.ts` precisely so it can be tested without a wallet or a
-chain.
+They cover the pure logic that must not be wrong, all of it deliberately separated from React, a
+wallet and a chain so it can be tested without any of them:
+
+- `src/state/amount.test.ts` — the coin ⇄ base-unit conversion: the `1.5 → 1500000n` round trip,
+  over-precision refused rather than rounded, values past 2^53 staying exact, and the `2^64 − 1`
+  ledger ceiling.
+- `src/state/swapAmounts.test.ts` — the Swap screen's boundary: per-leg parsing at each token's own
+  precision, the node's auto-price suggestion landing in the field as coins, and the affordability
+  gate comparing base units in bigint.
+- `src/services/takerBalance.test.ts` — the shortfall calculator: sufficient and exact balances
+  producing no shortfall, a missing token counting as zero, shielded and unshielded legs reading from
+  their own balance maps, multi-leg offers reporting only the uncovered leg, and a pin that balances
+  handed to it are base-unit strings.
+- `src/services/takeSelection.test.ts`, `src/state/reference.test.ts`, `src/state/myTrades.test.ts`
+  and the rest — selection totals, reference-price strings, the local trade log and offer parsing.
 
 > [!NOTE]
 > This template is **excluded from the repository's template test runner**. The reason is recorded

--- a/templates/zswap-da/src/hooks/useContract.ts
+++ b/templates/zswap-da/src/hooks/useContract.ts
@@ -9,6 +9,7 @@ import {
 import { MidnightBech32m, UnshieldedAddress } from '@midnightntwrk/wallet-sdk-address-format';
 import { api } from '../services/api';
 import { enqueueMintName, removeMintName } from '../services/mintQueue';
+import { DEFAULT_DECIMALS } from '../state/amount';
 
 export interface BrowserMintResult {
   color: string;
@@ -76,9 +77,10 @@ export function useContract(wallet: ContractWallet | null) {
     name: string,
     kind: 'shielded' | 'unshielded',
     queuedId: string,
+    decimals: number = DEFAULT_DECIMALS,
   ) => {
     try {
-      await api.registerKnownToken(color, name, kind);
+      await api.registerKnownToken(color, name, kind, decimals);
       removeMintName(queuedId);
     } catch (e: any) {
       // Leave the entry in the queue — the reconciler will retry when it
@@ -93,16 +95,19 @@ export function useContract(wallet: ContractWallet | null) {
       amount: bigint,
       nonce: bigint,
       name: string,
+      decimals: number = DEFAULT_DECIMALS,
     ): Promise<BrowserMintResult> => {
       const c = await ensureContract();
-      const queued = enqueueMintName(name);
-      console.log('[useContract] callTx.mint_shielded', { amount, nonce });
+      const queued = enqueueMintName(name, decimals);
+      // `amount` is BASE UNITS — the circuit's `Uint<64>` has no decimals
+      // notion, so the caller has already scaled the whole-coin allotment.
+      console.log('[useContract] callTx.mint_shielded', { amount, nonce, decimals });
       const txData: any = await (c as any).callTx.mint_shielded(domainSepBytes, amount, nonce);
       const colorBytes = txData.private?.result?.color as Uint8Array | undefined;
       if (!colorBytes) throw new Error('mint_shielded: missing color in result');
       const color = Array.from(colorBytes, (b) => b.toString(16).padStart(2, '0')).join('');
       const txHash: string = txData.public?.txHash ?? '';
-      await tryRegister(color, name, 'shielded', queued.id);
+      await tryRegister(color, name, 'shielded', queued.id, decimals);
       return { color, txHash };
     },
     [ensureContract, tryRegister],
@@ -124,11 +129,13 @@ export function useContract(wallet: ContractWallet | null) {
       domainSepBytes: Uint8Array,
       amount: bigint,
       name: string,
+      decimals: number = DEFAULT_DECIMALS,
     ): Promise<BrowserMintResult> => {
       const c = await ensureContract();
-      const queued = enqueueMintName(name);
+      const queued = enqueueMintName(name, decimals);
       const recipientBytes = await resolveRecipientBytes();
-      console.log('[useContract] callTx.mint_unshielded', { amount });
+      // `amount` is BASE UNITS; see mint_shielded above.
+      console.log('[useContract] callTx.mint_unshielded', { amount, decimals });
       const txData: any = await (c as any).callTx.mint_unshielded(
         domainSepBytes,
         amount,
@@ -138,7 +145,7 @@ export function useContract(wallet: ContractWallet | null) {
       if (!colorBytes) throw new Error('mint_unshielded: missing color in result');
       const color = Array.from(colorBytes, (b) => b.toString(16).padStart(2, '0')).join('');
       const txHash: string = txData.public?.txHash ?? '';
-      await tryRegister(color, name, 'unshielded', queued.id);
+      await tryRegister(color, name, 'unshielded', queued.id, decimals);
       return { color, txHash };
     },
     [ensureContract, resolveRecipientBytes, tryRegister],

--- a/templates/zswap-da/src/hooks/useMintReconciler.ts
+++ b/templates/zswap-da/src/hooks/useMintReconciler.ts
@@ -13,6 +13,7 @@ import type { ConnectedAPI } from '@midnight-ntwrk/dapp-connector-api';
 import type { KnownToken } from '../types';
 import { api } from '../services/api';
 import { listPending, peekOldest, removeMintName, subscribe } from '../services/mintQueue';
+import { DEFAULT_DECIMALS } from '../state/amount';
 
 const NIGHT_TOKEN_ID = '0'.repeat(64);
 
@@ -68,9 +69,13 @@ export function useMintReconciler(
           const kind: 'shielded' | 'unshielded' = unshieldedColors.has(color)
             ? 'unshielded'
             : 'shielded';
-          console.log('[mintReconciler] registering', { color, name: next.name, kind });
+          // Same precision the immediate registration would have sent; an
+          // entry queued by a pre-00024 build carries none and takes the
+          // default, which is what that build minted at anyway.
+          const decimals = next.decimals ?? DEFAULT_DECIMALS;
+          console.log('[mintReconciler] registering', { color, name: next.name, kind, decimals });
           try {
-            await api.registerKnownToken(color, next.name, kind);
+            await api.registerKnownToken(color, next.name, kind, decimals);
             removeMintName(next.id);
             progressed = true;
           } catch (e: any) {

--- a/templates/zswap-da/src/hooks/useTokens.ts
+++ b/templates/zswap-da/src/hooks/useTokens.ts
@@ -1,7 +1,24 @@
 // src/hooks/useTokens.ts
 import { useState, useEffect, useCallback } from 'react';
 import { api } from '../services/api';
+import { DEFAULT_DECIMALS } from '../state/amount';
 import type { KnownToken } from '../types';
+
+/**
+ * One registry row, with `decimals` guaranteed.
+ *
+ * A node older than kernel 00024 serves `known_tokens` without the field (the
+ * live preprod API still does), and a row could in principle carry junk. Every
+ * screen reads whole coins off this number, so it is normalised ONCE here
+ * rather than defaulted at each of the dozen render sites.
+ */
+function normalize(t: KnownToken): KnownToken {
+  const d = Number((t as Partial<KnownToken>).decimals);
+  return {
+    ...t,
+    decimals: Number.isFinite(d) && d >= 0 ? Math.trunc(d) : DEFAULT_DECIMALS,
+  };
+}
 
 export function useTokens() {
   const [knownTokens, setKnownTokens] = useState<KnownToken[]>([]);
@@ -11,7 +28,7 @@ export function useTokens() {
     try {
       setLoading(true);
       const tokens = await api.getKnownTokens();
-      setKnownTokens(tokens);
+      setKnownTokens(tokens.map(normalize));
     } catch (e) {
       console.error("Failed to load known tokens", e);
     } finally {

--- a/templates/zswap-da/src/screens/Faucet.tsx
+++ b/templates/zswap-da/src/screens/Faucet.tsx
@@ -7,6 +7,7 @@
 import { useMemo, useState } from 'react';
 import { Icon } from '../ui/icons';
 import { MAX_TOKEN_NAME_LENGTH } from '../constants';
+import { DEFAULT_DECIMALS, formatAmount, parseWholeCoins } from '../state/amount';
 import { formatShieldedAddress } from '../state/shieldedAddress';
 import type { ZSwapApp } from '../state/useZSwapApp';
 
@@ -50,9 +51,16 @@ function shortAddr(a: string | null): string {
 
 interface Receipt { name: string; amount: string; kind: Kind; color: string; txHash: string }
 
-// Fixed faucet allotment (matches the mock — one button, one amount).
-const MINT_AMOUNT = 1000;
-const MINT_AMOUNT_STR = MINT_AMOUNT.toLocaleString('en-US');
+// Fixed faucet allotment: 1,000 WHOLE COINS.
+//
+// Faucet tokens are minted at DEFAULT_DECIMALS and registered as such, so the
+// circuit is called with 1,000 × 10^6 = 1_000_000_000 base units while the user
+// is told, correctly, that they received 1,000 of the token. The scaling is
+// `parseWholeCoins`, never `1000 * 1e6`.
+const MINT_DECIMALS = DEFAULT_DECIMALS;
+const MINT_COINS = '1000';
+const MINT_BASE_UNITS = parseWholeCoins(MINT_COINS, MINT_DECIMALS)!;
+const MINT_AMOUNT_STR = formatAmount(MINT_BASE_UNITS, MINT_DECIMALS);
 
 export function Faucet({ st }: { st: ZSwapApp }) {
   const net = st.network || 'Undeployed';
@@ -88,10 +96,9 @@ export function Faucet({ st }: { st: ZSwapApp }) {
     setErr(null);
     try {
       const dsep = domainSepFromName(name);
-      const amountBig = BigInt(MINT_AMOUNT);
       const res = kind === 'shielded'
-        ? await st.mintShielded(dsep, amountBig, BigInt(Date.now()), name)
-        : await st.mintUnshielded(dsep, amountBig, name);
+        ? await st.mintShielded(dsep, MINT_BASE_UNITS, BigInt(Date.now()), name, MINT_DECIMALS)
+        : await st.mintUnshielded(dsep, MINT_BASE_UNITS, name, MINT_DECIMALS);
       setReceipt({ name, amount: MINT_AMOUNT_STR, kind, color: res.color, txHash: res.txHash });
       setStatus('done');
       st.toast(`${MINT_AMOUNT_STR} ${name} minted`, 'ok');
@@ -151,7 +158,7 @@ export function Faucet({ st }: { st: ZSwapApp }) {
           {kind === 'shielded' ? <Icon.shield style={{ color: 'var(--accent)' }} /> : <Icon.eye style={{ color: 'var(--ink-3)' }} />}
           <input value={name} onChange={(e) => { setName(sanitizeName(e.target.value)); setStatus('idle'); }} placeholder="e.g. ZTOKEN" spellCheck={false}
             style={{ border: 'none', background: 'transparent', outline: 'none', flex: 1, minWidth: 0, fontFamily: 'var(--font-mono)', fontSize: 14, color: 'var(--ink)', textTransform: 'uppercase' }} />
-          <span className="zs-num" style={{ fontSize: 12, color: 'var(--ink-3)', whiteSpace: 'nowrap' }}>{MINT_AMOUNT_STR} units</span>
+          <span className="zs-num" style={{ fontSize: 12, color: 'var(--ink-3)', whiteSpace: 'nowrap' }}>{MINT_AMOUNT_STR} coins</span>
         </div>
 
         <div style={{ fontSize: 12, color: 'var(--ink-3)', marginBottom: 18 }}>

--- a/templates/zswap-da/src/screens/Market.tsx
+++ b/templates/zswap-da/src/screens/Market.tsx
@@ -10,8 +10,9 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { Coin, Icon, isShielded } from '../ui/icons';
 import { api, type ChartHistoryRow, type ChartStats, type PairInfo } from '../services/api';
-import { shortToken } from '../utils';
+import { decimalsOf, shortToken } from '../utils';
 import { TokenChip } from '../ui/TokenChip';
+import { scaleRate, toWholeCoinsNumber } from '../state/amount';
 import { fmtAge, fmtOffsetPct } from '../state/format';
 import { referenceRate } from '../state/reference';
 import { usePrices } from '../state/usePrices';
@@ -21,6 +22,12 @@ type Side = 'ask' | 'bid';
 type View = 'both' | 'asks' | 'bids';
 interface Pair { base: string; quote: string }
 // A real order-book level — keeps the underlying offers so it can be taken.
+//
+// UNITS: `price`, `amt` and `total` are WHOLE COINS. Everything the node serves
+// (offer legs, /v1/chart prices and volumes) is base units, and this screen is
+// where that is converted — once, on the way into the ladder — so every
+// formatter below reads a coin number and the take path keeps the untouched
+// base-unit `orders`.
 interface BookRow { price: number; amt: number; total: number; orders: Order[] }
 interface Book { mid: number; asks: BookRow[]; bids: BookRow[]; maxTotal: number; spread: number }
 
@@ -65,6 +72,14 @@ export function Market({ st, onStartOrder }: { st: ZSwapApp; onStartOrder?: () =
   }, [st.knownTokens]);
   const baseColor = colorByName[base] ?? base;
   const quoteColor = colorByName[quote] ?? quote;
+  // Precision of each side of the pair. Amounts divide by their own token's
+  // 10^decimals; a PRICE is quote-per-base, so it scales by 10^(dBase − dQuote)
+  // — the identity while every token is 6, and correct the day one is not.
+  const baseDecimals = decimalsOf(baseColor, st.knownTokens);
+  const quoteDecimals = decimalsOf(quoteColor, st.knownTokens);
+  const toBaseCoins = (v: number) => toWholeCoinsNumber(v, baseDecimals);
+  const toQuoteCoins = (v: number) => toWholeCoinsNumber(v, quoteDecimals);
+  const toCoinPrice = (p: number) => scaleRate(p, baseDecimals, quoteDecimals);
 
   const [stats, setStats] = useState<ChartStats | null>(null);
   const [history, setHistory] = useState<ChartHistoryRow[]>([]);
@@ -169,12 +184,22 @@ export function Market({ st, onStartOrder }: { st: ZSwapApp; onStartOrder?: () =
     };
     for (const o of st.orders) {
       if (!(o.amtFrom > 0 && o.amtTo > 0)) continue;
-      if (o.from === base && o.to === quote) push(askAt, o.amtTo / o.amtFrom, o);
-      else if (o.from === quote && o.to === base) push(bidAt, o.amtFrom / o.amtTo, o);
+      // `o.impliedRate` is already the whole-coin rate of from→to, so an ask
+      // (giving base, wanting quote) prices directly off it and a bid — quoted
+      // the other way round — off its reciprocal.
+      if (o.from === base && o.to === quote) push(askAt, o.impliedRate, o);
+      else if (o.from === quote && o.to === base) push(bidAt, o.impliedRate > 0 ? 1 / o.impliedRate : 0, o);
     }
+    // The BASE token's amount at this level, in coins: an ask gives base
+    // (`amtFrom`), a bid wants it (`amtTo`).
     const mkRows = (m: Map<number, Order[]>, side: Side): BookRow[] =>
       [...m.entries()]
-        .map(([price, orders]) => ({ price, amt: orders.reduce((s, o) => s + (side === 'ask' ? o.amtFrom : o.amtTo), 0), total: 0, orders }))
+        .map(([price, orders]) => ({
+          price,
+          amt: orders.reduce((s, o) => s + toBaseCoins(side === 'ask' ? o.amtFrom : o.amtTo), 0),
+          total: 0,
+          orders,
+        }))
         .sort((a, b) => b.price - a.price);
     const asks = mkRows(askAt, 'ask');
     const bids = mkRows(bidAt, 'bid');
@@ -189,7 +214,8 @@ export function Market({ st, onStartOrder }: { st: ZSwapApp; onStartOrder?: () =
     const spread = bestAsk && bestBid ? bestAsk - bestBid : 0;
     const maxTotal = Math.max(1, asks.length ? asks[0].total : 0, bids.length ? bids[bids.length - 1].total : 0);
     return { mid, asks, bids, maxTotal, spread };
-  }, [st.orders, pair, base, quote]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [st.orders, pair, base, quote, baseDecimals]);
 
   // depth-derived locals (empty-safe)
   const asks = realDepth?.asks ?? [];
@@ -214,10 +240,14 @@ export function Market({ st, onStartOrder }: { st: ZSwapApp; onStartOrder?: () =
     () => referenceRate(prices, baseColor, quoteColor),
     [prices, baseColor, quoteColor],
   );
+  // `referenceRate` divides two per-BASE-UNIT USD prices, so it is a base-unit
+  // rate like everything else the node publishes: scale it before comparing it
+  // with the book's coin mid or printing "1 base = … quote".
+  const referenceCoinRate = reference ? toCoinPrice(reference.rate) : null;
   const referenceSub = reference
     ? [reference.label, fmtAge(reference.updatedAt)].filter(Boolean).join(' · ')
     : null;
-  const midVsReference = reference && mid > 0 ? fmtOffsetPct(mid, reference.rate) : null;
+  const midVsReference = referenceCoinRate != null && mid > 0 ? fmtOffsetPct(mid, referenceCoinRate) : null;
 
   // —— row selection: hover previews a cumulative range, click commits ——
   const [active, setActive] = useState<Record<string, boolean>>({});
@@ -359,11 +389,13 @@ export function Market({ st, onStartOrder }: { st: ZSwapApp; onStartOrder?: () =
         {pair && (stats || reference) && (
           <div style={{ display: 'flex', gap: 30, flexWrap: 'wrap', alignItems: 'flex-start' }}>
             {stats && <>
-              <Stat label="Last price">{fmtPrice(stats.last)} <span style={{ fontSize: 12, color: 'var(--ink-3)', fontWeight: 600 }}>{quote}</span></Stat>
+              {/* /v1/chart/* serves base units and base-unit price ratios; the
+                  API shape is untouched and the scaling happens here (Q7). */}
+              <Stat label="Last price">{fmtPrice(toCoinPrice(stats.last))} <span style={{ fontSize: 12, color: 'var(--ink-3)', fontWeight: 600 }}>{quote}</span></Stat>
               <Stat label="24h"><span style={{ color: lastUp ? 'var(--pos)' : 'var(--neg)' }}>{lastUp ? '+' : ''}{change24.toFixed(2)}%</span></Stat>
-              <Stat label="High">{fmtPrice(stats.high)}</Stat>
-              <Stat label="Low">{fmtPrice(stats.low)}</Stat>
-              <Stat label="Volume" sub={fmtQty(stats.volume_quote) + ' ' + quote}>{fmtQty(stats.volume_base)} <span style={{ fontSize: 12, color: 'var(--ink-3)', fontWeight: 600 }}>{base}</span></Stat>
+              <Stat label="High">{fmtPrice(toCoinPrice(stats.high))}</Stat>
+              <Stat label="Low">{fmtPrice(toCoinPrice(stats.low))}</Stat>
+              <Stat label="Volume" sub={fmtQty(toQuoteCoins(stats.volume_quote)) + ' ' + quote}>{fmtQty(toBaseCoins(stats.volume_base))} <span style={{ fontSize: 12, color: 'var(--ink-3)', fontWeight: 600 }}>{base}</span></Stat>
             </>}
             <Stat
               label="Reference"
@@ -372,13 +404,13 @@ export function Market({ st, onStartOrder }: { st: ZSwapApp; onStartOrder?: () =
                 ? `Reference price from GET /v1/prices (${reference.label})`
                 : `No market reference for this pair - at least one token is priced by the demo fallback`}
             >
-              {reference
-                ? <>1 {base} = {fmtPrice(reference.rate)} <span style={{ fontSize: 12, color: 'var(--ink-3)', fontWeight: 600 }}>{quote}</span></>
+              {reference && referenceCoinRate != null
+                ? <>1 {base} = {fmtPrice(referenceCoinRate)} <span style={{ fontSize: 12, color: 'var(--ink-3)', fontWeight: 600 }}>{quote}</span></>
                 : <span style={{ color: 'var(--ink-3)', fontWeight: 600 }}>no reference</span>}
             </Stat>
             <Stat label="Mid vs reference" title="How far the order book's mid price sits from the reference price">
               {midVsReference
-                ? <span style={{ color: mid <= (reference?.rate ?? 0) ? 'var(--pos)' : 'var(--neg)' }}>{midVsReference}</span>
+                ? <span style={{ color: mid <= (referenceCoinRate ?? 0) ? 'var(--pos)' : 'var(--neg)' }}>{midVsReference}</span>
                 : <span style={{ color: 'var(--ink-3)', fontWeight: 600 }}>{reference ? 'no book' : 'no reference'}</span>}
             </Stat>
             <Stat label="Asset ID"><TokenChip color={baseColor} knownTokens={st.knownTokens} size="sm" /></Stat>
@@ -537,8 +569,8 @@ export function Market({ st, onStartOrder }: { st: ZSwapApp; onStartOrder?: () =
                   const ts = at.toISOString().slice(0, 16).replace('T', ' ');
                   rows.push(
                     <div key={i} style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1.2fr', padding: '5px 12px', alignItems: 'center' }}>
-                      <span className="zs-num" style={{ fontSize: 13, fontWeight: 600, color: h.up ? 'var(--pos)' : 'var(--neg)' }}>{fmtPrice(h.price)}</span>
-                      <span className="zs-num" style={{ fontSize: 13, textAlign: 'right', color: 'var(--ink)' }}>{fmtQty(h.amt)}</span>
+                      <span className="zs-num" style={{ fontSize: 13, fontWeight: 600, color: h.up ? 'var(--pos)' : 'var(--neg)' }}>{fmtPrice(toCoinPrice(h.price))}</span>
+                      <span className="zs-num" style={{ fontSize: 13, textAlign: 'right', color: 'var(--ink)' }}>{fmtQty(toBaseCoins(h.amt))}</span>
                       <span className="zs-num" style={{ fontSize: 12, textAlign: 'right', color: 'var(--ink-3)' }}>{ts}</span>
                     </div>,
                   );

--- a/templates/zswap-da/src/screens/MyTrades.tsx
+++ b/templates/zswap-da/src/screens/MyTrades.tsx
@@ -6,8 +6,9 @@
 import { useState } from 'react';
 import { Coin, Icon } from '../ui/icons';
 import { Modal, ModalHead } from '../ui/Modal';
-import { fmtAmt, rateDisplay } from '../state/format';
-import type { MyTrade } from '../state/myTrades';
+import { DEFAULT_DECIMALS, formatAmount, scaleRate } from '../state/amount';
+import { rateDisplay } from '../state/format';
+import type { MyTrade, TradeLeg } from '../state/myTrades';
 import type { ZSwapApp } from '../state/useZSwapApp';
 
 function downloadText(name: string, text: string) {
@@ -60,12 +61,14 @@ function StatusBadge({ status }: { status: MyTrade['status'] }) {
   return <span title={s.hint} style={{ display: 'inline-flex', alignItems: 'center', gap: 5, fontSize: 11.5, fontWeight: 700, color: s.c, background: s.bg, borderRadius: 'var(--r-pill)', padding: '4px 10px', whiteSpace: 'nowrap', cursor: s.hint ? 'help' : undefined }}><Icon.dot /> {s.label}</span>;
 }
 
-function Cell({ amt, sym, accent }: { amt: number; sym: string; accent?: boolean }) {
+/** A recorded leg. `amt` is base units; `decimals` is absent on records written
+ *  before project 00024, which are then read at the default precision. */
+function Cell({ leg, accent }: { leg: TradeLeg; accent?: boolean }) {
   return (
     <span style={{ display: 'inline-flex', alignItems: 'center', gap: 7, whiteSpace: 'nowrap' }}>
-      <Coin sym={sym} size="sm" />
-      <span className="zs-num" style={{ fontWeight: 600, fontSize: 13.5, color: accent ? 'var(--accent)' : 'var(--ink)' }}>{fmtAmt(amt)}</span>
-      <span style={{ fontSize: 12, color: 'var(--ink-3)' }}>{sym}</span>
+      <Coin sym={leg.sym} size="sm" />
+      <span className="zs-num" style={{ fontWeight: 600, fontSize: 13.5, color: accent ? 'var(--accent)' : 'var(--ink)' }}>{formatAmount(leg.amt, leg.decimals ?? DEFAULT_DECIMALS)}</span>
+      <span style={{ fontSize: 12, color: 'var(--ink-3)' }}>{leg.sym}</span>
     </span>
   );
 }
@@ -152,13 +155,17 @@ export function MyTrades({ st, compact }: { st: ZSwapApp; compact?: boolean }) {
               </tr></thead>
               <tbody>
                 {rows.map((t) => {
-                  const price = t.give.amt > 0 ? t.get.amt / t.give.amt : 0;
+                  // Both legs are base units, so their ratio is a base-unit
+                  // rate — scaled to "1 offered coin = price requested coins".
+                  const price = t.give.amt > 0
+                    ? scaleRate(t.get.amt / t.give.amt, t.give.decimals ?? DEFAULT_DECIMALS, t.get.decimals ?? DEFAULT_DECIMALS)
+                    : 0;
                   const r = rateDisplay(price);
                   const d = new Date(t.at);
                   return (
                     <tr key={t.id}>
-                      <td><Cell amt={t.give.amt} sym={t.give.sym} /></td>
-                      <td><Cell amt={t.get.amt} sym={t.get.sym} accent /></td>
+                      <td><Cell leg={t.give} /></td>
+                      <td><Cell leg={t.get} accent /></td>
                       <td style={{ textAlign: 'right' }}>
                         <div className="zs-num" style={{ fontSize: 13, fontWeight: 600, whiteSpace: 'nowrap' }}>{r.kind === 'plain' ? r.text : (<>{r.mant} × 10<sup style={{ fontSize: '.72em' }}>{r.exp}</sup></>)} <span style={{ color: 'var(--ink-3)', fontWeight: 400 }}>{t.get.sym}</span></div>
                       </td>
@@ -192,9 +199,9 @@ export function MyTrades({ st, compact }: { st: ZSwapApp; compact?: boolean }) {
             <ModalHead title="Offer file" onClose={() => setViewing(null)} />
             <div style={{ padding: 16 }}>
               <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 12 }}>
-                <Coin sym={viewing.give.sym} size="sm" /><span className="zs-num" style={{ fontWeight: 600, fontSize: 13 }}>{fmtAmt(viewing.give.amt)} {viewing.give.sym}</span>
+                <Coin sym={viewing.give.sym} size="sm" /><span className="zs-num" style={{ fontWeight: 600, fontSize: 13 }}>{formatAmount(viewing.give.amt, viewing.give.decimals ?? DEFAULT_DECIMALS)} {viewing.give.sym}</span>
                 <Icon.arrow style={{ color: 'var(--ink-3)' }} />
-                <Coin sym={viewing.get.sym} size="sm" /><span className="zs-num" style={{ fontWeight: 600, fontSize: 13, color: 'var(--accent)' }}>{fmtAmt(viewing.get.amt)} {viewing.get.sym}</span>
+                <Coin sym={viewing.get.sym} size="sm" /><span className="zs-num" style={{ fontWeight: 600, fontSize: 13, color: 'var(--accent)' }}>{formatAmount(viewing.get.amt, viewing.get.decimals ?? DEFAULT_DECIMALS)} {viewing.get.sym}</span>
                 {viewing.shielded && <span className="zs-badge-shield" style={{ marginLeft: 'auto' }}><Icon.shield /> Shielded</span>}
               </div>
               <textarea readOnly value={viewing.blob ?? '(no offer blob stored for this trade)'} onFocus={(e) => e.currentTarget.select()}
@@ -218,10 +225,10 @@ export function MyTrades({ st, compact }: { st: ZSwapApp; compact?: boolean }) {
           {preview && (preview.pays.length > 0 || preview.gets.length > 0) ? (
             <div style={{ marginTop: 12, padding: '11px 13px', borderRadius: 'var(--r-field)', background: 'var(--surface-2)', display: 'flex', alignItems: 'center', gap: 10, flexWrap: 'wrap', fontSize: 13 }}>
               <span style={{ color: 'var(--ink-3)' }}>You pay</span>
-              {preview.pays.map((l, i) => <span key={'p' + i} style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}><Coin sym={l.sym} size="sm" /><span className="zs-num" style={{ fontWeight: 700 }}>{fmtAmt(l.amt)}</span> {l.sym}</span>)}
+              {preview.pays.map((l, i) => <span key={'p' + i} style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}><Coin sym={l.sym} size="sm" /><span className="zs-num" style={{ fontWeight: 700 }}>{formatAmount(l.amt, l.decimals)}</span> {l.sym}</span>)}
               <Icon.arrow style={{ color: 'var(--ink-3)' }} />
               <span style={{ color: 'var(--ink-3)' }}>receive</span>
-              {preview.gets.map((l, i) => <span key={'g' + i} style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}><Coin sym={l.sym} size="sm" /><span className="zs-num" style={{ fontWeight: 700, color: 'var(--accent)' }}>{fmtAmt(l.amt)}</span> {l.sym}</span>)}
+              {preview.gets.map((l, i) => <span key={'g' + i} style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}><Coin sym={l.sym} size="sm" /><span className="zs-num" style={{ fontWeight: 700, color: 'var(--accent)' }}>{formatAmount(l.amt, l.decimals)}</span> {l.sym}</span>)}
               {preview.shielded && <span className="zs-badge-shield" style={{ marginLeft: 'auto' }}><Icon.shield /> Shielded</span>}
             </div>
           ) : dump.trim() ? (

--- a/templates/zswap-da/src/screens/Swap.tsx
+++ b/templates/zswap-da/src/screens/Swap.tsx
@@ -8,7 +8,9 @@
 // inside the bottom console dock (`compact`). `Swap` keeps the standalone hero
 // layout for any full-page use.
 //
-// Amounts are integer base units (the ledger has no decimals). Requires the
+// Amounts are typed and shown in WHOLE COINS, scaled by each token's own
+// `decimals` from the registry; everything below this screen — the quote
+// request, the offer legs, the chain — stays integer base units. Requires the
 // browser wallet (Lace / ConnectedAPI); the local JS wallet can't makeIntent.
 
 import { useEffect, useState } from 'react';
@@ -17,35 +19,30 @@ import { TokenPicker } from '../ui/TokenPicker';
 import { api, type Quote } from '../services/api';
 import { log } from '../lib/log';
 import { fmtUsd, rateDisplay } from '../state/format';
+import {
+  amountErrorText,
+  formatAmount,
+  formatBaseUnits,
+  sanitizeAmountInput,
+} from '../state/amount';
+import {
+  displayRate,
+  hasBalanceFor,
+  legDecimals,
+  parseLeg,
+  suggestedFieldValue,
+} from '../state/swapAmounts';
 import { describeQuote } from '../state/reference';
 import type { KnownToken } from '../types';
 import type { OfferLeg } from '../services/makerOffer';
 import type { ZSwapApp } from '../state/useZSwapApp';
-
-/**
- * Parse a typed amount into exact integer base units.
- *
- * Returns null for anything that isn't a whole non-negative number — including
- * decimals, which the ledger has no notion of. Rejecting them here beats
- * `BigInt(1.5)` throwing a bare RangeError from inside the submit path.
- */
-function parseUnits(raw: string): bigint | null {
-  const s = raw.trim().replace(/[,_\s]/g, '');
-  if (!/^\d+$/.test(s)) return null;
-  try {
-    return BigInt(s);
-  } catch {
-    return null;
-  }
-}
-
-const intize = (v: string) => v.replace(/[^0-9]/g, '');
 
 function RateInline({ value }: { value: number }) {
   const r = rateDisplay(value);
   return <span className="zs-num" style={{ fontWeight: 600, color: 'var(--ink)' }}>{r.kind === 'plain' ? r.text : (<>{r.mant} × 10<sup style={{ fontSize: '.72em' }}>{r.exp}</sup></>)}</span>;
 }
 
+/** Raw base-unit balance string for a token, or null when there is none. */
 function balanceFor(st: ZSwapApp, token: KnownToken | null): string | null {
   if (!token) return null;
   const map = token.kind === 'shielded' ? st.shieldedBalances : st.unshieldedBalances;
@@ -54,20 +51,29 @@ function balanceFor(st: ZSwapApp, token: KnownToken | null): string | null {
 
 function FieldRow({ label, token, value, onValue, onPick, onClear, readOnly, accent, balance, usd, compact }: {
   label: string; token: KnownToken | null; value: string; onValue?: (v: string) => void;
-  onPick: () => void; onClear?: () => void; readOnly?: boolean; accent?: boolean; balance?: string | null; usd?: number | null; compact?: boolean;
+  onPick: () => void; onClear?: () => void; readOnly?: boolean; accent?: boolean;
+  /** RAW base-unit balance string, as the wallet reports it. Rendered in coins. */
+  balance?: string | null; usd?: number | null; compact?: boolean;
 }) {
+  // The token's own precision drives both the keystroke filter and the balance
+  // chip; with no token picked yet, fall back to the app-wide default.
+  const decimals = legDecimals(token);
   return (
     <div className="zs-field">
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: compact ? 7 : 12 }}>
         <span className="zs-field-label">{label}</span>
         {token && balance != null && (
-          <span style={{ fontSize: 12.5, color: 'var(--ink-3)' }}>Balance <span className="zs-num" style={{ color: 'var(--ink-2)' }}>{balance}</span>
-            {!readOnly && <button onClick={() => onValue?.(intize(balance))} className="zs-num" style={{ marginLeft: 7, border: 'none', background: 'var(--accent-soft)', color: 'var(--accent)', borderRadius: 6, padding: '2px 6px', fontSize: 11, fontWeight: 700, cursor: 'pointer' }}>MAX</button>}
+          <span style={{ fontSize: 12.5, color: 'var(--ink-3)' }}>Balance <span className="zs-num" style={{ color: 'var(--ink-2)' }}>{formatAmount(balance, decimals)}</span>
+            {/* MAX pastes the EXACT balance in coins (`formatBaseUnits`, not the
+                grouped/rounded `formatAmount`), so re-parsing it returns the
+                wallet's balance to the base unit and "spend everything" is
+                actually everything. */}
+            {!readOnly && <button onClick={() => onValue?.(formatBaseUnits(balance, decimals))} className="zs-num" style={{ marginLeft: 7, border: 'none', background: 'var(--accent-soft)', color: 'var(--accent)', borderRadius: 6, padding: '2px 6px', fontSize: 11, fontWeight: 700, cursor: 'pointer' }}>MAX</button>}
           </span>
         )}
       </div>
       <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
-        <input value={value} onChange={(e) => onValue?.(intize(e.target.value))} readOnly={readOnly} placeholder="0" inputMode="numeric"
+        <input value={value} onChange={(e) => onValue?.(sanitizeAmountInput(e.target.value, decimals))} readOnly={readOnly} placeholder="0" inputMode="decimal"
           className="zs-amount" style={{ fontSize: compact ? 24 : undefined, color: value ? (accent ? 'var(--accent)' : 'var(--ink)') : 'var(--ink-4)', cursor: readOnly ? 'default' : 'text' }} />
         {token ? (
           <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6, flex: '0 0 auto' }}>
@@ -110,20 +116,24 @@ export function PlaceOrderForm({ st, compact, requestPayPicker, onPayPickerHandl
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [requestPayPicker]);
 
-  // Amounts are parsed straight from the input STRING to bigint. Going via
-  // Number() first would silently round anything past 2^53 (a double's exact
-  // integer range) and the BigInt() afterwards would faithfully preserve the
-  // corrupted value — so the wallet would build an offer for an amount the user
-  // never typed. Ledger amounts are u128 integer base units, so a plain decimal
-  // string is the whole grammar.
-  const payBig = parseUnits(payAmt);
-  const recvBig = parseUnits(recvAmt);
+  // Amounts are parsed straight from the input STRING to bigint, EACH LEG WITH
+  // ITS OWN TOKEN'S DECIMALS. Going via Number() first would silently round
+  // anything past 2^53 (a double's exact integer range) and the BigInt()
+  // afterwards would faithfully preserve the corrupted value — so the wallet
+  // would build an offer for an amount the user never typed. `parseLeg` also
+  // says WHY it refused, which is how an over-precise amount gets a message
+  // naming the token's precision instead of a generic "invalid".
+  const payParsed = parseLeg(payAmt, from);
+  const recvParsed = parseLeg(recvAmt, to);
+  const payBig = payParsed.value;
+  const recvBig = recvParsed.value;
   const bothSel = !!(from && to);
   const sameKind = from && to ? from.kind === to.kind : true;
   const bothShielded = !!(from && to && from.kind === 'shielded' && to.kind === 'shielded');
 
-  // Canonical decimal strings — the quote endpoint takes strings, so the whole
-  // path stays exact with no double round-trip.
+  // Canonical BASE-UNIT decimal strings — `/v1/quote` speaks base units and
+  // always has, so this is the conversion boundary: coins above it, base units
+  // below it. No double round-trip anywhere on the path.
   const payStr = payBig?.toString() ?? '';
   const recvStr = recvBig?.toString() ?? '';
 
@@ -137,7 +147,8 @@ export function PlaceOrderForm({ st, compact, requestPayPicker, onPayPickerHandl
         const qres = await api.getQuote(from.token_color, to.token_color, payStr, autoPrice ? undefined : (recvBig && recvBig > 0n ? recvStr : undefined));
         if (cancelled) return;
         setQuote(qres);
-        if (autoPrice) setRecvAmt(qres.suggested_to_amount);
+        // `suggested_to_amount` is base units; the field is coins.
+        if (autoPrice) setRecvAmt(suggestedFieldValue(qres.suggested_to_amount, to));
       } catch {
         if (!cancelled) setQuote(null);
       }
@@ -156,8 +167,10 @@ export function PlaceOrderForm({ st, compact, requestPayPicker, onPayPickerHandl
     setErrorCode(null);
     if (!from || !to) return;
     if (!sameKind) { setError('Both tokens must be the same privacy kind (all shielded or all unshielded).'); return; }
-    if (payAmt.trim() !== '' && payBig === null) { setError('Amounts are whole base units — no decimals or separators.'); return; }
-    if (recvAmt.trim() !== '' && recvBig === null) { setError('Amounts are whole base units — no decimals or separators.'); return; }
+    // Over-precision is REFUSED here, never rounded: the amount below is what
+    // settles on chain, and quietly posting a different one is not an option.
+    if (payAmt.trim() !== '' && payParsed.error) { setError(amountErrorText(payParsed.error, from.decimals, from.name)); return; }
+    if (recvAmt.trim() !== '' && recvParsed.error) { setError(amountErrorText(recvParsed.error, to.decimals, to.name)); return; }
     if (payBig === null || recvBig === null || payBig <= 0n || recvBig <= 0n) { setError('Enter both amounts.'); return; }
     setPosting(true);
     let phase = 'Building offer in wallet…';
@@ -166,7 +179,7 @@ export function PlaceOrderForm({ st, compact, requestPayPicker, onPayPickerHandl
     try {
       const gives: OfferLeg[] = [{ kind: from.kind, color: from.token_color, amount: payBig }];
       const wants: OfferLeg[] = [{ kind: to.kind, color: to.token_color, amount: recvBig }];
-      log.info('[create-offer] start', { pay: payBig.toString(), recv: recvBig.toString(), from: from.name, to: to.name, kind: from.kind, fromColor: from.token_color, toColor: to.token_color });
+      log.info('[create-offer] start', { payCoins: payAmt, recvCoins: recvAmt, pay: payBig.toString(), recv: recvBig.toString(), from: from.name, to: to.name, kind: from.kind, fromColor: from.token_color, toColor: to.token_color });
       // Bound the whole flow so a hung wallet/proof step can't sit on "Creating…"
       // forever — surface a clear, retryable error naming the phase it stuck on.
       await Promise.race([
@@ -191,13 +204,13 @@ export function PlaceOrderForm({ st, compact, requestPayPicker, onPayPickerHandl
     }
   };
 
-  // Maker can only offer to pay tokens it holds. Compared in bigint: balances
-  // are raw integer strings, so Number() on either side could round two
-  // distinct amounts onto the same double and let an unaffordable offer through
-  // this gate. (createOffer re-checks authoritatively in bigint regardless.)
+  // Maker can only offer to pay tokens it holds. Compared in bigint AND IN THE
+  // SAME UNIT on both sides: the wallet reports raw base-unit integer strings
+  // and `payBig` is already base units, so no scaling happens here — doing it
+  // in Number() could round two distinct amounts onto the same double and let
+  // an unaffordable offer through. (createOffer re-checks in bigint regardless.)
   const payBalance = balanceFor(st, from);
-  const payBalanceBig = parseUnits(String(payBalance ?? '0')) ?? 0n;
-  const insufficientPay = !!from && payBig !== null && payBig > 0n && payBalanceBig < payBig;
+  const insufficientPay = !!from && payBig !== null && payBig > 0n && !hasBalanceFor(payBig, payBalance);
 
   // primary button state machine (mirrors the mock)
   let label = 'Connect wallet';
@@ -207,8 +220,8 @@ export function PlaceOrderForm({ st, compact, requestPayPicker, onPayPickerHandl
     if (!st.canTrade) { label = 'Use the browser wallet (Lace) to create offers'; disabled = true; action = () => {}; }
     else if (!bothSel) { label = 'Select tokens'; disabled = true; action = () => {}; }
     else if (!sameKind) { label = 'Tokens must share privacy kind'; disabled = true; action = () => {}; }
-    else if (payAmt.trim() !== '' && payBig === null) { label = 'Whole base units only'; disabled = true; action = () => {}; }
-    else if (recvAmt.trim() !== '' && recvBig === null) { label = 'Whole base units only'; disabled = true; action = () => {}; }
+    else if (payAmt.trim() !== '' && payParsed.error) { label = payParsed.error === 'precision' ? `Max ${from!.decimals} decimals for ${from!.name}` : 'Check the amount you pay'; disabled = true; action = () => {}; }
+    else if (recvAmt.trim() !== '' && recvParsed.error) { label = recvParsed.error === 'precision' ? `Max ${to!.decimals} decimals for ${to!.name}` : 'Check the amount you want'; disabled = true; action = () => {}; }
     else if (payBig === null || payBig <= 0n) { label = 'Enter the amount you pay'; disabled = true; action = () => {}; }
     else if (recvBig === null || recvBig <= 0n) { label = 'Enter the amount you want'; disabled = true; action = () => {}; }
     else if (insufficientPay) { label = `Insufficient ${from!.name}`; disabled = true; action = () => {}; }
@@ -221,6 +234,13 @@ export function PlaceOrderForm({ st, compact, requestPayPicker, onPayPickerHandl
   // offset from it, the sponsorship threshold, and where the price came from.
   // Pure and unit-tested in state/reference.test.ts.
   const ref = quote ? describeQuote(quote, from?.name ?? '', to?.name ?? '') : null;
+
+  // The node's `implied_rate` / `market_rate` are BASE-UNIT rates (base units of
+  // `to` per base unit of `from`). "1 WBTC = X WETH" is a WHOLE-COIN rate, so
+  // both are scaled by 10^(dFrom − dTo) — the identity while every token is 6,
+  // and the reason a future 8-decimals token still reads right. `ref.offset` and
+  // the sponsorship percentages are ratios of two rates and so need no scaling.
+  const rateScale = (r: number | null | undefined): number => displayRate(r, from, to);
 
   return (
     <>
@@ -244,7 +264,7 @@ export function PlaceOrderForm({ st, compact, requestPayPicker, onPayPickerHandl
             {payBig !== null && payBig > 0n && recvBig !== null && recvBig > 0n && quote && (
               <>
                 <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', justifyContent: 'space-between', gap: '4px 14px', fontSize: 13 }}>
-                  <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6, color: 'var(--ink-2)', whiteSpace: 'nowrap' }}><Icon.shield style={{ color: 'var(--accent)', flex: '0 0 auto' }} /> Your rate · 1 {from!.name} = <RateInline value={quote.implied_rate ?? 0} /> {to!.name}</span>
+                  <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6, color: 'var(--ink-2)', whiteSpace: 'nowrap' }}><Icon.shield style={{ color: 'var(--accent)', flex: '0 0 auto' }} /> Your rate · 1 {from!.name} = <RateInline value={rateScale(quote.implied_rate)} /> {to!.name}</span>
                   {ref?.offset && <span className="zs-num" style={{ color: ref.offsetBelow ? 'var(--pos)' : 'var(--neg)', whiteSpace: 'nowrap', fontWeight: 600 }}>{ref.offset} vs reference</span>}
                 </div>
                 {/* The reference rate is shown in BOTH price modes now: in auto
@@ -252,7 +272,7 @@ export function PlaceOrderForm({ st, compact, requestPayPicker, onPayPickerHandl
                     and how far below it the sponsorship threshold sits. */}
                 {ref?.referenceRate != null && (
                   <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: '2px 12px', fontSize: 11.5, color: 'var(--ink-3)' }}>
-                    <span style={{ whiteSpace: 'nowrap' }}>Reference · 1 {from!.name} = <RateInline value={ref.referenceRate} /> {to!.name}</span>
+                    <span style={{ whiteSpace: 'nowrap' }}>Reference · 1 {from!.name} = <RateInline value={rateScale(ref.referenceRate)} /> {to!.name}</span>
                     {ref.thresholdText && <span style={{ whiteSpace: 'nowrap' }}>{ref.thresholdText}</span>}
                   </div>
                 )}

--- a/templates/zswap-da/src/services/api.test.ts
+++ b/templates/zswap-da/src/services/api.test.ts
@@ -46,8 +46,8 @@ const PRICES_FIXTURE = {
     { asset_id: 'usdm', price_usd: '1', source: 'fixed', provider_updated_at: null, updated_at: '2026-09-03T00:00:04.000Z' },
   ],
   tokens: [
-    { token_color: 'e7'.repeat(32), name: 'WBTC', kind: 'shielded', decimals: 0, asset_id: 'bitcoin', price_usd: '77387', source: 'feed', updated_at: '2026-09-03T00:00:04.000Z' },
-    { token_color: 'aa'.repeat(32), name: 'TESTTOKENA', kind: 'shielded', decimals: 0, asset_id: null, price_usd: '13.02', source: 'fallback', updated_at: '2026-09-01T10:00:00.000Z' },
+    { token_color: 'e7'.repeat(32), name: 'WBTC', kind: 'shielded', decimals: 6, asset_id: 'bitcoin', price_usd: '77387', source: 'feed', updated_at: '2026-09-03T00:00:04.000Z' },
+    { token_color: 'aa'.repeat(32), name: 'TESTTOKENA', kind: 'shielded', decimals: 6, asset_id: null, price_usd: '13.02', source: 'fallback', updated_at: '2026-09-01T10:00:00.000Z' },
   ],
 };
 

--- a/templates/zswap-da/src/services/api.ts
+++ b/templates/zswap-da/src/services/api.ts
@@ -6,6 +6,7 @@ import type {
   OfferStatusLookup,
 } from '../types';
 import { API_BASE, BATCHER_URL, BATCHER_TARGET } from '../config';
+import { DEFAULT_DECIMALS } from '../state/amount';
 import { dlog, timed } from '../debug';
 import type { PriceSource } from '../state/format';
 
@@ -407,11 +408,24 @@ export const api = {
     return data;
   },
 
-  registerKnownToken: async (color: string, name: string, kind: 'shielded' | 'unshielded') => {
+  /**
+   * Register a freshly minted colour in the node's `known_tokens` registry.
+   *
+   * `decimals` is sent EXPLICITLY rather than relying on the server default: an
+   * older node still defaults the column to 0, and a token registered at 0
+   * would render a million times too large everywhere. Sending it also makes a
+   * future non-6 token a deliberate override rather than a silent inheritance.
+   */
+  registerKnownToken: async (
+    color: string,
+    name: string,
+    kind: 'shielded' | 'unshielded',
+    decimals: number = DEFAULT_DECIMALS,
+  ) => {
     const res = await fetch(`${V1}/known-tokens`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ color, name, kind }),
+      body: JSON.stringify({ color, name, kind, decimals }),
     });
     const data = await res.json();
     if (!res.ok) throw new Error(data.message ?? JSON.stringify(data));

--- a/templates/zswap-da/src/services/mintQueue.ts
+++ b/templates/zswap-da/src/services/mintQueue.ts
@@ -12,12 +12,18 @@
 // registers it with the oldest queued name. The queue is persisted to
 // localStorage so it survives reloads.
 
+import { DEFAULT_DECIMALS } from '../state/amount';
+
 const STORAGE_KEY = 'zswap-da:pending-mint-names';
 
 export interface PendingMintName {
   id: string;        // unique — used to remove entries once consumed
   name: string;
   enqueuedAt: number;
+  /** Precision the mint was made at, so the reconciler's retry registers the
+   *  same value the immediate call would have. Optional: entries persisted by a
+   *  build before project 00024 have none and fall back to DEFAULT_DECIMALS. */
+  decimals?: number;
 }
 
 function read(): PendingMintName[] {
@@ -55,11 +61,12 @@ export function listPending(): PendingMintName[] {
   return read();
 }
 
-export function enqueueMintName(name: string): PendingMintName {
+export function enqueueMintName(name: string, decimals: number = DEFAULT_DECIMALS): PendingMintName {
   const entry: PendingMintName = {
     id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
     name,
     enqueuedAt: Date.now(),
+    decimals,
   };
   const next = [...read(), entry];
   write(next);

--- a/templates/zswap-da/src/services/takeSelection.test.ts
+++ b/templates/zswap-da/src/services/takeSelection.test.ts
@@ -7,35 +7,42 @@ import type { KnownToken } from '../types';
 import { affordableSelection, defaultSelection, summarize, type SelectableOffer } from './takeSelection';
 
 const WETH = 'aa'.repeat(32);
-const known: KnownToken[] = [{ token_color: WETH, name: 'WETH', kind: 'shielded' } as KnownToken];
+const DECIMALS = 6;
+/** One whole WETH coin in base units. Every fixture below is written in coins
+ *  and scaled here, because the module's own unit is base units. */
+const COIN = 10 ** DECIMALS;
+const known: KnownToken[] = [{ token_color: WETH, name: 'WETH', kind: 'shielded', decimals: DECIMALS } as KnownToken];
 const leg = (amount: bigint): ParsedLeg => ({ color: WETH, kind: 'shielded', amount });
 
-/** Taker pays `cost` WETH and receives `gets` WBTC — the shape of one book row. */
+/** Taker pays `cost` WETH coins and receives `gets` WBTC coins — one book row. */
 const offer = (id: string, cost: number, gets: number, mine = false): SelectableOffer => ({
   id,
-  pay: { sym: 'WETH', amt: cost },
-  receive: { sym: 'WBTC', amt: gets },
-  pays: [leg(BigInt(cost))],
+  pay: { sym: 'WETH', amt: cost * COIN, decimals: DECIMALS },
+  receive: { sym: 'WBTC', amt: gets * COIN, decimals: DECIMALS },
+  pays: [leg(BigInt(cost * COIN))],
   mine,
 });
 
 const items = [offer('a', 3, 15), offer('b', 4, 18), offer('c', 5, 20)];
-const balances = (weth: string) => ({ shielded: { [WETH]: weth }, unshielded: null });
+/** Wallet balance in WETH coins → the base-unit string the wallet reports. */
+const balances = (weth: string) => ({ shielded: { [WETH]: String(Number(weth) * COIN) }, unshielded: null });
 
 describe('summarize totals', () => {
   test('all checked → the full pay/receive of the selection', () => {
     const s = summarize(items, ['a', 'b', 'c'], balances('100'), known);
     expect(s.count).toBe(3);
-    expect(s.pay).toEqual({ sym: 'WETH', amt: 12 });
-    expect(s.receive).toEqual({ sym: 'WBTC', amt: 53 });
+    // Totals are summed in BASE UNITS — integers add exactly; the caller
+    // renders them as coins with the `decimals` carried alongside.
+    expect(s.pay).toEqual({ sym: 'WETH', amt: 12 * COIN, decimals: DECIMALS });
+    expect(s.receive).toEqual({ sym: 'WBTC', amt: 53 * COIN, decimals: DECIMALS });
     expect(s.blocked).toBeNull();
   });
 
   test('unchecking a row recomputes both totals', () => {
     const s = summarize(items, ['a', 'c'], balances('100'), known);
     expect(s.count).toBe(2);
-    expect(s.pay.amt).toBe(8);
-    expect(s.receive.amt).toBe(35);
+    expect(s.pay.amt).toBe(8 * COIN);
+    expect(s.receive.amt).toBe(35 * COIN);
   });
 
   test('the checked order is irrelevant — it is a fold, not a sequence', () => {
@@ -50,8 +57,8 @@ describe('summarize totals', () => {
   test('nothing checked → zero totals, the pair still named', () => {
     const s = summarize(items, [], balances('100'), known);
     expect(s.count).toBe(0);
-    expect(s.pay).toEqual({ sym: 'WETH', amt: 0 });
-    expect(s.receive).toEqual({ sym: 'WBTC', amt: 0 });
+    expect(s.pay).toEqual({ sym: 'WETH', amt: 0, decimals: DECIMALS });
+    expect(s.receive).toEqual({ sym: 'WBTC', amt: 0, decimals: DECIMALS });
     // Not a shortfall: an empty selection costs nothing, it is simply not
     // confirmable (the dialog disables the CTA).
     expect(s.blocked).toBeNull();
@@ -65,8 +72,9 @@ describe('summarize totals', () => {
 });
 
 describe('summarize blocked message', () => {
-  test('the checked subset is what gets balance-checked', () => {
-    // 12 WETH for all three, but only 9 in the wallet.
+  test('the checked subset is what gets balance-checked, in WHOLE COINS', () => {
+    // 12 WETH for all three, but only 9 in the wallet. The message reads in
+    // coins, not the 12000000/9000000 base units it compares.
     expect(summarize(items, ['a', 'b', 'c'], balances('9'), known).blocked)
       .toBe('Insufficient WETH: need 12, have 9');
     // Uncheck the 5 and it fits.
@@ -149,6 +157,6 @@ describe('own offers stay identifiable in the list', () => {
     expect(withMine.filter((i) => i.mine).map((i) => i.id)).toEqual(['a']);
     // Including your own offer is a normal selection — it costs and pays like
     // any other row.
-    expect(summarize(withMine, ['a', 'b'], balances('100')).pay.amt).toBe(7);
+    expect(summarize(withMine, ['a', 'b'], balances('100')).pay.amt).toBe(7 * COIN);
   });
 });

--- a/templates/zswap-da/src/services/takeSelection.ts
+++ b/templates/zswap-da/src/services/takeSelection.ts
@@ -9,14 +9,22 @@
 
 import type { ParsedLeg } from './offerParse';
 import type { KnownToken } from '../types';
+import { DEFAULT_DECIMALS } from '../state/amount';
 import { affordableIndices, shortfallMessage, shortfallsFromLegs, sumLegs } from './takerBalance';
 
-/** One selectable offer of a take. Display amounts are floats (the book's own
- *  unit); `pays` carries the exact bigint legs the balance check needs. */
+/**
+ * One selectable offer of a take.
+ *
+ * `pay.amt`/`receive.amt` are BASE UNITS as floats (the book's own unit) with
+ * the token's `decimals` beside them; the caller renders coins. Totals are
+ * summed in base units on purpose — integers add exactly below 2^53, whereas
+ * summing already-divided coins would drift across a deep ladder. `pays`
+ * carries the exact bigint legs the balance check needs.
+ */
 export interface SelectableOffer {
   id: string;
-  pay: { sym: string; amt: number };
-  receive: { sym: string; amt: number };
+  pay: { sym: string; amt: number; decimals?: number };
+  receive: { sym: string; amt: number; decimals?: number };
   /** Legs the taker must SUPPLY for this offer. Empty for an undecodable blob,
    *  which then contributes no cost — the settle path surfaces those. */
   pays: ParsedLeg[];
@@ -31,8 +39,9 @@ export interface TakerBalances {
 
 export interface TakeSummary {
   count: number;
-  pay: { sym: string; amt: number };
-  receive: { sym: string; amt: number };
+  /** Totals in BASE UNITS, with the precision needed to render them as coins. */
+  pay: { sym: string; amt: number; decimals: number };
+  receive: { sym: string; amt: number; decimals: number };
   /** Why the checked set can't be funded, or null. */
   blocked: string | null;
   cta: string;
@@ -86,8 +95,16 @@ export function summarize(
       );
   return {
     count: n,
-    pay: { sym: shape?.pay.sym ?? '—', amt: sel.reduce((s, i) => s + i.pay.amt, 0) },
-    receive: { sym: shape?.receive.sym ?? '—', amt: sel.reduce((s, i) => s + i.receive.amt, 0) },
+    pay: {
+      sym: shape?.pay.sym ?? '—',
+      amt: sel.reduce((s, i) => s + i.pay.amt, 0),
+      decimals: shape?.pay.decimals ?? DEFAULT_DECIMALS,
+    },
+    receive: {
+      sym: shape?.receive.sym ?? '—',
+      amt: sel.reduce((s, i) => s + i.receive.amt, 0),
+      decimals: shape?.receive.decimals ?? DEFAULT_DECIMALS,
+    },
     blocked,
     // The CTA states the size of the commitment; with nothing checked it names
     // what's missing rather than offering "Take 0 offers".

--- a/templates/zswap-da/src/services/takerBalance.test.ts
+++ b/templates/zswap-da/src/services/takerBalance.test.ts
@@ -6,7 +6,9 @@ import { shortfallsFromLegs, shortfallMessage, takerShortfalls, batchTakerShortf
 const A = 'aa'.repeat(32); // shielded token color
 const B = 'bb'.repeat(32); // unshielded token color
 const leg = (color: string, kind: ParsedLeg['kind'], amount: bigint): ParsedLeg => ({ color, kind, amount });
-const known: KnownToken[] = [{ token_color: A, name: 'TESTTOKENA', kind: 'shielded' } as KnownToken];
+const known: KnownToken[] = [{ token_color: A, name: 'TESTTOKENA', kind: 'shielded', decimals: 6 } as KnownToken];
+/** One whole TESTTOKENA coin in base units. */
+const COIN = 1_000_000n;
 
 describe('shortfallsFromLegs', () => {
   test('sufficient balance → no shortfall', () => {
@@ -50,6 +52,23 @@ describe('shortfallsFromLegs', () => {
     expect(shortfallsFromLegs([leg(A, 'shielded', 1500n)], { [A]: '1,000' }, null)[0]).toMatchObject({ have: 1000n });
   });
 
+  test('balances are BASE-UNIT strings — a whole-coin string is truncated', () => {
+    // Pin, not a feature: `toBig` cuts at the '.', so handing this comparison a
+    // whole-coin string ("1.5") would silently read 1 base unit and block every
+    // take. Wallet balances and ParsedLeg.amount are both base units, and this
+    // test exists so a future refactor that "helpfully" formats a balance into
+    // coins on the way in fails here instead of in a user's wallet.
+    expect(shortfallsFromLegs([leg(A, 'shielded', 2n)], { [A]: '1.5' }, null)[0]).toMatchObject({ have: 1n });
+    expect(shortfallsFromLegs([leg(A, 'shielded', 1_500_000n)], { [A]: '1500000' }, null)).toEqual([]);
+  });
+
+  test('the shortfall carries the token precision it will be rendered with', () => {
+    const sf = shortfallsFromLegs([leg(A, 'shielded', 51n)], { [A]: '10' }, null, known);
+    expect(sf[0].decimals).toBe(6);
+    // Unregistered colour: nothing says otherwise, so the default applies.
+    expect(shortfallsFromLegs([leg(B, 'unshielded', 5n)], null, {})[0].decimals).toBe(6);
+  });
+
   test('no pays legs → nothing to block', () => {
     expect(shortfallsFromLegs([], null, null)).toEqual([]);
   });
@@ -59,14 +78,24 @@ describe('shortfallMessage', () => {
   test('null when fundable', () => {
     expect(shortfallMessage([])).toBeNull();
   });
-  test('names the first token + need/have', () => {
-    const msg = shortfallMessage(shortfallsFromLegs([leg(A, 'shielded', 51n)], { [A]: '10' }, null, known));
+  test('names the first token + need/have IN WHOLE COINS', () => {
+    // The comparison is in base units; the sentence sits beside the confirm
+    // dialog's coin totals, so it has to speak the same unit the user does.
+    const msg = shortfallMessage(
+      shortfallsFromLegs([leg(A, 'shielded', 51n * COIN)], { [A]: '10000000' }, null, known),
+    );
     expect(msg).toBe('Insufficient TESTTOKENA: need 51, have 10');
+  });
+  test('a sub-coin shortfall keeps its precision rather than reading as 0', () => {
+    const msg = shortfallMessage(
+      shortfallsFromLegs([leg(A, 'shielded', 1_500_000n)], { [A]: '1' }, null, known),
+    );
+    expect(msg).toBe('Insufficient TESTTOKENA: need 1.5, have 0.000001');
   });
   test('summarizes extra shortfalls', () => {
     const msg = shortfallMessage([
-      { color: A, kind: 'shielded', need: 5n, have: 0n, sym: 'TESTTOKENA' },
-      { color: B, kind: 'unshielded', need: 2n, have: 0n, sym: 'USDC' },
+      { color: A, kind: 'shielded', need: 5n * COIN, have: 0n, sym: 'TESTTOKENA', decimals: 6 },
+      { color: B, kind: 'unshielded', need: 2n * COIN, have: 0n, sym: 'USDC', decimals: 6 },
     ]);
     expect(msg).toBe('Insufficient TESTTOKENA: need 5, have 0 (+1 more)');
   });

--- a/templates/zswap-da/src/services/takerBalance.ts
+++ b/templates/zswap-da/src/services/takerBalance.ts
@@ -10,20 +10,31 @@
 import type { NetworkId } from '@midnight-ntwrk/midnight-js-network-id';
 import type { KnownToken } from '../types';
 import { parseTakerLegs, type ParsedLeg } from './offerParse';
-import { findTokenName, shortToken } from '../utils';
+import { DEFAULT_DECIMALS, formatBaseUnits } from '../state/amount';
+import { decimalsOf, findTokenName, shortToken } from '../utils';
 
 export interface Shortfall {
   color: string;
   kind: 'shielded' | 'unshielded';
+  /** BASE UNITS — the comparison unit. Rendered as coins via `decimals`. */
   need: bigint;
   have: bigint;
   sym: string;
+  /** The token's precision, for the message. DEFAULT_DECIMALS when unknown. */
+  decimals: number;
 }
 
 type Balances = Record<string, string> | null | undefined;
 
-// Parse a raw balance string ("1000", possibly comma-grouped) to bigint. Never
-// throws — an unparseable balance counts as zero (safe: it can only over-block).
+// Parse a raw balance string ("1000", possibly comma-grouped) to bigint.
+//
+// It must ONLY ever be handed BASE-UNIT strings — that is what the wallet
+// reports and what `ParsedLeg.amount` is, so the comparison below needs no
+// scaling at all. It truncates at the '.', so a whole-coin string sneaking in
+// here would silently compare 1.5 as 1: pinned by a test.
+//
+// Never throws — an unparseable balance counts as zero (safe: it can only
+// over-block).
 function toBig(raw: string | undefined): bigint {
   if (raw == null) return 0n;
   try {
@@ -54,6 +65,7 @@ export function shortfallsFromLegs(
         need: leg.amount,
         have,
         sym: findTokenName(leg.color, knownTokens) ?? shortToken(leg.color),
+        decimals: decimalsOf(leg.color, knownTokens),
       });
     }
   }
@@ -146,10 +158,17 @@ export function affordableIndices(
   return idxs;
 }
 
-/** One-line reason for the first shortfall, for a disabled CTA / toast. */
+/**
+ * One-line reason for the first shortfall, for a disabled CTA / toast.
+ *
+ * Rendered in WHOLE COINS: this string sits next to the confirm dialog's own
+ * coin totals, and "need 1500000, have 0" beside "1.5 WBTC" is exactly the
+ * confusion project 00024 exists to remove.
+ */
 export function shortfallMessage(shortfalls: Shortfall[]): string | null {
   if (shortfalls.length === 0) return null;
   const [first] = shortfalls;
+  const d = first.decimals ?? DEFAULT_DECIMALS;
   const more = shortfalls.length > 1 ? ` (+${shortfalls.length - 1} more)` : '';
-  return `Insufficient ${first.sym}: need ${first.need.toString()}, have ${first.have.toString()}${more}`;
+  return `Insufficient ${first.sym}: need ${formatBaseUnits(first.need, d)}, have ${formatBaseUnits(first.have, d)}${more}`;
 }

--- a/templates/zswap-da/src/state/amount.test.ts
+++ b/templates/zswap-da/src/state/amount.test.ts
@@ -1,0 +1,219 @@
+// Whole coins ⇄ base units (project 00024).
+//
+// These cases exist because the amount is what settles on chain: a rounding bug
+// here posts an offer the user never agreed to. So the round trip is pinned
+// exactly, over-precision is pinned as a REFUSAL rather than a rounding, and
+// values past 2^53 are pinned to prove the maths never goes through a double.
+import { describe, expect, test } from 'bun:test';
+import {
+  DEFAULT_DECIMALS,
+  MAX_BASE_UNITS,
+  amountErrorText,
+  formatAmount,
+  formatBaseUnits,
+  parseAmount,
+  parseWholeCoins,
+  sanitizeAmountInput,
+  scaleRate,
+  toWholeCoinsNumber,
+} from './amount';
+
+describe('DEFAULT_DECIMALS', () => {
+  test('is 6 — every token this stack mints has 6', () => {
+    expect(DEFAULT_DECIMALS).toBe(6);
+  });
+});
+
+describe('parseWholeCoins', () => {
+  test('the headline case: 1.5 of a 6-decimals token is 1_500_000 base units', () => {
+    expect(parseWholeCoins('1.5', 6)).toBe(1_500_000n);
+  });
+
+  test('whole numbers scale by 10^decimals', () => {
+    expect(parseWholeCoins('1000', 6)).toBe(1_000_000_000n);
+    expect(parseWholeCoins('1', 6)).toBe(1_000_000n);
+    expect(parseWholeCoins('0', 6)).toBe(0n);
+  });
+
+  test('the smallest expressible amount is one base unit', () => {
+    expect(parseWholeCoins('0.000001', 6)).toBe(1n);
+  });
+
+  test('a partial fraction is right-padded, not left-padded', () => {
+    expect(parseWholeCoins('0.1', 6)).toBe(100_000n);
+    expect(parseWholeCoins('0.01', 6)).toBe(10_000n);
+    expect(parseWholeCoins('.5', 6)).toBe(500_000n);
+    expect(parseWholeCoins('2.', 6)).toBe(2_000_000n);
+  });
+
+  test('grouping separators are accepted', () => {
+    expect(parseWholeCoins('1,000.5', 6)).toBe(1_000_500_000n);
+    expect(parseWholeCoins('1 000', 6)).toBe(1_000_000_000n);
+  });
+
+  test('other decimals are honoured — nothing hard-codes 6', () => {
+    expect(parseWholeCoins('1.5', 8)).toBe(150_000_000n);
+    expect(parseWholeCoins('1.5', 2)).toBe(150n);
+    expect(parseWholeCoins('7', 0)).toBe(7n);
+  });
+
+  test('a float would have lost this — string maths does not', () => {
+    // 0.07 * 1e6 === 70000.00000000001 in IEEE-754.
+    expect(parseWholeCoins('0.07', 6)).toBe(70_000n);
+    // 4.35 * 100 === 434.99999999999994.
+    expect(parseWholeCoins('4.35', 2)).toBe(435n);
+  });
+
+  test('past 2^53 the value is still exact', () => {
+    // 2^53 = 9_007_199_254_740_992; this is a coin amount well beyond it.
+    expect(parseWholeCoins('12345678901.234567', 6)).toBe(12_345_678_901_234_567n);
+    // What the banned `Number(x) * 1e6` would have produced instead: off by one
+    // base unit, and BigInt() would have preserved the corruption faithfully.
+    expect(BigInt(12345678901.234567 * 1e6)).toBe(12_345_678_901_234_568n);
+  });
+
+  test('over-precision is REFUSED, not rounded (spec Q9)', () => {
+    expect(parseWholeCoins('1.0000005', 6)).toBeNull();
+    expect(parseAmount('1.0000005', 6).error).toBe('precision');
+    expect(parseAmount('1.0000005', 6).fractionDigits).toBe(7);
+    expect(parseWholeCoins('0.5', 0)).toBeNull();
+  });
+
+  test('trailing zeros past the precision are not over-precision', () => {
+    // "1.5000000" is exactly 1.5 — nothing is lost, so nothing is refused.
+    expect(parseWholeCoins('1.5000000', 6)).toBe(1_500_000n);
+    expect(parseWholeCoins('1.000000000', 6)).toBe(1_000_000n);
+  });
+
+  test('negatives, exponents and junk are refused with distinct reasons', () => {
+    expect(parseAmount('-1', 6).error).toBe('negative');
+    expect(parseAmount('1e6', 6).error).toBe('malformed');
+    expect(parseAmount('1.2.3', 6).error).toBe('malformed');
+    expect(parseAmount('abc', 6).error).toBe('malformed');
+    expect(parseAmount('', 6).error).toBe('empty');
+    expect(parseAmount('.', 6).error).toBe('empty');
+  });
+
+  test('anything past the ledger ceiling (2^64 − 1) is refused', () => {
+    expect(formatBaseUnits(MAX_BASE_UNITS, 0)).toBe('18446744073709551615');
+    expect(parseWholeCoins('18446744073709.551615', 6)).toBe(MAX_BASE_UNITS);
+    expect(parseAmount('18446744073709.551616', 6).error).toBe('overflow');
+    expect(parseWholeCoins('99999999999999999999', 6)).toBeNull();
+  });
+});
+
+describe('formatBaseUnits', () => {
+  test('exact inverse of parseWholeCoins, without trailing zeros', () => {
+    expect(formatBaseUnits(1_500_000n, 6)).toBe('1.5');
+    expect(formatBaseUnits(1n, 6)).toBe('0.000001');
+    expect(formatBaseUnits(1_000_000_000n, 6)).toBe('1000');
+    expect(formatBaseUnits(0n, 6)).toBe('0');
+    expect(formatBaseUnits(100_000n, 6)).toBe('0.1');
+  });
+
+  test('round-trips every sample through parseWholeCoins', () => {
+    for (const raw of ['0', '1', '1.5', '0.000001', '1000', '1234.5678', '0.999999']) {
+      const base = parseWholeCoins(raw, 6)!;
+      expect(formatBaseUnits(base, 6)).toBe(String(Number(raw)));
+    }
+  });
+
+  test('decimals 0 has no fractional part at all', () => {
+    expect(formatBaseUnits(1234n, 0)).toBe('1234');
+  });
+
+  test('accepts the string balances the wallet actually returns', () => {
+    expect(formatBaseUnits('1000000000', 6)).toBe('1000');
+    expect(formatBaseUnits('1,000,000', 6)).toBe('1');
+    expect(formatBaseUnits('not-a-number', 6)).toBe('0');
+  });
+});
+
+describe('formatAmount', () => {
+  test('groups the integer part and drops trailing zeros', () => {
+    expect(formatAmount(1_234_500_000n, 6)).toBe('1,234.5');
+    expect(formatAmount(1_000_000_000n, 6)).toBe('1,000');
+    expect(formatAmount(1_500_000n, 6)).toBe('1.5');
+  });
+
+  test('maxFrac rounds half-up for display only', () => {
+    expect(formatAmount(1_234_567n, 6, 2)).toBe('1.23');
+    expect(formatAmount(1_235_000n, 6, 2)).toBe('1.24');
+    expect(formatAmount(1_999_999n, 6, 0)).toBe('2');
+  });
+
+  test('a sub-unit amount still reads as a number, not as 0', () => {
+    expect(formatAmount(1n, 6)).toBe('0.000001');
+  });
+});
+
+describe('sanitizeAmountInput', () => {
+  test('keeps digits and one decimal point', () => {
+    expect(sanitizeAmountInput('1.5', 6)).toBe('1.5');
+    expect(sanitizeAmountInput('1a.5b', 6)).toBe('1.5');
+    expect(sanitizeAmountInput('1.2.3', 6)).toBe('1.23');
+    expect(sanitizeAmountInput('-5', 6)).toBe('5');
+  });
+
+  test('a typed comma becomes the decimal point (nobody groups by hand here)', () => {
+    expect(sanitizeAmountInput('1,5', 6)).toBe('1.5');
+  });
+
+  test('one digit past the precision SURVIVES so the refusal can be seen', () => {
+    // Truncating at exactly 6 would silently swallow the 7th digit — the very
+    // thing Q9 forbids. The parser refuses it and the screen says why.
+    expect(sanitizeAmountInput('1.0000005', 6)).toBe('1.0000005');
+    expect(parseWholeCoins(sanitizeAmountInput('1.0000005', 6), 6)).toBeNull();
+  });
+
+  test('a pasted essay is still bounded', () => {
+    expect(sanitizeAmountInput('1.123456789012345', 6)).toBe('1.1234567');
+    expect(sanitizeAmountInput('1.5', 0)).toBe('1.5');
+  });
+});
+
+describe('toWholeCoinsNumber', () => {
+  test('base units read as coins', () => {
+    expect(toWholeCoinsNumber(1_500_000n, 6)).toBe(1.5);
+    expect(toWholeCoinsNumber('1000000000', 6)).toBe(1000);
+    expect(toWholeCoinsNumber(0n, 6)).toBe(0);
+  });
+});
+
+describe('scaleRate', () => {
+  test('equal decimals leave the rate untouched', () => {
+    expect(scaleRate(13.33, 6, 6)).toBe(13.33);
+  });
+
+  test('a 6-decimals base against an 8-decimals quote scales by 10^-2', () => {
+    // 1 base coin = 10^6 base units; 1 quote coin = 10^8. A base-unit rate of
+    // 1333 means 1 base coin buys 1333 × 10^6 / 10^8 = 13.33 quote coins.
+    expect(scaleRate(1333, 6, 8)).toBeCloseTo(13.33, 9);
+    expect(scaleRate(13.33, 8, 6)).toBeCloseTo(1333, 9);
+  });
+
+  test('non-finite input never leaks NaN into the UI', () => {
+    expect(scaleRate(NaN, 6, 6)).toBe(0);
+    expect(scaleRate(Infinity, 6, 8)).toBe(0);
+  });
+});
+
+describe('amountErrorText', () => {
+  test('the precision message names the token and its precision', () => {
+    expect(amountErrorText('precision', 6, 'WBTC')).toBe(
+      'Too many decimal places: WBTC supports 6 (e.g. 1.000001).',
+    );
+  });
+
+  test('a 0-decimals token is told to use whole numbers', () => {
+    expect(amountErrorText('precision', 0, 'NIGHT')).toBe(
+      'NIGHT has no fractional units — enter a whole number.',
+    );
+  });
+
+  test('every other reason has its own sentence', () => {
+    expect(amountErrorText('negative', 6)).toBe('Amounts must be positive.');
+    expect(amountErrorText('overflow', 6)).toBe('That amount is larger than the ledger can hold.');
+    expect(amountErrorText('malformed', 6)).toContain('digits and one decimal point');
+  });
+});

--- a/templates/zswap-da/src/state/amount.ts
+++ b/templates/zswap-da/src/state/amount.ts
@@ -1,0 +1,252 @@
+// Whole coins ⇄ base units. The single place this app converts between what a
+// user types/reads and what the chain and the node API carry.
+//
+// THE INVARIANT: every amount on the wire (`/v1/quote`, `/v1/offers`,
+// `/v1/chart/*`, wallet balances) and every amount on chain is an INTEGER of
+// base units. A token's `decimals` (from `GET /v1/known-tokens`) says how many
+// base units make one whole coin: 1 coin = 10^decimals base units. Nothing in
+// this module ever changes what is submitted — it only changes how the number
+// is spelled at the edges.
+//
+// Everything here is string/bigint maths. `Number(x) * 1e6` is not used and
+// must not be introduced: 1e6 is exactly representable but the product is not
+// for most inputs (`0.07 * 1e6 === 70000.00000000001`), and above 2^53 a double
+// silently rounds — which would post an offer for an amount the user never
+// typed. Doubles appear only in `toWholeCoinsNumber` / `scaleRate`, which exist
+// for display ratios and are documented as such.
+
+/**
+ * Decimals assumed when a token does not say.
+ *
+ * Two cases: a node older than kernel 00024 serves `known_tokens` rows without
+ * the field, and a colour the wallet holds that is in no registry at all
+ * (TokenPicker synthesises those). Every token this stack mints has 6, so 6 is
+ * the honest assumption rather than 0 (project 00024 / spec Q8).
+ */
+export const DEFAULT_DECIMALS = 6;
+
+/** The ledger mints `Uint<64>`, so no base-unit amount may exceed 2^64 − 1. */
+export const MAX_BASE_UNITS = (1n << 64n) - 1n;
+
+/** Why a typed amount was refused. `null` value + this code drives the copy. */
+export type AmountError =
+  /** No digits at all (empty, or just a dot). */
+  | 'empty'
+  /** Characters outside `[0-9.]`, more than one dot, or an exponent. */
+  | 'malformed'
+  /** A leading `-`: offers are never negative. */
+  | 'negative'
+  /** More fraction digits than the token can express — refused, NEVER rounded. */
+  | 'precision'
+  /** Past the ledger's `Uint<64>` ceiling. */
+  | 'overflow';
+
+export interface ParsedAmount {
+  /** Exact base units, or null when `error` is set. */
+  value: bigint | null;
+  error: AmountError | null;
+  /** Fraction digits actually typed — for the 'precision' message. */
+  fractionDigits: number;
+}
+
+const GROUPING = /[,_\s]/g;
+
+/**
+ * Parse a typed whole-coin amount into exact base units, reporting WHY it was
+ * refused. `parseWholeCoins` is the value-only form used by callers that just
+ * need the number.
+ */
+export function parseAmount(raw: string, decimals: number): ParsedAmount {
+  const s = String(raw ?? '').replace(GROUPING, '');
+  if (s === '') return { value: null, error: 'empty', fractionDigits: 0 };
+  if (s.startsWith('-')) return { value: null, error: 'negative', fractionDigits: 0 };
+  if (!/^\d*\.?\d*$/.test(s)) return { value: null, error: 'malformed', fractionDigits: 0 };
+  const [intPart = '', fracPart = ''] = s.split('.');
+  if (intPart === '' && fracPart === '') return { value: null, error: 'empty', fractionDigits: 0 };
+  const d = safeDecimals(decimals);
+  // Trailing zeros past the token's precision are not a loss of information —
+  // "1.5000000" at 6 decimals is exactly 1.5 — so only SIGNIFICANT excess
+  // digits are refused.
+  const significantFrac = fracPart.replace(/0+$/, '');
+  if (significantFrac.length > d) {
+    return { value: null, error: 'precision', fractionDigits: significantFrac.length };
+  }
+  const padded = (fracPart + '0'.repeat(d)).slice(0, d);
+  let value: bigint;
+  try {
+    value = BigInt((intPart || '0') + padded);
+  } catch {
+    return { value: null, error: 'malformed', fractionDigits: fracPart.length };
+  }
+  if (value > MAX_BASE_UNITS) {
+    return { value: null, error: 'overflow', fractionDigits: fracPart.length };
+  }
+  return { value, error: null, fractionDigits: fracPart.length };
+}
+
+/**
+ * Whole coins → base units, exactly. `parseWholeCoins('1.5', 6) === 1500000n`.
+ *
+ * Returns null for anything refused (see {@link AmountError}); over-precise
+ * input is REFUSED, never rounded — the amount is what settles on chain, and
+ * quietly posting a different one than the user typed is not an option
+ * (spec 00024 Q9).
+ */
+export function parseWholeCoins(raw: string, decimals: number): bigint | null {
+  return parseAmount(raw, decimals).value;
+}
+
+/** Human sentence for a refusal, naming the token and its precision. */
+export function amountErrorText(
+  error: AmountError,
+  decimals: number,
+  symbol?: string | null,
+): string {
+  const d = safeDecimals(decimals);
+  const tok = symbol ? ` ${symbol}` : '';
+  switch (error) {
+    case 'empty':
+      return 'Enter an amount.';
+    case 'negative':
+      return 'Amounts must be positive.';
+    case 'precision':
+      return d === 0
+        ? `${symbol ?? 'This token'} has no fractional units — enter a whole number.`
+        : `Too many decimal places:${tok} supports ${d} (e.g. ${exampleFor(d)}).`;
+    case 'overflow':
+      return 'That amount is larger than the ledger can hold.';
+    case 'malformed':
+    default:
+      return 'Enter a number, e.g. 1.5 — digits and one decimal point only.';
+  }
+}
+
+function exampleFor(decimals: number): string {
+  return decimals <= 0 ? '1' : '1.' + '0'.repeat(decimals - 1) + '1';
+}
+
+/**
+ * Base units → the exact whole-coin string, with no trailing zeros.
+ * `formatBaseUnits(1n, 6) === '0.000001'`, `formatBaseUnits(1500000n, 6) === '1.5'`.
+ *
+ * Exact inverse of {@link parseWholeCoins}; ungrouped, so it round-trips.
+ */
+export function formatBaseUnits(v: bigint | string | number, decimals: number): string {
+  const d = safeDecimals(decimals);
+  const n = toBigIntLoose(v);
+  const neg = n < 0n;
+  const digits = (neg ? -n : n).toString().padStart(d + 1, '0');
+  const intPart = digits.slice(0, digits.length - d) || '0';
+  const fracPart = d === 0 ? '' : digits.slice(digits.length - d).replace(/0+$/, '');
+  return (neg ? '-' : '') + intPart + (fracPart ? '.' + fracPart : '');
+}
+
+/**
+ * Base units → a grouped whole-coin string for display: `1234500000n` at 6
+ * decimals reads `1,234.5`. Rounds (half-up) to `maxFrac` fraction digits —
+ * DISPLAY ONLY; never feed the result back into a submit path.
+ */
+export function formatAmount(
+  v: bigint | string | number,
+  decimals: number,
+  maxFrac?: number,
+): string {
+  const d = safeDecimals(decimals);
+  const cap = maxFrac == null ? d : Math.max(0, Math.min(Math.trunc(maxFrac), d));
+  let n = toBigIntLoose(v);
+  const neg = n < 0n;
+  if (neg) n = -n;
+  let scale = d;
+  const drop = d - cap;
+  if (drop > 0) {
+    const p = 10n ** BigInt(drop);
+    n = (n + p / 2n) / p; // half-up
+    scale = cap;
+  }
+  const exact = formatBaseUnits(n, scale);
+  const [intPart, fracPart] = exact.split('.');
+  const grouped = BigInt(intPart).toLocaleString('en-US');
+  return (neg ? '−' : '') + grouped + (fracPart ? '.' + fracPart : '');
+}
+
+/**
+ * Keystroke filter for an amount field: digits and at most one decimal point,
+ * everything else dropped.
+ *
+ * The fraction is bounded at `decimals + 1` digits rather than `decimals`: it
+ * has to be possible to SEE that you typed one digit too many, because
+ * over-precision is refused with a message and not silently truncated (Q9).
+ * Truncating at exactly `decimals` would swallow the seventh digit of
+ * `1.0000005` and the user would never learn why their amount changed; the
+ * bound only stops a pasted essay from living in the field.
+ */
+export function sanitizeAmountInput(raw: string, decimals: number): string {
+  const d = safeDecimals(decimals);
+  let out = '';
+  let seenDot = false;
+  for (const ch of String(raw ?? '')) {
+    if (ch >= '0' && ch <= '9') { out += ch; continue; }
+    if ((ch === '.' || ch === ',') && !seenDot) { out += '.'; seenDot = true; }
+  }
+  const dot = out.indexOf('.');
+  if (dot >= 0) out = out.slice(0, dot + 1) + out.slice(dot + 1, dot + 1 + d + 1);
+  return out;
+}
+
+/**
+ * Base units → whole coins as a double.
+ *
+ * For RATIOS and chart maths only (a book price, a percentage, a bar width) —
+ * never for an amount that is submitted. Above 2^53 base units the result is
+ * approximate, which is fine for a price ladder and fatal for a settlement.
+ */
+export function toWholeCoinsNumber(v: bigint | string | number, decimals: number): number {
+  const n = Number(formatBaseUnits(v, decimals));
+  return Number.isFinite(n) ? n : 0;
+}
+
+/**
+ * A base-unit rate → the same rate between whole coins.
+ *
+ * The node's `implied_rate`, `market_rate`, `/v1/chart` prices and
+ * `price(base)/price(quote)` are all "base units of TO per base unit of FROM".
+ * One whole FROM coin is 10^dFrom base units and one whole TO coin is 10^dTo,
+ * so the whole-coin rate is `rate × 10^(dFrom − dTo)` — the identity while
+ * every token is 6, and the reason a future 8-decimals token still reads right.
+ */
+export function scaleRate(rate: number, fromDecimals: number, toDecimals: number): number {
+  if (!Number.isFinite(rate)) return 0;
+  const e = safeDecimals(fromDecimals) - safeDecimals(toDecimals);
+  return e === 0 ? rate : rate * Math.pow(10, e);
+}
+
+/**
+ * A RAW BASE-UNIT value (a wallet balance string, a leg amount) → bigint.
+ *
+ * No scaling: this is for numbers that are already base units and only need to
+ * stop being a string. Never throws — an unparseable balance counts as zero,
+ * which can only ever over-block, never over-spend.
+ */
+export function parseBaseUnits(v: bigint | string | number | null | undefined): bigint {
+  return v == null ? 0n : toBigIntLoose(v);
+}
+
+/** Registry values are `[0, 38]`; anything else is a broken row, not a token. */
+function safeDecimals(d: number | null | undefined): number {
+  const n = Number(d);
+  if (!Number.isFinite(n)) return DEFAULT_DECIMALS;
+  return Math.min(38, Math.max(0, Math.trunc(n)));
+}
+
+/** Tolerant bigint coercion: balances arrive as strings, sums as numbers. */
+function toBigIntLoose(v: bigint | string | number): bigint {
+  if (typeof v === 'bigint') return v;
+  if (typeof v === 'number') return Number.isFinite(v) ? BigInt(Math.round(v)) : 0n;
+  const s = String(v ?? '').replace(GROUPING, '').split('.')[0];
+  if (s === '' || s === '-') return 0n;
+  try {
+    return BigInt(s);
+  } catch {
+    return 0n;
+  }
+}

--- a/templates/zswap-da/src/state/format.ts
+++ b/templates/zswap-da/src/state/format.ts
@@ -1,22 +1,18 @@
 // Display formatters, ported from the mock's data.jsx. Pure + reusable.
-// Symbol-keyed `dp` is kept for the mock token symbols; real (color-keyed)
-// balances use `fmtBalance`.
-
-export function dp(sym?: string): number {
-  if (!sym) return 2;
-  if (sym === 'wBTC' || sym === 'wsBTC') return 5;
-  if (/^(w|ws)(ETH|SOL)$/.test(sym)) return 3;
-  return 2;
-}
+//
+// TOKEN AMOUNTS DO NOT LIVE HERE. They are base-unit integers whose meaning
+// depends on the token's `decimals`, so they are rendered by
+// `state/amount.ts::formatAmount(baseUnits, decimals)`. The symbol-keyed `dp()`
+// and the decimals-blind `fmtAmt`/`fmtBalance` that used to sit here were
+// removed in project 00024: they keyed precision off a hard-coded list of mock
+// symbols and printed raw base units as if they were coins.
+//
+// What remains is USD, rates and percentages — none of which is a token amount.
 
 export function fmt(n: number | null | undefined, d?: number): string {
   if (n == null || isNaN(n)) return '0';
   if (d == null) d = n >= 1000 ? 2 : 4;
   return Number(n).toLocaleString('en-US', { minimumFractionDigits: d, maximumFractionDigits: d });
-}
-
-export function fmtAmt(n: number, sym?: string): string {
-  return fmt(n, dp(sym));
 }
 
 export function fmtUsd(n: number): string {
@@ -37,15 +33,6 @@ export function rateDisplay(v: number): RateDisplay {
   const sciLen = mantStr.length + 4 + String(Math.abs(exp)).length;
   if (plain.length <= sciLen) return { kind: 'plain', text: plain };
   return { kind: 'sci', mant: mantStr, exp };
-}
-
-/** Format a balance amount that arrives as a string (real wallet balances are
- *  string-encoded). Falls back to the raw string if it isn't numeric. */
-export function fmtBalance(amount: string | number | null | undefined): string {
-  if (amount == null) return '0';
-  const n = typeof amount === 'number' ? amount : Number(String(amount).replace(/,/g, ''));
-  if (!isFinite(n)) return String(amount);
-  return fmt(n, n >= 1000 ? 2 : n === Math.floor(n) ? 0 : 4);
 }
 
 // ── Reference-price helpers (00005) ───────────────────────────────────────────

--- a/templates/zswap-da/src/state/myTrades.ts
+++ b/templates/zswap-da/src/state/myTrades.ts
@@ -11,7 +11,16 @@ import { bucketOf, readBuckets, writeBuckets, type Buckets } from './scope';
 
 export type MyTradeStatus = 'not_public' | 'live' | 'consumed' | 'cancelled' | 'expired';
 
-export interface TradeLeg { sym: string; amt: number }
+/**
+ * One leg of a recorded trade.
+ *
+ * `amt` is BASE UNITS — the same unit the chain and the node use — and
+ * `decimals` says how to read it. `decimals` is OPTIONAL because records
+ * written before project 00024 have no such field; read them with
+ * DEFAULT_DECIMALS rather than migrating localStorage (spec Q4: pre-change
+ * amounts re-read at 10^-6 of their old face value, which is accepted).
+ */
+export interface TradeLeg { sym: string; amt: number; decimals?: number }
 export interface MyTrade {
   id: string;
   kind: 'create' | 'take';

--- a/templates/zswap-da/src/state/reference.test.ts
+++ b/templates/zswap-da/src/state/reference.test.ts
@@ -7,6 +7,7 @@
 import { describe, expect, test } from 'bun:test';
 import type { PricesResponse, Quote, TokenPrice } from '../services/api';
 import { describeQuote, referenceRate, sourceLabel, tokenPriceOf } from './reference';
+import { scaleRate } from './amount';
 
 const NOW = Date.parse('2026-09-02T12:00:00.000Z');
 const HOURS_AGO = (h: number) => new Date(NOW - h * 3_600_000).toISOString();
@@ -156,7 +157,7 @@ describe('sourceLabel', () => {
 });
 
 const token = (over: Partial<TokenPrice> & Pick<TokenPrice, 'token_color' | 'price_usd'>): TokenPrice => ({
-  name: 'T', kind: 'shielded', decimals: 0, asset_id: null, source: 'feed', updated_at: HOURS_AGO(1), ...over,
+  name: 'T', kind: 'shielded', decimals: 6, asset_id: null, source: 'feed', updated_at: HOURS_AGO(1), ...over,
 });
 
 const WBTC = 'e7'.repeat(32);
@@ -205,6 +206,32 @@ describe('referenceRate', () => {
     const p = prices();
     p.tokens[1] = token({ token_color: WETH, name: 'USDM', price_usd: '0.000001', source: 'fixed' });
     expect(referenceRate(p, WBTC, WETH)!.label).toBe('CoinGecko + pegged');
+  });
+});
+
+// `price_usd` is USD per BASE UNIT, so `referenceRate` is a BASE-UNIT rate like
+// everything else the node publishes. Turning it into the "1 WBTC = X WETH" a
+// screen prints is `scaleRate(rate, dFrom, dTo)` — the identity while every
+// token is 6, and the whole point of carrying decimals the day one is not
+// (project 00024, FR-104).
+describe('referenceRate → whole-coin rate', () => {
+  test('equal decimals: the displayed rate is the raw ratio', () => {
+    const r = referenceRate(prices(), WBTC, WETH)!;
+    expect(scaleRate(r.rate, 6, 6)).toBeCloseTo(77387 / 2393.28, 9);
+  });
+
+  test('a 6-decimals base against an 8-decimals quote divides by 100', () => {
+    const r = referenceRate(prices(), WBTC, WETH)!;
+    // One WBTC coin is 10^6 base units, one WETH coin 10^8: the same USD ratio
+    // buys a hundredth as many whole quote coins.
+    expect(scaleRate(r.rate, 6, 8)).toBeCloseTo((77387 / 2393.28) / 100, 9);
+    // …and the mirror direction multiplies by 100.
+    expect(scaleRate(r.rate, 8, 6)).toBeCloseTo((77387 / 2393.28) * 100, 6);
+  });
+
+  test('scaling is exactly reversible, so a round trip cannot drift the book', () => {
+    const r = referenceRate(prices(), WBTC, WETH)!;
+    expect(scaleRate(scaleRate(r.rate, 6, 8), 8, 6)).toBeCloseTo(r.rate, 9);
   });
 });
 

--- a/templates/zswap-da/src/state/swapAmounts.test.ts
+++ b/templates/zswap-da/src/state/swapAmounts.test.ts
@@ -1,0 +1,121 @@
+// The Swap screen's coin ⇄ base-unit boundary (project 00024, spec User Story 2).
+//
+// This is the path an offer actually takes: what the user typed → what is sent
+// to `/v1/quote` → what the wallet puts in the offer leg. Each case below is an
+// acceptance scenario from the spec, pinned where it can be tested without a
+// browser.
+import { describe, expect, test } from 'bun:test';
+import type { KnownToken } from '../types';
+import { amountErrorText } from './amount';
+import {
+  displayRate,
+  hasBalanceFor,
+  legDecimals,
+  parseLeg,
+  suggestedFieldValue,
+} from './swapAmounts';
+
+const token = (name: string, decimals: number): KnownToken => ({
+  token_color: name.toLowerCase().padEnd(64, '0'),
+  name,
+  kind: 'shielded',
+  decimals,
+});
+
+const WBTC = token('WBTC', 6);
+const WETH = token('WETH', 6);
+/** A token that is deliberately NOT 6 — nothing may hard-code the default. */
+const WSBTC = token('WSBTC', 8);
+
+describe('legDecimals', () => {
+  test("uses the token's own precision, and the default before one is picked", () => {
+    expect(legDecimals(WBTC)).toBe(6);
+    expect(legDecimals(WSBTC)).toBe(8);
+    expect(legDecimals(null)).toBe(6);
+  });
+});
+
+describe('parseLeg — what reaches /v1/quote and the offer', () => {
+  test('typing 1.5 WBTC gives the give leg exactly 1500000n', () => {
+    expect(parseLeg('1.5', WBTC).value).toBe(1_500_000n);
+  });
+
+  test('a pair of different precisions converts each leg with its own', () => {
+    // "1.5 WBTC for 20 WSBTC" → 1_500_000 ↔ 2_000_000_000.
+    expect(parseLeg('1.5', WBTC).value).toBe(1_500_000n);
+    expect(parseLeg('20', WSBTC).value).toBe(2_000_000_000n);
+  });
+
+  test('1.0000005 of a 6-decimals token is refused, and the message says why', () => {
+    const p = parseLeg('1.0000005', WBTC);
+    expect(p.value).toBeNull();
+    expect(p.error).toBe('precision');
+    expect(amountErrorText(p.error!, WBTC.decimals, WBTC.name)).toBe(
+      'Too many decimal places: WBTC supports 6 (e.g. 1.000001).',
+    );
+    // The very same digits ARE valid for the 8-decimals token.
+    expect(parseLeg('1.0000005', WSBTC).value).toBe(100_000_050n);
+  });
+
+  test('an empty field is "empty", not a malformed number', () => {
+    expect(parseLeg('', WBTC).error).toBe('empty');
+  });
+});
+
+describe('suggestedFieldValue — the node auto-price lands in the field as coins', () => {
+  test('suggested_to_amount 20000000 shows as 20', () => {
+    expect(suggestedFieldValue('20000000', WETH)).toBe('20');
+  });
+
+  test('it round-trips: what the field shows re-parses to what the node sent', () => {
+    for (const base of ['1', '1500000', '20000000', '999999999999']) {
+      expect(parseLeg(suggestedFieldValue(base, WETH), WETH).value).toBe(BigInt(base));
+    }
+  });
+
+  test('the TO leg uses the TO token precision, not the FROM one', () => {
+    expect(suggestedFieldValue('2000000000', WSBTC)).toBe('20');
+    expect(suggestedFieldValue('2000000000', WETH)).toBe('2000');
+  });
+});
+
+describe('hasBalanceFor — the pre-submit affordability gate', () => {
+  test('compares base units against the wallet string, with no scaling', () => {
+    // 1.5 WBTC needed, 1.5 WBTC held.
+    expect(hasBalanceFor(1_500_000n, '1500000')).toBe(true);
+    expect(hasBalanceFor(1_500_001n, '1500000')).toBe(false);
+  });
+
+  test('a missing or unparseable balance is zero, never a pass', () => {
+    expect(hasBalanceFor(1n, null)).toBe(false);
+    expect(hasBalanceFor(1n, undefined)).toBe(false);
+    expect(hasBalanceFor(1n, 'n/a')).toBe(false);
+  });
+
+  test('nothing typed yet is not a shortfall', () => {
+    expect(hasBalanceFor(null, '0')).toBe(true);
+    expect(hasBalanceFor(0n, '0')).toBe(true);
+  });
+
+  test('stays exact past 2^53, where a double comparison would tie', () => {
+    const a = 9_007_199_254_740_993n; // 2^53 + 1
+    expect(hasBalanceFor(a, '9007199254740992')).toBe(false);
+    expect(Number(a)).toBe(9007199254740992); // …which is what a double would say
+  });
+});
+
+describe('displayRate — "1 FROM = X TO"', () => {
+  test('equal precisions print the node rate unchanged', () => {
+    expect(displayRate(13.33, WBTC, WETH)).toBe(13.33);
+  });
+
+  test('mixed precisions scale by 10^(dFrom − dTo)', () => {
+    expect(displayRate(1333, WBTC, WSBTC)).toBeCloseTo(13.33, 9);
+    expect(displayRate(13.33, WSBTC, WBTC)).toBeCloseTo(1333, 9);
+  });
+
+  test('a missing rate prints 0 rather than NaN', () => {
+    expect(displayRate(null, WBTC, WETH)).toBe(0);
+    expect(displayRate(undefined, WBTC, WETH)).toBe(0);
+  });
+});

--- a/templates/zswap-da/src/state/swapAmounts.ts
+++ b/templates/zswap-da/src/state/swapAmounts.ts
@@ -1,0 +1,77 @@
+// The Swap screen's amount decisions, extracted from the component so they can
+// be unit-tested without a DOM.
+//
+// Swap.tsx is the boundary between the two units this app deals in: WHOLE COINS
+// above (what the user types, what the balance chip and the rate lines say) and
+// BASE UNITS below (what `/v1/quote` takes, what the offer legs carry, what the
+// chain settles). Each leg converts with ITS OWN token's `decimals` — a pair is
+// routinely two different precisions — so every function here takes the token,
+// not a global.
+
+import {
+  DEFAULT_DECIMALS,
+  formatBaseUnits,
+  parseAmount,
+  parseBaseUnits,
+  scaleRate,
+  type ParsedAmount,
+} from './amount';
+import type { KnownToken } from '../types';
+
+/** Precision of a leg's token; the app default before one is picked. */
+export function legDecimals(token: KnownToken | null | undefined): number {
+  return token?.decimals ?? DEFAULT_DECIMALS;
+}
+
+/**
+ * Parse one leg's typed whole-coin amount into base units, at that leg's own
+ * precision. The `error` explains a refusal well enough to name the token's
+ * precision back to the user — over-precision is never rounded away.
+ */
+export function parseLeg(raw: string, token: KnownToken | null | undefined): ParsedAmount {
+  return parseAmount(raw, legDecimals(token));
+}
+
+/**
+ * The value the "You receive" field should show for the node's auto-price
+ * suggestion. `suggested_to_amount` is base units of the TO token; the field is
+ * coins. Exact (`formatBaseUnits`, not the grouped/rounded display form), so
+ * submitting the suggestion posts exactly what the node suggested.
+ */
+export function suggestedFieldValue(
+  suggestedBaseUnits: string | number | bigint,
+  token: KnownToken | null | undefined,
+): string {
+  return formatBaseUnits(suggestedBaseUnits, legDecimals(token));
+}
+
+/**
+ * Can the maker cover the amount it is offering to pay?
+ *
+ * Both sides are BASE UNITS — the wallet reports raw integer strings and `need`
+ * came out of `parseLeg` — so no scaling happens here and the comparison stays
+ * in bigint. Going through Number() could round two distinct amounts onto the
+ * same double and let an unaffordable offer through. A missing balance is zero.
+ */
+export function hasBalanceFor(need: bigint | null, balance: string | null | undefined): boolean {
+  if (need == null || need <= 0n) return true;
+  return parseBaseUnits(balance) >= need;
+}
+
+/**
+ * A rate the node published (`implied_rate`, `market_rate`) → the whole-coin
+ * rate the screen prints as "1 FROM = X TO".
+ *
+ * The node's rates are base units of TO per base unit of FROM, so this is
+ * `× 10^(dFrom − dTo)`: the identity while every token is 6, and the reason a
+ * future 8-decimals token still reads right. Percentages derived from two such
+ * rates (the offset from reference, the sponsorship discount) are ratios and
+ * need no scaling at all.
+ */
+export function displayRate(
+  rate: number | null | undefined,
+  from: KnownToken | null | undefined,
+  to: KnownToken | null | undefined,
+): number {
+  return rate == null ? 0 : scaleRate(rate, legDecimals(from), legDecimals(to));
+}

--- a/templates/zswap-da/src/state/usePrices.test.ts
+++ b/templates/zswap-da/src/state/usePrices.test.ts
@@ -23,7 +23,7 @@ const BODY = {
   feed: { provider: 'coingecko', last_run_at: null, last_ok_at: null, last_error: null },
   assets: [],
   tokens: [
-    { token_color: A, name: 'WBTC', kind: 'shielded', decimals: 0, asset_id: 'bitcoin', price_usd: '77387', source: 'feed', updated_at: '2026-09-03T00:00:04.000Z' },
+    { token_color: A, name: 'WBTC', kind: 'shielded', decimals: 6, asset_id: 'bitcoin', price_usd: '77387', source: 'feed', updated_at: '2026-09-03T00:00:04.000Z' },
   ],
 };
 

--- a/templates/zswap-da/src/state/useZSwapApp.ts
+++ b/templates/zswap-da/src/state/useZSwapApp.ts
@@ -33,7 +33,7 @@ import {
   type OwnOfferDecision,
   type OwnOfferSplit,
 } from '../services/ownOffers';
-import { fmtAmt } from './format';
+import { DEFAULT_DECIMALS, formatAmount, scaleRate } from './amount';
 import {
   addTrade,
   clearTrades,
@@ -47,7 +47,7 @@ import {
 import { buildScope } from './scope';
 import { parseTakerLegs } from '../services/offerParse';
 import { isOwnOffer, parseOfferSender, unshieldedAddressToHex } from '../services/offerSender';
-import { findTokenName, shortToken } from '../utils';
+import { decimalsOf, findTokenName, shortToken } from '../utils';
 import { log } from '../lib/log';
 import { dlog, timed } from '../debug';
 import { takerShortfalls, shortfallsFromLegs, shortfallMessage, batchTakerShortfalls } from '../services/takerBalance';
@@ -68,8 +68,16 @@ export interface Order {
   to: string;
   fromColor: string;
   toColor: string;
+  /** BASE UNITS, as the node serves them. Render with `decimalsFrom`. */
   amtFrom: number;
+  /** BASE UNITS, as the node serves them. Render with `decimalsTo`. */
   amtTo: number;
+  /** Precision of each leg's token, so every consumer can turn the base-unit
+   *  amounts above into whole coins without another registry lookup. */
+  decimalsFrom: number;
+  decimalsTo: number;
+  /** WHOLE-COIN rate: how many `to` coins one `from` coin buys. Already scaled
+   *  by 10^(decimalsFrom − decimalsTo), so it is directly displayable. */
   impliedRate: number;
   /** Conservative floor on expiry — shielded offers can outlive it. Display as
    *  "expires ≥ …"; `status` is the authoritative end state. */
@@ -92,10 +100,11 @@ export interface Order {
   isMine: boolean;
 }
 
-/** Taker-perspective preview of an importable offer blob. */
+/** Taker-perspective preview of an importable offer blob. Amounts are BASE
+ *  UNITS; `decimals` is what turns each one into coins at render time. */
 export interface OfferPreview {
-  pays: { sym: string; amt: number }[];
-  gets: { sym: string; amt: number }[];
+  pays: { sym: string; amt: number; decimals: number }[];
+  gets: { sym: string; amt: number; decimals: number }[];
   shielded: boolean;
 }
 
@@ -107,12 +116,16 @@ function toOrder(offer: ZSwapOffer, knownTokens: KnownToken[]): Order | null {
   if (!give || !want) return null;
   const fromColor = String(give.token ?? '');
   const toColor = String(want.token ?? '');
-  // NOTE: amounts are decimal strings (u128 on-chain). Number() is lossy above
-  // 2^53 and is used here only for display and for the book's price ordering,
-  // which the existing UI has always done in floats. Anything exact (balance
-  // checks, settlement) works from the blob's own legs, not these.
+  // NOTE: amounts are decimal strings of BASE UNITS (u128 on-chain). Number()
+  // is lossy above 2^53 and is used here only for display and for the book's
+  // price ordering, which the existing UI has always done in floats. Anything
+  // exact (balance checks, settlement) works from the blob's own legs, not
+  // these. The unit is deliberately NOT converted here: coins are a rendering
+  // concern, and `decimalsFrom`/`decimalsTo` carry what each consumer needs.
   const amtFrom = Number(give.amount);
   const amtTo = Number(want.amount);
+  const decimalsFrom = decimalsOf(fromColor, knownTokens);
+  const decimalsTo = decimalsOf(toColor, knownTokens);
   return {
     from: findTokenName(fromColor, knownTokens) ?? shortToken(fromColor),
     to: findTokenName(toColor, knownTokens) ?? shortToken(toColor),
@@ -120,7 +133,10 @@ function toOrder(offer: ZSwapOffer, knownTokens: KnownToken[]): Order | null {
     toColor,
     amtFrom,
     amtTo,
-    impliedRate: amtFrom > 0 ? amtTo / amtFrom : 0,
+    decimalsFrom,
+    decimalsTo,
+    // A base-unit ratio scaled to whole coins — "1 from = impliedRate to".
+    impliedRate: amtFrom > 0 ? scaleRate(amtTo / amtFrom, decimalsFrom, decimalsTo) : 0,
     // `expiresAt` is a conservative FLOOR — a shielded offer can stay fillable
     // past it. Surfaced for display only; the status field is the authority.
     expiresAt: offer.computed?.expiresAt ?? null,
@@ -197,8 +213,10 @@ export interface ZSwapApp {
   // faucet / mint — browser-wallet (ConnectedAPI) path only
   canMint: boolean;
   contractBusy: boolean;
-  mintShielded: (domainSepBytes: Uint8Array, amount: bigint, nonce: bigint, name: string) => Promise<BrowserMintResult>;
-  mintUnshielded: (domainSepBytes: Uint8Array, amount: bigint, name: string) => Promise<BrowserMintResult>;
+  /** `amount` is BASE UNITS; `decimals` is what the colour is REGISTERED with,
+   *  so the rest of the app knows how to read the balance it creates. */
+  mintShielded: (domainSepBytes: Uint8Array, amount: bigint, nonce: bigint, name: string, decimals?: number) => Promise<BrowserMintResult>;
+  mintUnshielded: (domainSepBytes: Uint8Array, amount: bigint, name: string, decimals?: number) => Promise<BrowserMintResult>;
   onMinted: () => void;
   // swap — create / take offers (browser-wallet ConnectedAPI path)
   canTrade: boolean;
@@ -539,8 +557,8 @@ export function useZSwapApp(): ZSwapApp {
       const want = wants[0];
       addTrade({
         kind: 'create',
-        give: { sym: findTokenName(give.color, knownTokens) ?? shortToken(give.color), amt: Number(give.amount) },
-        get: { sym: findTokenName(want.color, knownTokens) ?? shortToken(want.color), amt: Number(want.amount) },
+        give: { sym: findTokenName(give.color, knownTokens) ?? shortToken(give.color), amt: Number(give.amount), decimals: decimalsOf(give.color, knownTokens) },
+        get: { sym: findTokenName(want.color, knownTokens) ?? shortToken(want.color), amt: Number(want.amount), decimals: decimalsOf(want.color, knownTokens) },
         // A duplicate is already indexed, so skip 'not_public' and take the
         // server's word for where it is in its lifecycle.
         status: duplicateStatus ?? 'not_public',
@@ -733,8 +751,10 @@ export function useZSwapApp(): ZSwapApp {
       // display floats.
       const items: SelectableOffer[] = takeable.map((o) => ({
         id: o.offerId ?? o.blob,
-        pay: { sym: o.to, amt: o.amtTo },
-        receive: { sym: o.from, amt: o.amtFrom },
+        // Base units in, coins out at `toView` — summing base-unit integers is
+        // exact, summing coins would accumulate float error across a ladder.
+        pay: { sym: o.to, amt: o.amtTo, decimals: o.decimalsTo },
+        receive: { sym: o.from, amt: o.amtFrom, decimals: o.decimalsFrom },
         pays: parseTakerLegs(o.blob, NETWORK_ID as any)?.pays ?? [],
         // The user may have chosen to include their own offers a dialog ago;
         // keep saying which ones they are.
@@ -748,8 +768,8 @@ export function useZSwapApp(): ZSwapApp {
       const checkedByDefault = new Set(defaultSelection(items, balances));
       const initial = summarize(items, checkedByDefault, balances, knownTokens);
       const toView = (s: TakeSummary) => ({
-        pay: { sym: s.pay.sym, amt: fmtAmt(s.pay.amt) },
-        receive: { sym: s.receive.sym, amt: fmtAmt(s.receive.amt) },
+        pay: { sym: s.pay.sym, amt: formatAmount(s.pay.amt, s.pay.decimals) },
+        receive: { sym: s.receive.sym, amt: formatAmount(s.receive.amt, s.receive.decimals) },
         blocked: s.blocked ?? undefined,
         cta: s.cta,
       });
@@ -774,8 +794,8 @@ export function useZSwapApp(): ZSwapApp {
         for (const o of chosen) {
           addTrade({
             kind: 'take',
-            give: { sym: o.to, amt: o.amtTo },
-            get: { sym: o.from, amt: o.amtFrom },
+            give: { sym: o.to, amt: o.amtTo, decimals: o.decimalsTo },
+            get: { sym: o.from, amt: o.amtFrom, decimals: o.decimalsFrom },
             status: 'consumed',
             shielded: false,
             blob: o.blob,
@@ -791,8 +811,8 @@ export function useZSwapApp(): ZSwapApp {
         ...toView(initial),
         items: items.map((it) => ({
           id: it.id,
-          pay: `${fmtAmt(it.pay.amt)} ${it.pay.sym}`,
-          receive: `${fmtAmt(it.receive.amt)} ${it.receive.sym}`,
+          pay: `${formatAmount(it.pay.amt, it.pay.decimals ?? DEFAULT_DECIMALS)} ${it.pay.sym}`,
+          receive: `${formatAmount(it.receive.amt, it.receive.decimals ?? DEFAULT_DECIMALS)} ${it.receive.sym}`,
           ok: affordable.has(it.id),
           mine: it.mine,
           checked: checkedByDefault.has(it.id),
@@ -831,16 +851,16 @@ export function useZSwapApp(): ZSwapApp {
       const open = () =>
         setPendingConfirm({
           title: 'Take offer',
-          pay: { sym: o.to, amt: fmtAmt(o.amtTo) },
-          receive: { sym: o.from, amt: fmtAmt(o.amtFrom) },
+          pay: { sym: o.to, amt: formatAmount(o.amtTo, o.decimalsTo) },
+          receive: { sym: o.from, amt: formatAmount(o.amtFrom, o.decimalsFrom) },
           cta: 'Take offer',
           blocked: takerShortfall(b) ?? undefined,
           onConfirm: async () => {
             await takeOffer(b);
             addTrade({
               kind: 'take',
-              give: { sym: o.to, amt: o.amtTo },
-              get: { sym: o.from, amt: o.amtFrom },
+              give: { sym: o.to, amt: o.amtTo, decimals: o.decimalsTo },
+              get: { sym: o.from, amt: o.amtFrom, decimals: o.decimalsFrom },
               status: 'consumed',
               shielded: false,
               blob: b,
@@ -930,9 +950,14 @@ export function useZSwapApp(): ZSwapApp {
       if (!parsed) return null;
       const nm = (color: string) => findTokenName(color, knownTokens) ?? shortToken(color);
       const legs = [...parsed.pays, ...parsed.gets];
+      const leg = (l: { color: string; amount: bigint }) => ({
+        sym: nm(l.color),
+        amt: Number(l.amount),
+        decimals: decimalsOf(l.color, knownTokens),
+      });
       return {
-        pays: parsed.pays.map((l) => ({ sym: nm(l.color), amt: Number(l.amount) })),
-        gets: parsed.gets.map((l) => ({ sym: nm(l.color), amt: Number(l.amount) })),
+        pays: parsed.pays.map(leg),
+        gets: parsed.gets.map(leg),
         shielded: legs.length > 0 && legs.every((l) => l.kind === 'shielded'),
       };
     },
@@ -948,8 +973,8 @@ export function useZSwapApp(): ZSwapApp {
       await takeOffer(b);
       addTrade({
         kind: 'take',
-        give: preview?.pays[0] ?? { sym: '—', amt: 0 },
-        get: preview?.gets[0] ?? { sym: '—', amt: 0 },
+        give: preview?.pays[0] ?? { sym: '—', amt: 0, decimals: DEFAULT_DECIMALS },
+        get: preview?.gets[0] ?? { sym: '—', amt: 0, decimals: DEFAULT_DECIMALS },
         status: 'consumed',
         shielded: preview?.shielded ?? false,
         blob: b,

--- a/templates/zswap-da/src/types/index.ts
+++ b/templates/zswap-da/src/types/index.ts
@@ -5,6 +5,18 @@ export interface KnownToken {
   token_color: string;
   name: string;
   kind: 'shielded' | 'unshielded';
+  /**
+   * Base units per whole coin: 1 coin = 10^decimals base units.
+   *
+   * Off-chain metadata from the kernel registry (`known_tokens.decimals`) — the
+   * ledger itself has no decimals notion, so this is the ONLY thing that says
+   * how an on-chain integer should be read. `useTokens` fills in
+   * DEFAULT_DECIMALS when a node predates the field, and TokenPicker does the
+   * same for a wallet-held colour that is in no registry.
+   */
+  decimals: number;
+  /** Market asset the node prices this token against, when it has one. */
+  asset_id?: string | null;
 }
 
 /**

--- a/templates/zswap-da/src/ui/TokenPicker.tsx
+++ b/templates/zswap-da/src/ui/TokenPicker.tsx
@@ -7,7 +7,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { Modal, ModalHead } from './Modal';
 import { Coin, Icon } from './icons';
 import { shortToken } from '../utils';
-import { fmtBalance } from '../state/format';
+import { DEFAULT_DECIMALS, formatAmount } from '../state/amount';
 import type { KnownToken } from '../types';
 
 const HEX_RE = /^[0-9a-fA-F]+$/;
@@ -50,7 +50,11 @@ export function TokenPicker({
     for (const t of tokens) byColor.set(t.token_color, t);
     const addWallet = (map: Record<string, string> | null | undefined, kind: 'shielded' | 'unshielded') => {
       for (const color of Object.keys(map ?? {})) {
-        if (!byColor.has(color)) byColor.set(color, { token_color: color, name: shortToken(color), kind });
+        // Wallet-only colour: nothing in the registry says how to read it, so
+        // it takes the default precision like every other unregistered token.
+        if (!byColor.has(color)) {
+          byColor.set(color, { token_color: color, name: shortToken(color), kind, decimals: DEFAULT_DECIMALS });
+        }
       }
     };
     addWallet(shieldedBalances, 'shielded');
@@ -74,7 +78,7 @@ export function TokenPicker({
     if (!manualValid) return;
     // If the id already matches a known/held token, reuse its real record.
     const existing = merged.find((t) => t.token_color === manualNorm);
-    onPick(existing ?? { token_color: manualNorm, name: shortToken(manualNorm), kind: manualKind });
+    onPick(existing ?? { token_color: manualNorm, name: shortToken(manualNorm), kind: manualKind, decimals: DEFAULT_DECIMALS });
     onClose();
   };
 
@@ -100,7 +104,7 @@ export function TokenPicker({
                   <div style={{ fontWeight: 700, fontSize: 14, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{t.name}</div>
                   <div className="zs-num" style={{ fontSize: 11, color: 'var(--ink-3)' }}>{shortToken(t.token_color)}</div>
                 </div>
-                {bal != null && <span className="zs-num" style={{ fontSize: 12.5, fontWeight: 600, color: 'var(--ink-2)', flex: '0 0 auto' }}>{fmtBalance(bal)}</span>}
+                {bal != null && <span className="zs-num" style={{ fontSize: 12.5, fontWeight: 600, color: 'var(--ink-2)', flex: '0 0 auto' }}>{formatAmount(bal, t.decimals)}</span>}
                 {t.kind === 'shielded'
                   ? <span className="zs-badge-shield" style={{ padding: '4px 8px', flex: '0 0 auto' }}><Icon.shield /> Shielded</span>
                   : <span className="zs-pill" style={{ padding: '4px 8px', flex: '0 0 auto' }}><Icon.eye /> Unshielded</span>}

--- a/templates/zswap-da/src/ui/WalletMenu.tsx
+++ b/templates/zswap-da/src/ui/WalletMenu.tsx
@@ -3,8 +3,8 @@
 import { useEffect, useRef, useState, type CSSProperties } from 'react';
 import { WalletPill, type WalletInfo } from './WalletPill';
 import { Icon } from './icons';
-import { isShieldedAddress, truncateAddress } from '../utils';
-import { fmtBalance } from '../state/format';
+import { decimalsOf, isShieldedAddress, truncateAddress } from '../utils';
+import { formatAmount } from '../state/amount';
 import { formatShieldedAddress } from '../state/shieldedAddress';
 import { TokenChip } from './TokenChip';
 import type { KnownToken } from '../types';
@@ -54,7 +54,7 @@ function BalRows({ title, balances, knownTokens }: { title: string; balances: Re
           {entries.map(([color, amt]) => (
             <div key={color} style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12 }}>
               <TokenChip color={color} knownTokens={knownTokens} size="sm" />
-              <span className="zs-num" style={{ fontWeight: 600, fontSize: 13 }}>{fmtBalance(amt)}</span>
+              <span className="zs-num" style={{ fontWeight: 600, fontSize: 13 }}>{formatAmount(amt, decimalsOf(color, knownTokens))}</span>
             </div>
           ))}
         </div>

--- a/templates/zswap-da/src/utils.ts
+++ b/templates/zswap-da/src/utils.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_DECIMALS } from './state/amount';
 import type { KnownToken } from './types';
 
 export function shortToken(t?: string): string {
@@ -43,6 +44,22 @@ export function truncateAddress(addr: string): string {
   return addr.slice(0, HEAD) + '...' + addr.slice(-TAIL);
 }
 
+export function findToken(token: string, knownTokens: KnownToken[]): KnownToken | undefined {
+  return knownTokens.find(k => k.token_color === token);
+}
+
 export function findTokenName(token: string, knownTokens: KnownToken[]): string | undefined {
-  return knownTokens.find(k => k.token_color === token)?.name;
+  return findToken(token, knownTokens)?.name;
+}
+
+/**
+ * How many base units make one whole coin of this colour.
+ *
+ * DEFAULT_DECIMALS when the colour is not in the registry — a wallet-only
+ * token, or a node that predates `known_tokens.decimals`. Assuming 6 is the
+ * honest guess here: every token this stack mints has 6, and assuming 0 would
+ * render a faucet balance a million times too large (spec Q8).
+ */
+export function decimalsOf(token: string, knownTokens: KnownToken[]): number {
+  return findToken(token, knownTokens)?.decimals ?? DEFAULT_DECIMALS;
 }


### PR DESCRIPTION
Spec: `Offer Files/spec/00024-token-decimals-6.md` — FR-101…FR-108 (frontend half of project 00024).

`templates/zswap-da` had no decimals awareness at all. `Swap.tsx` parsed integers only and its keystroke sanitiser deleted `.`; balances, the order book, "My trades", the take-confirmation dialog and every rate were rendered in raw base units; and `registerKnownToken` posted `{color, name, kind}`, so faucet-minted tokens landed on `decimals 0`. With the kernel moving every token to 6 decimals (PR A, separate), that would have made each amount in the app read a million times too large.

Amounts are now typed and shown in **whole coins**, scaled by each token's own `decimals` from `GET /v1/known-tokens`.

## The invariant this preserves

**Nothing about the wire or the chain changes.** `/v1/quote`, the offer legs, the mint circuits and wallet balances are still base-unit integers; `/v1/chart/*` still serves base units and its shape is untouched. Coins exist only above the render boundary. `src/state/amount.ts` is the single conversion point, and `src/state/swapAmounts.ts` is the Swap screen's half of it — extracted from the component so it can be unit-tested without a DOM.

The conversion is string/bigint maths throughout. `Number(x) * 1e6` is not used and the module says why: the product is inexact for most inputs (`0.07 * 1e6 === 70000.00000000001`) and above 2^53 a double rounds silently, which would post an offer for an amount nobody typed.

## The fallback-6 rule

A token with no `decimals` reads as `DEFAULT_DECIMALS = 6`. Two cases, both real: a node older than kernel PR A serves `known_tokens` rows without the field (the live preprod API still does), and a colour the wallet holds that is in no registry at all. Assuming 6 is the honest guess — every token this stack mints has 6 — and assuming 0 would render a faucet balance a million times too large. **This PR therefore stands alone: it works against today's preprod, before the kernel change lands.**

## What changed, per screen

| Screen | Change |
|---|---|
| **Swap** | Each leg parses at *its own* token's precision (a pair is routinely two different ones). Balance chip and MAX in coins — MAX pastes the *exact* coin string, so re-parsing returns the balance to the base unit and "spend everything" is actually everything. The node's `suggested_to_amount` lands in the field as coins. Both rate lines ("Your rate", "Reference") scaled by `10^(dFrom − dTo)`. "Amounts are whole base units — no decimals or separators" is gone. |
| **Market** | The ladder converts once at its boundary: prices come off the order's whole-coin `impliedRate`, amounts and totals via `toWholeCoinsNumber`. 24h stats, both volumes and the trade history are scaled here rather than in the kernel, so the `/v1/chart/*` contract stays non-breaking for other consumers. The reference rate is scaled before both the "1 base = … quote" line and the mid-vs-reference comparison. |
| **My trades** | Legs, the price column, the blob viewer and the import preview all in coins. `TradeLeg.decimals` is **optional**: records already in `localStorage` have none and read at the default. |
| **Take confirm** | Totals and per-row strings in coins. Sums stay in base units and are formatted at render — integers add exactly below 2^53, whereas summing already-divided coins would drift across a deep ladder. |
| **Wallet menu / token picker** | Balance chips in coins, per colour. |
| **Faucet** | Mints **1,000 whole coins** = `1_000_000_000` base units, and registers the colour with `decimals: 6` explicitly — carried through the mint queue so the reconciler's retry sends the same value. Copy reads "1,000 WBTC" / "1,000 coins" (was "1,000 units"). |

Over-precise input (`1.0000005` for a 6-decimals token) is **refused with a message naming the token's precision, never rounded** — the amount is what settles on chain, and quietly posting a different one than the user typed is not an option.

Two things beyond the spec's list, both the same bug class:

- `takerBalance.shortfallMessage` printed raw base units ("need 1500000, have 0") straight into the confirm dialog *beside* the coin totals. `Shortfall` now carries `decimals` and the sentence speaks coins.
- `format.ts` loses `dp()`, `fmtAmt()` and `fmtBalance()` rather than gaining a decimals parameter: they keyed precision off a hard-coded list of design-mock symbols (`wBTC`, `wsETH`) and printed base units as if they were coins. `fmt` / `fmtUsd` / `rateDisplay` and the 00005 reference helpers stay — none of those is a token amount.

## Not breaking

No API call, request body field or persisted shape changes meaning. `registerKnownToken` **adds** `decimals` to its body; a node that ignores the field behaves exactly as before. `TradeLeg.decimals` and `PendingMintName.decimals` are optional, so existing `localStorage` reads keep working. The one visible discontinuity is inherent to the project and accepted in the spec (Q4): coins minted *before* the kernel change (1,000 base units) display as `0.001` after it. Preprod is redeployed clean and the dev stack is ephemeral.

## Verification

- `bun test` in `templates/zswap-da`: **241 pass / 0 fail / 532 assertions across 15 files** (baseline on `v-next` @ `41b6054` was 189/13).
  - New: `src/state/amount.test.ts` (31) — the round trip, over-precision refused rather than rounded, exactness past 2^53, the `2^64 − 1` ceiling; `src/state/swapAmounts.test.ts` (21) — the spec's User Story 2 acceptance scenarios; `referenceRate → whole-coin rate` (3, including a 6-vs-8 mixed-decimals case); 3 new `takerBalance` cases, one of which pins that its balance strings are base units so a future refactor that "helpfully" formats them into coins fails there instead of in a user's wallet.
  - Every `decimals: 0` fixture moved to `6`.
- `bun run build` (`build:contract` → `tsc -b` → `vite build`): clean. Note this template is excluded from CI's template runner (`templates/run-template-tests.ts`), so these are the whole gate.
- **Not verified**: no browser walkthrough — that needs a live kernel on `:9999` for Midnight config, ZK artifacts and the batcher. Planned for project 00024's P4 on a dev stack.

## Follow-ups

- A cherry-pick of this onto **`midnight-1`** follows (project 00024 P3); the only expected conflict is the hostname-rewrite block in `services/api.ts::getMidnightConfig`.
- The kernel PR (registry default 6, explicit `decimals: 6` from every registrant, faucet amounts ×10^6) is **breaking** and carries the rollout note; it is independent of this one and lands separately.
- `src/ui/icons.tsx`'s `TOKENS`/`isShielded` table is keyed on design-mock symbols (`wBTC`) that no real token name (`WBTC`) matches, and marks `USDC` unshielded while the faucet mints it shielded. Pre-existing and untouched here, so filed rather than fixed (spec FR-108): `Offer Files/issues/00025-zswap-da-icons-token-keys-mismatch.md`.