### PR TITLE
fix(runtime): trust the reverse proxy so request.ip is the client, not nginx

### DIFF
--- a/packages/effectstream-sdk/utils/src/config.ts
+++ b/packages/effectstream-sdk/utils/src/config.ts
@@ -207,6 +207,13 @@ const definitions: Record<string, ConfigDefinition> = {
     description:
       "Main Paima API Port. Used by developers custom endpoints and RPC endpoints. Example: '9999'",
   },
+  EFFECTSTREAM_TRUST_PROXY: {
+    key: "EFFECTSTREAM_TRUST_PROXY",
+    type: "string",
+    defaultValue: "true",
+    description:
+      "Whether the HTTP server trusts X-Forwarded-For / X-Forwarded-Proto from a reverse proxy in front of it, so request.ip is the client and not the proxy. 'true' (default, trust every hop), 'false' (never), or a comma-separated list of proxy IPs/CIDRs such as '127.0.0.1,10.0.0.0/8'. Mirrors Fastify's trustProxy option.",
+  },
   EFFECTSTREAM_EXPLORER_PORT: {
     key: "EFFECTSTREAM_EXPLORER_PORT",
     type: "number",
@@ -411,6 +418,9 @@ export class ENV {
   }
   static get EFFECTSTREAM_API_PORT(): number {
     return ENV.getConfig(definitions.EFFECTSTREAM_API_PORT);
+  }
+  static get EFFECTSTREAM_TRUST_PROXY(): string {
+    return ENV.getConfig(definitions.EFFECTSTREAM_TRUST_PROXY);
   }
   static get RECAPTCHA_V3_FRONTEND(): string {
     return ENV.getConfig(definitions.RECAPTCHA_V3_FRONTEND);

--- a/packages/node-sdk/runtime/src/api/http-server.ts
+++ b/packages/node-sdk/runtime/src/api/http-server.ts
@@ -1,4 +1,9 @@
-import fastify, { type FastifyInstance, type FastifyReply, type FastifyRequest } from "fastify";
+import fastify, {
+  type FastifyInstance,
+  type FastifyReply,
+  type FastifyRequest,
+  type FastifyServerOptions,
+} from "fastify";
 import { evmRpcEngine } from "./rpc-evm/eip1193.ts";
 import { appliedBlockStatus } from "./apply-status.ts";
 import { finalizedStreamStatus } from "./stream-status.ts";
@@ -52,6 +57,23 @@ import {
 } from "./pagination.ts";
 import { PrimitiveRegistry } from "@effectstream/sm";
 import { ConfigNetworkType, getWriteNamespace, usePaimaStaticConfig } from "@effectstream/config";
+
+/**
+ * Parse `EFFECTSTREAM_TRUST_PROXY` into Fastify's `trustProxy` option.
+ *
+ * - `true` / `1` / empty → `true` (trust every hop; the default)
+ * - `false` / `0`        → `false`
+ * - anything else        → comma-separated proxy IPs / CIDRs
+ */
+export function parseTrustProxy(raw: string | undefined): boolean | string[] {
+  const value = (raw ?? "").trim();
+  if (value === "" || value.toLowerCase() === "true" || value === "1") return true;
+  if (value.toLowerCase() === "false" || value === "0") return false;
+  return value
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+}
 
 function tableListContains(
   list: Array<{ table_name: string | null }>,
@@ -172,7 +194,15 @@ export const startHttpServer = function* (
   // Use dbConn directly; queries are executed via pgtyped PreparedQuery.run
   // Allow any webpage to access the server.
   // This node is not specific for a specific website.
-  const server = fastify({ routerOptions: { maxParamLength: 300 } });
+  // trustProxy decides what `request.ip` means. Deployments front this server
+  // with nginx/Caddy, and without it Fastify reports the proxy's address for
+  // every client — so anything keyed per IP (the rate limiter above all)
+  // shares ONE bucket across every user behind the proxy.
+  const serverOptions: FastifyServerOptions = {
+    routerOptions: { maxParamLength: 300 },
+    trustProxy: parseTrustProxy(ENV.EFFECTSTREAM_TRUST_PROXY),
+  };
+  const server = fastify(serverOptions);
   // OpenAPI Docs
   yield* registerOpenApiDocumentation(server, ENV.EFFECTSTREAM_API_PORT);
 

--- a/packages/node-sdk/runtime/src/api/trust-proxy.test.ts
+++ b/packages/node-sdk/runtime/src/api/trust-proxy.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test";
+import { parseTrustProxy } from "./http-server.ts";
+
+describe("parseTrustProxy", () => {
+  test("defaults to trusting every hop", () => {
+    expect(parseTrustProxy(undefined)).toBe(true);
+    expect(parseTrustProxy("")).toBe(true);
+    expect(parseTrustProxy("true")).toBe(true);
+    expect(parseTrustProxy("TRUE")).toBe(true);
+    expect(parseTrustProxy("1")).toBe(true);
+  });
+  test("can be switched off", () => {
+    expect(parseTrustProxy("false")).toBe(false);
+    expect(parseTrustProxy("0")).toBe(false);
+  });
+  test("a bare number that is not 0/1 is treated as an address list entry", () => {
+    expect(parseTrustProxy("2")).toEqual(["2"]);
+  });
+  test("a list becomes trimmed proxy addresses", () => {
+    expect(parseTrustProxy(" 127.0.0.1, 10.0.0.0/8 ,")).toEqual(["127.0.0.1", "10.0.0.0/8"]);
+  });
+});


### PR DESCRIPTION
## Why
Every deployment fronts the runtime's Fastify server with nginx or Caddy, but the server was created without `trustProxy`, so `request.ip` was always the proxy's address. Anything keyed per IP — the offer-files kernel's `@fastify/rate-limit` budget above all — shared ONE bucket across every user behind the proxy: preprod's 60/min allowance was drained by strangers and by the console's poller, and a browser in another city got 429 within seconds (measured 2026-09-09: 60 requests gone ~35 s after a reset with 8 of them ours).

## What
- New `EFFECTSTREAM_TRUST_PROXY` env (`packages/effectstream-sdk/utils/src/config.ts`): `true` (default, trust every hop), `false`, or a comma-separated list of proxy IPs/CIDRs.
- `packages/node-sdk/runtime/src/api/http-server.ts`: `parseTrustProxy()` and the value passed as Fastify's `trustProxy` (options typed as `FastifyServerOptions`; an untyped literal broke overload resolution).
- Unit test `trust-proxy.test.ts`.

## ⚠️ Behaviour change
The default trusts every hop. A runtime exposed **without** a proxy can be fed a spoofed `X-Forwarded-For` to dodge per-IP logic — set `EFFECTSTREAM_TRUST_PROXY=false` (or a proxy list) there. The proxy must send `X-Forwarded-For` for this to have any effect.

## Tests
- `bun test packages/node-sdk/runtime/src/api/trust-proxy.test.ts`: 4 pass / 0 fail
- root `bunx tsc --noEmit -p tsconfig.json`: 306 pre-existing diagnostics before and after, `http-server.ts` unchanged at 1

Port to `midnight-1` follows as its own PR (cherry-pick `-x` + ledger row).