### PR TITLE
fix(zswap-da): 'Offer created' feedback + generic Midnight Wallet copy

### DIFF
--- a/templates/zswap-da/README.md
+++ b/templates/zswap-da/README.md
@@ -115,7 +115,7 @@ Prerequisites:
 
 - **Bun.** The app has no local Faucet contract or generated Compact assets; test-token minting is
   handled by the external Faucet service.
-- **A wallet.** Either works, for everything: the injected browser wallet (Lace) via the
+- **A wallet.** Either works, for everything: any Midnight wallet extension (Lace, for example) via the
   dapp-connector, or the **built-in JS wallet** via the Midnight wallet facade — no extension
   needed. `src/services/browserOffers.ts` and `src/services/localTradeOffers.ts` implement the two
   offer-settlement paths.

--- a/templates/zswap-da/src/screens/HowItWorks.tsx
+++ b/templates/zswap-da/src/screens/HowItWorks.tsx
@@ -75,7 +75,7 @@ function AnimatedLifecycle() {
       <div {...hover(0)} style={phaseBg(0)}>
         <PhaseShell active={active === 0} icon={<Icon.wallet />}>
           {head(1, active === 0, 'Connect a wallet')}
-          <p style={body(active === 0)}>Connect <a href="https://www.lace.io/" target="_blank" rel="noopener noreferrer" style={{ color: 'var(--accent)', fontWeight: 700, textDecoration: 'none' }}>Lace</a> or any Midnight-compatible wallet (on Undeployed, a built-in JS wallet is offered). Your address is never shared on-chain.</p>
+          <p style={body(active === 0)}>Connect your Midnight Wallet (on Undeployed, a built-in JS wallet is offered). Your address is never shared on-chain.</p>
         </PhaseShell>
       </div>
 

--- a/templates/zswap-da/src/screens/Swap.tsx
+++ b/templates/zswap-da/src/screens/Swap.tsx
@@ -217,7 +217,7 @@ export function PlaceOrderForm({ st, compact, requestPayPicker, onPayPickerHandl
   let action: () => void = () => st.connect();
   let disabled = false;
   if (st.wallet) {
-    if (!st.canTrade) { label = 'Use the browser wallet (Lace) to create offers'; disabled = true; action = () => {}; }
+    if (!st.canTrade) { label = 'Use a Midnight Wallet extension to create offers'; disabled = true; action = () => {}; }
     else if (!bothSel) { label = 'Select tokens'; disabled = true; action = () => {}; }
     else if (!sameKind) { label = 'Tokens must share privacy kind'; disabled = true; action = () => {}; }
     else if (payAmt.trim() !== '' && payParsed.error) { label = payParsed.error === 'precision' ? `Max ${from!.decimals} decimals for ${from!.name}` : 'Check the amount you pay'; disabled = true; action = () => {}; }

--- a/templates/zswap-da/src/services/makerOffer.ts
+++ b/templates/zswap-da/src/services/makerOffer.ts
@@ -49,7 +49,7 @@ export async function buildMakerOfferBlob(
   wants: OfferLeg[],
 ): Promise<string> {
   if (typeof (connectedApi as any).makeIntent !== 'function') {
-    throw new Error('This wallet does not support makeIntent — update Lace to a version with the Midnight swap-intent API.');
+    throw new Error('This wallet does not support makeIntent — update your Midnight Wallet to a version with the swap-intent API.');
   }
   const { shieldedAddress } = await connectedApi.getShieldedAddresses();
   const { unshieldedAddress } = await connectedApi.getUnshieldedAddress();

--- a/templates/zswap-da/src/state/createOfferFeedback.test.ts
+++ b/templates/zswap-da/src/state/createOfferFeedback.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from 'bun:test';
+import { createOfferToast } from './createOfferFeedback';
+
+const ID = 'd6b94d6ce300959bbfc4a6ba737f02864e2db3f6b7e34bb2392f46f55ba0521f';
+
+describe('createOfferToast', () => {
+  test('a fresh post says the offer was created, never "already active"', () => {
+    const t = createOfferToast({ offerId: ID, duplicate: false, duplicateStatus: null });
+    expect(t.kind).toBe('ok');
+    expect(t.msg).toBe('Offer created (d6b94d…521f)');
+    expect(t.msg).not.toContain('already');
+  });
+
+  test('a fresh post without an id still reads as created', () => {
+    expect(createOfferToast({ offerId: null, duplicate: false, duplicateStatus: null }).msg).toBe('Offer created');
+  });
+
+  test('a duplicate with a known status reports that status as a plain notice', () => {
+    const t = createOfferToast({ offerId: ID, duplicate: true, duplicateStatus: 'filled' });
+    expect(t.msg).toBe('This offer was already posted (filled)');
+    expect(t.kind).toBeUndefined();
+  });
+
+  test('a duplicate without a status falls back to the active-intent line', () => {
+    const t = createOfferToast({ offerId: ID, duplicate: true, duplicateStatus: null });
+    expect(t.msg).toBe('This intent was already active (d6b94d…521f)');
+    expect(createOfferToast({ offerId: null, duplicate: true, duplicateStatus: null }).msg)
+      .toBe('This intent was already active (existing offer)');
+  });
+});

--- a/templates/zswap-da/src/state/createOfferFeedback.ts
+++ b/templates/zswap-da/src/state/createOfferFeedback.ts
@@ -1,0 +1,26 @@
+// The toast shown after `createOffer` resolves. Kept as a pure function because
+// the three outcomes (posted, already indexed with a known status, already
+// active without one) once collapsed into a single "already active" line that
+// fired on every successful post — the offer had landed, but the copy said
+// otherwise.
+import { shortToken } from '../utils';
+import type { OfferStatus } from '../types';
+
+export interface CreateOfferOutcome {
+  /** Id from `POST /v1/offers`, or the active offer's id on a 409 duplicate. */
+  offerId: string | null;
+  /** True when the node answered 409 DUPLICATE_OFFER / DUPLICATE_MARKERS. */
+  duplicate: boolean;
+  /** Lifecycle status the node reported alongside the duplicate, if any. */
+  duplicateStatus: OfferStatus | null;
+}
+
+export function createOfferToast(o: CreateOfferOutcome): { msg: string; kind: 'ok' | undefined } {
+  if (!o.duplicate) {
+    return { msg: o.offerId ? `Offer created (${shortToken(o.offerId)})` : 'Offer created', kind: 'ok' };
+  }
+  if (o.duplicateStatus) {
+    return { msg: `This offer was already posted (${o.duplicateStatus})`, kind: undefined };
+  }
+  return { msg: `This intent was already active (${o.offerId ? shortToken(o.offerId) : 'existing offer'})`, kind: 'ok' };
+}

--- a/templates/zswap-da/src/state/useZSwapApp.ts
+++ b/templates/zswap-da/src/state/useZSwapApp.ts
@@ -4,6 +4,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { WalletInfo } from '../ui/WalletPill';
+import { createOfferToast } from './createOfferFeedback';
 import type { ToastItem } from '../ui/Toasts';
 import {
   connectInjected,
@@ -487,12 +488,14 @@ export function useZSwapApp(): ZSwapApp {
       // it as a wallet/indexer misconfiguration and returns a `hint` naming the
       // exact fix, which we surface verbatim rather than burying under retries.
       let offerId: string | null = null;
+      let duplicate = false;
       let duplicateStatus: OfferStatus | null = null;
       try {
         const submitted = await api.submitSwapOffer(blob);
         offerId = submitted?.offerId ?? null;
       } catch (e: any) {
         if (e?.code === 'DUPLICATE_OFFER' || e?.code === 'DUPLICATE_MARKERS') {
+          duplicate = true;
           offerId = e.data?.activeOfferId ?? e.data?.offerId ?? null;
           duplicateStatus = (e.data?.status as OfferStatus) ?? null;
           dlog('createOffer: duplicate offer', { code: e.code, offerId, status: duplicateStatus });
@@ -518,12 +521,8 @@ export function useZSwapApp(): ZSwapApp {
         blob,
         offerId: offerId ?? undefined,
       });
-      toast(
-        duplicateStatus
-          ? `This offer was already posted (${duplicateStatus})`
-          : `This intent was already active (${offerId ?? 'existing offer'})`,
-        duplicateStatus ? undefined : 'ok',
-      );
+      const fb = createOfferToast({ offerId, duplicate, duplicateStatus });
+      toast(fb.msg, fb.kind);
       zapi.fetchOffers();
       refreshBalances();
     },
@@ -834,7 +833,7 @@ export function useZSwapApp(): ZSwapApp {
   const requestTakeMany = useCallback(
     async (orders: Order[]) => {
       if (!tradeWallet?.canTrade) {
-        toast('Use the browser wallet (Lace) to take offers.');
+        toast('Use a Midnight Wallet extension to take offers.');
         return;
       }
       // Own offers deliberately stay IN the candidate set: they are a question


### PR DESCRIPTION
## What

- **Success toast said the wrong thing.** Since 840c352b (duplicate-marker handling) every successful `createOffer` showed `This intent was already active (<id>)`. The offer had posted; only the copy was wrong. The message choice now lives in `src/state/createOfferFeedback.ts` (`createOfferToast`) with an explicit `duplicate` flag:
  - fresh post → `Offer created (d6b94d…521f)` (ok)
  - 409 with a status → `This offer was already posted (<status>)`
  - 409 without a status → `This intent was already active (…)`
- **No hardcoded wallet name in user-facing copy.** Swap button, take-offers toast, the `makeIntent` unsupported error, the How-it-works step and the README prerequisite now say *Midnight Wallet* instead of *Lace*.

Left as-is: the connect modal's "not detected" rows (Lace / 1am with install links) and the code comments / `chooseLaceBalancing` identifier, which describe real Lace-specific `makeIntent` / `balanceSealedTransaction` behaviour.

## Tests

New `src/state/createOfferFeedback.test.ts` pins the three outcomes, including that a fresh post never contains "already".

Gate in Docker `oven/bun:1.4.0` (`bun install --frozen-lockfile`): 268 pass / 0 fail across 19 files, `tsc -b` clean, `bun run build` ok.

Port to `midnight-1` follows in a separate PR.